### PR TITLE
Fix quoting in segmentation report echo statements

### DIFF
--- a/src/modules/segmentation.sh
+++ b/src/modules/segmentation.sh
@@ -2298,7 +2298,7 @@ EOF
     echo ""
     echo "  # View on T1:"
     echo "  fsleyes ${t1_file} \\"
-    echo "          ${brainstem_mask} -cm red -a 50
+    echo "          ${brainstem_mask} -cm red -a 50"
     echo ""
     
     if [ -f "$flair_registered" ]; then


### PR DESCRIPTION
## Summary
- close unmatched quotes in `generate_segmentation_report`

## Testing
- `bash src/pipeline.sh -h`

------
https://chatgpt.com/codex/tasks/task_b_68542cd47eac832cbb0b01a9b07f5c36