### PR TITLE
Registration params: cross-modality SyN metric (MI), winsorization, label-aware interpolation

### DIFF
--- a/config/default_config.sh
+++ b/config/default_config.sh
@@ -176,6 +176,24 @@ export REG_METRIC_CROSS_MODALITY="MI"  # Mutual Information - for cross-modality
 export REG_METRIC_SAME_MODALITY="CC"   # Cross Correlation - for same modality
 export REG_PRECISION=1                 # Registration precision
 
+# Per-metric tuning shared by all stages of perform_multistage_registration().
+# CC radius applies when CC is used (same-modality SyN); MI bins apply when MI is
+# used (cross-modality rigid/affine/SyN). The SyN stage now selects MI for
+# cross-modality pairs (e.g. FLAIR↔T1) since CC assumes correlated intensities.
+export REG_MI_BINS=32                   # Histogram bins for Mutual Information metric
+export REG_CC_RADIUS=4                  # Neighbourhood radius for Cross Correlation metric
+
+# Intensity winsorization (antsRegistrationSyN.sh community standard).
+# Clamps the intensity tails before registration to suppress outliers; applied to
+# the global antsRegistration command in perform_multistage_registration().
+export REG_WINSORIZE_LOWER=0.005        # Lower winsorize quantile
+export REG_WINSORIZE_UPPER=0.995        # Upper winsorize quantile
+
+# Interpolation used by apply_transformation() when warping discrete label/atlas/
+# mask volumes (is_label=true). GenericLabel is the modern label-aware default
+# (anti-aliased, preserves discrete values); continuous intensity images keep Linear.
+export REG_LABEL_INTERPOLATION="GenericLabel"
+
 # ANTs specific parameters - if not set, ANTs will use defaults
 # export METRIC_SAMPLING_STRATEGY="NONE"  # Options: NONE (use all voxels), REGULAR, RANDOM
 # export METRIC_SAMPLING_PERCENTAGE=1.0   # Percentage of voxels to sample (when not NONE)

--- a/src/modules/analysis.sh
+++ b/src/modules/analysis.sh
@@ -1684,7 +1684,8 @@ transform_segmentation_to_original() {
     
     # Extract transform prefix from transform file path
     local transform_prefix="${transform_file%0GenericAffine.mat}"
-    if apply_transformation "$segmentation_file" "$reference_file" "$output_file" "$transform_prefix" "NearestNeighbor"; then
+    # Discrete segmentation labels: use label-aware interpolation (7th arg = is_label)
+    if apply_transformation "$segmentation_file" "$reference_file" "$output_file" "$transform_prefix" "NearestNeighbor" "inverse" "true"; then
         log_message "✓ Successfully applied transform using centralized function"
     else
         log_formatted "ERROR" "Failed to apply transform using centralized function"

--- a/src/modules/enhanced_registration_validation.sh
+++ b/src/modules/enhanced_registration_validation.sh
@@ -1287,7 +1287,8 @@ transform_segmentation_to_original() {
             
             # Extract transform prefix from transform file path
             local transform_prefix="${transform%0GenericAffine.mat}"
-            if apply_transformation "$segmentation" "$reference" "$output" "$transform_prefix" "NearestNeighbor"; then
+            # Discrete segmentation labels: use label-aware interpolation (7th arg = is_label)
+            if apply_transformation "$segmentation" "$reference" "$output" "$transform_prefix" "NearestNeighbor" "inverse" "true"; then
                 log_message "✓ Successfully applied transform using centralized function"
             else
                 log_formatted "ERROR" "Failed to apply transform using centralized function"

--- a/src/modules/qa.sh
+++ b/src/modules/qa.sh
@@ -348,7 +348,8 @@ validate_transformation() {
             
             # Extract transform prefix from transform file path
             local transform_prefix="${transform%0GenericAffine.mat}"
-            if apply_transformation "$moving_mask" "$fixed" "$transformed_mask" "$transform_prefix" "NearestNeighbor"; then
+            # Discrete mask: use label-aware interpolation (7th arg = is_label)
+            if apply_transformation "$moving_mask" "$fixed" "$transformed_mask" "$transform_prefix" "NearestNeighbor" "inverse" "true"; then
                 log_message "✓ Successfully applied mask transform using centralized function"
             else
                 log_formatted "ERROR" "Failed to apply mask transform using centralized function"

--- a/src/modules/registration.sh
+++ b/src/modules/registration.sh
@@ -45,14 +45,21 @@ perform_multistage_registration() {
     local output_prefix="$3"
     local initial_transform="$4"  # Optional initialization
     local mask="$5"              # Optional mask
-    
+    local fixed_modality="${6:-}"   # Optional fixed-image modality (e.g. T1)
+    local moving_modality="${7:-}"  # Optional moving-image modality (e.g. FLAIR)
+
     log_message "=== Multi-stage Registration: Rigid → Affine → SyN ==="
     log_message "Fixed: $fixed_image"
     log_message "Moving: $moving_image"
     log_message "Output: $output_prefix"
     
     local ants_bin="${ANTS_BIN:-${ANTS_PATH}/bin}"
-    
+
+    # Winsorize intensity tails to suppress outliers (antsRegistrationSyN.sh standard).
+    # Bounds are config-driven; defaults match the ANTs community standard [0.005,0.995].
+    local winsorize_lower="${REG_WINSORIZE_LOWER:-0.005}"
+    local winsorize_upper="${REG_WINSORIZE_UPPER:-0.995}"
+
     # Build base antsRegistration command
     local ants_cmd=(
         "${ants_bin}/antsRegistration"
@@ -60,6 +67,7 @@ perform_multistage_registration() {
         "--float" "0"
         "--output" "[${output_prefix},${output_prefix}Warped.nii.gz]"
         "--interpolation" "Linear"
+        "--winsorize-image-intensities" "[${winsorize_lower},${winsorize_upper}]"
         "--use-histogram-matching" "0"
         "--write-composite-transform" "0"
         "--collapse-output-transforms" "1"
@@ -132,22 +140,37 @@ perform_multistage_registration() {
         "--smoothing-sigmas" "${smoothing_sigmas}vox"
     )
     
-    # Stage 3: SyN registration with brainstem ROI constraint
-    # Use --restrict-deformation 0x0x1 to constrain deformation above pontomedullary sulcus
-    local syn_metric="${REG_METRIC_SAME_MODALITY:-CC}"
+    # Stage 3: SyN registration
+    # Select the SyN metric the same way the rigid/affine stages do: CC assumes
+    # correlated intensities, which only holds for same-modality pairs.  For a
+    # cross-modality pair (e.g. FLAIR↔T1) use Mutual Information, which is robust
+    # to differing intensity relationships.  When the modalities are unknown we
+    # default to the cross-modality (MI) path, since that is how this function is
+    # invoked (FLAIR/SWI/DWI registered to a T1 reference).
+    local cross_metric="${REG_METRIC_CROSS_MODALITY:-MI}"
+    local cc_radius="${REG_CC_RADIUS:-4}"
+    local mi_bins="${REG_MI_BINS:-32}"
+    local syn_metric_arg
+    if [ -n "$fixed_modality" ] && [ -n "$moving_modality" ] && [ "$fixed_modality" = "$moving_modality" ]; then
+        local syn_metric="${REG_METRIC_SAME_MODALITY:-CC}"
+        syn_metric_arg="${syn_metric}[${fixed_image},${moving_image},1,${cc_radius}]"
+        log_message "SyN metric: same-modality (${syn_metric}, radius ${cc_radius})"
+    else
+        syn_metric_arg="${cross_metric}[${fixed_image},${moving_image},1,${mi_bins}]"
+        log_message "SyN metric: cross-modality (${cross_metric}, ${mi_bins} bins)"
+    fi
     ants_cmd+=(
         "--transform" "SyN[0.1,3,0]"
-        "--metric" "${syn_metric}[${fixed_image},${moving_image},1,4]"
+        "--metric" "$syn_metric_arg"
         "--convergence" "$syn_convergence"
         "--shrink-factors" "$shrink_factors"
         "--smoothing-sigmas" "${smoothing_sigmas}vox"
-        "--restrict-deformation" "0x0x1"
     )
     
     log_message "Multi-stage registration command: ${ants_cmd[*]}"
     
     # Execute the multi-stage registration
-    execute_ants_command "multistage_registration" "Multi-stage registration (rigid→affine→SyN with brainstem constraint)" "${ants_cmd[@]}"
+    execute_ants_command "multistage_registration" "Multi-stage registration (rigid→affine→SyN)" "${ants_cmd[@]}"
     local reg_status=$?
     
     # Check registration status first
@@ -191,7 +214,7 @@ register_to_reference() {
     # Enhanced with multi-stage registration for brainstem analysis:
     # 1. Rigid registration for initial alignment
     # 2. Affine registration for linear corrections
-    # 3. SyN registration with brainstem ROI constraint (--restrict-deformation 0x0x1)
+    # 3. SyN registration (metric chosen by modality: MI cross-modality, CC same-modality)
     #
     # This multi-stage approach offers several advantages:
     # - Better control over deformation at each stage
@@ -203,6 +226,28 @@ register_to_reference() {
     local moving_image="$2"
     local moving_modality_name="${3:-OTHER}"  # Default to OTHER if not specified
     local out_prefix="${4:-${RESULTS_DIR}/registered/$(basename "$moving_image" .nii.gz)_to_ref}"
+
+    # Modalities of the fixed/moving images drive the SyN metric selection in
+    # perform_multistage_registration (MI for cross-modality, CC for same-modality).
+    # Infer the fixed-image modality from its filename rather than a global, since
+    # the literal fixed image may differ from PIPELINE_REFERENCE_MODALITY (e.g. a
+    # T1->FLAIR fallback path can still pass a T1 fixed image).  Standardized files
+    # carry their modality token (e.g. *T1*_std.nii.gz, *FLAIR*_std.nii.gz).
+    local fixed_basename
+    fixed_basename="$(basename "$fixed_image")"
+    local fixed_modality=""
+    local candidate_modality
+    for candidate_modality in T1 "${SUPPORTED_MODALITIES[@]}"; do
+        if [[ "$fixed_basename" == *"$candidate_modality"* || "$fixed_basename" == *"${candidate_modality,,}"* ]]; then
+            fixed_modality="$candidate_modality"
+            break
+        fi
+    done
+    # Fall back to the configured pipeline reference if the filename is unlabelled.
+    if [ -z "$fixed_modality" ]; then
+        fixed_modality="${PIPELINE_REFERENCE_MODALITY:-T1}"
+    fi
+    local moving_modality="$moving_modality_name"
 
     if [ ! -f "$fixed_image" ] || [ ! -f "$moving_image" ]; then
         log_formatted "ERROR" "Fixed or moving image not found"
@@ -403,7 +448,7 @@ register_to_reference() {
                 
                 # Use multi-stage registration with WM initialization
                 log_message "Starting WM-guided multi-stage registration..."
-                perform_multistage_registration "$fixed_image" "$moving_image" "$out_prefix" "$ants_wm_init_matrix" "$wm_mask"
+                perform_multistage_registration "$fixed_image" "$moving_image" "$out_prefix" "$ants_wm_init_matrix" "$wm_mask" "$fixed_modality" "$moving_modality"
                 local ants_status=$?
                 
                 # Calculate elapsed time
@@ -433,7 +478,7 @@ register_to_reference() {
                     local fb_start_time=$(date +%s)
                     
                     # Use multi-stage registration without initialization
-                    perform_multistage_registration "$fixed_image" "$moving_image" "$out_prefix" "" ""
+                    perform_multistage_registration "$fixed_image" "$moving_image" "$out_prefix" "" "" "$fixed_modality" "$moving_modality"
                     local fb_status=$?
                     
                     local fb_end_time=$(date +%s)
@@ -465,17 +510,17 @@ register_to_reference() {
             log_message "Running multi-stage registration with cost function masking"
             
             # Use multi-stage registration with mask
-            perform_multistage_registration "$fixed_image" "$moving_image" "$out_prefix" "" "$outer_ribbon_mask"
-            
+            perform_multistage_registration "$fixed_image" "$moving_image" "$out_prefix" "" "$outer_ribbon_mask" "$fixed_modality" "$moving_modality"
+
             if [ $? -ne 0 ]; then
                 log_formatted "WARNING" "Multi-stage registration with cost function masking failed, falling back to standard registration"
                 # Fall back to standard multi-stage registration
-                perform_multistage_registration "$fixed_image" "$moving_image" "$out_prefix" "" ""
+                perform_multistage_registration "$fixed_image" "$moving_image" "$out_prefix" "" "" "$fixed_modality" "$moving_modality"
             fi
         else
             log_formatted "WARNING" "Outer ribbon mask is invalid, falling back to standard registration"
             # Fall back to standard multi-stage registration
-            perform_multistage_registration "$fixed_image" "$moving_image" "$out_prefix" "" ""
+            perform_multistage_registration "$fixed_image" "$moving_image" "$out_prefix" "" "" "$fixed_modality" "$moving_modality"
         fi
     else
         # Check if orientation preservation is enabled
@@ -488,10 +533,10 @@ register_to_reference() {
             # Fall back to standard multi-stage registration when no initialization or mask is available
             # This is still effective, just without the benefits of white matter guidance
             log_message "Using standard multi-stage registration (no white matter guidance)"
-            log_message "This approach still leverages multi-stage optimization with brainstem constraint"
-            
+            log_message "This approach still leverages multi-stage optimization"
+
             # Use standard multi-stage registration without initialization or mask
-            perform_multistage_registration "$fixed_image" "$moving_image" "$out_prefix" "" ""
+            perform_multistage_registration "$fixed_image" "$moving_image" "$out_prefix" "" "" "$fixed_modality" "$moving_modality"
         fi
     fi
     
@@ -1082,12 +1127,24 @@ apply_transformation() {
     local transform="$4"
     local interpolation="${5:-Linear}"
     local direction="${6:-inverse}"  # inverse: atlas/template -> subject; forward: moving -> fixed
-    
+    local is_label="${7:-false}"     # true => warping a discrete label/atlas/mask image
+
     log_message "Applying transformation to $input"
     log_message "Transform: $transform"
+
+    # Label-aware interpolation: Linear corrupts discrete label/atlas/mask
+    # boundaries when warped.  When the caller flags the input as a label image,
+    # override the interpolation with a label-aware method (GenericLabel by
+    # default), reserving Linear for continuous intensity images.
+    if [ "$is_label" = "true" ]; then
+        local label_interpolation="${REG_LABEL_INTERPOLATION:-GenericLabel}"
+        log_message "Label image detected: overriding interpolation '${interpolation}' -> '${label_interpolation}'"
+        interpolation="$label_interpolation"
+    fi
+
     log_message "Interpolation: $interpolation"
     log_message "Direction: $direction"
-    
+
     # Determine ANTs bin path
     local ants_bin="${ANTS_BIN:-${ANTS_PATH}/bin}"
     

--- a/src/modules/segment_talairach.sh
+++ b/src/modules/segment_talairach.sh
@@ -333,7 +333,8 @@ extract_brainstem_talairach_with_transform() {
     
     # Use centralized apply_transformation function for consistent SyN transform handling
     local transform_prefix="${ants_prefix}"
-    if apply_transformation "$talairach_atlas" "$orientation_corrected_input" "$atlas_in_subject" "$transform_prefix" "NearestNeighbor"; then
+    # Talairach atlas is a discrete label volume: use label-aware interpolation (7th arg = is_label)
+    if apply_transformation "$talairach_atlas" "$orientation_corrected_input" "$atlas_in_subject" "$transform_prefix" "NearestNeighbor" "inverse" "true"; then
         log_message "✓ Successfully applied transform using centralized function"
     else
         log_formatted "ERROR" "Failed to apply transform using centralized function"
@@ -1161,7 +1162,8 @@ extract_brainstem_talairach() {
     log_message "Applying composite transforms: warp field + affine (atlas→subject mapping)"
     
     # Use centralized apply_transformation function for consistent SyN transform handling
-    if apply_transformation "$talairach_atlas" "$orientation_corrected_input" "$atlas_in_subject" "$ants_prefix" "NearestNeighbor"; then
+    # Talairach atlas is a discrete label volume: use label-aware interpolation (7th arg = is_label)
+    if apply_transformation "$talairach_atlas" "$orientation_corrected_input" "$atlas_in_subject" "$ants_prefix" "NearestNeighbor" "inverse" "true"; then
         log_message "✓ Successfully applied transform using centralized function"
     else
         log_formatted "ERROR" "Failed to apply transform using centralized function"

--- a/src/modules/utils.sh
+++ b/src/modules/utils.sh
@@ -61,25 +61,40 @@ apply_transform() {
     local output_file="$4"
     local interp="${5:-trilinear}"
 
+    # FLIRT only accepts trilinear|nearestneighbour|sinc|spline; callers may pass
+    # ANTs-style names (Linear, NearestNeighbor, GenericLabel). Normalise the FSL
+    # interpolation so a label-aware request still maps to nearest-neighbour.
+    local flirt_interp="$interp"
+    case "$interp" in
+        NearestNeighbor|GenericLabel|MultiLabel|nearestneighbour) flirt_interp="nearestneighbour" ;;
+        Linear|trilinear)                                          flirt_interp="trilinear" ;;
+    esac
+
     # Handle usesqform flag (skip init matrix)
     if [ "${transform_file}" == "-usesqform" ]; then
         log_message "Applying transform with FLIRT using sform/qform: ${input_file} -> ${output_file}"
-        flirt -in "${input_file}" -ref "${ref_file}" -applyxfm -usesqform -out "${output_file}" -interp "${interp}"
+        flirt -in "${input_file}" -ref "${ref_file}" -applyxfm -usesqform -out "${output_file}" -interp "${flirt_interp}"
         return $?
     fi
 
     if [ "${USE_ANTS_SYN}" = "true" ]; then
-        # Map interpolation to ANTs options
+        # Map interpolation to ANTs options.  A nearest-neighbour / label request
+        # implies a discrete label/mask, so flag it as a label image for label-aware
+        # interpolation; intensity images keep Linear.
         local ants_interp="Linear"
-        if [[ "${interp}" == "nearestneighbour" ]]; then
-            ants_interp="NearestNeighbor"
-        fi
+        local ants_is_label="false"
+        case "${interp}" in
+            nearestneighbour|NearestNeighbor|GenericLabel|MultiLabel)
+                ants_interp="NearestNeighbor"
+                ants_is_label="true"
+                ;;
+        esac
         # Use centralized apply_transformation function for consistent SyN transform handling
         log_message "Using centralized apply_transformation function..."
-        
+
         # Extract transform prefix from transform file path
         local transform_prefix="${transform_file%0GenericAffine.mat}"
-        if apply_transformation "${input_file}" "${ref_file}" "${output_file}" "$transform_prefix" "${ants_interp}"; then
+        if apply_transformation "${input_file}" "${ref_file}" "${output_file}" "$transform_prefix" "${ants_interp}" "inverse" "${ants_is_label}"; then
             log_message "✓ Successfully applied transform using centralized function"
         else
             log_formatted "ERROR" "Failed to apply transform using centralized function"
@@ -88,7 +103,7 @@ apply_transform() {
     else
         log_message "Applying transform with FLIRT: ${input_file} -> ${output_file}"
         flirt -in "${input_file}" -ref "${ref_file}" -applyxfm -init "${transform_file}" \
-            -out "${output_file}" -interp "${interp}"
+            -out "${output_file}" -interp "${flirt_interp}"
     fi
 }
 

--- a/src/pipeline.sh
+++ b/src/pipeline.sh
@@ -906,7 +906,8 @@ run_pipeline() {
                 log_message "Transforming $(basename $mask_file) to reference space..."
                 # The registration was computed as T1 moving -> FLAIR fixed, so
                 # masks derived from T1 must use the forward transform chain.
-                apply_transformation "$mask_file" "$flair_std" "$out_mask" "$transform_warp" "NearestNeighbor" "forward"
+                # These are discrete segmentation masks: use label-aware interpolation.
+                apply_transformation "$mask_file" "$flair_std" "$out_mask" "$transform_warp" "NearestNeighbor" "forward" "true"
             done
             log_formatted "SUCCESS" "Segmentation masks transformed to reference space."
             # Update brainstem_output to point to the transformed mask for QA and downstream use


### PR DESCRIPTION
## Summary

Brings the custom multi-stage `antsRegistration` (Rigid→Affine→SyN on the cross-modality FLAIR↔T1 pair) and `apply_transformation()` in line with 2020–2025 ANTs best practice, prioritizing brainstem/pons accuracy.

### Changes (`src/modules/registration.sh`, `config/default_config.sh`, call-sites)

1. **SyN metric CC→MI for cross-modality (HIGH).** The SyN stage used `CC[fixed,moving,1,4]`, but CC assumes correlated intensities, which T1/FLAIR violate. The metric now mirrors the rigid/affine modality logic: `MI[fixed,moving,1,32]` for cross-modality pairs, `CC` only when fixed and moving modalities are the same. When modalities are unknown, MI (cross-modality) is the default — matching how this function is invoked (FLAIR/SWI/DWI → T1). `register_to_reference()` infers the fixed-image modality from its filename rather than a global, so the literal fixed image drives the choice even on fallback paths. CC radius / MI bins are config-driven.

2. **Removed `--restrict-deformation 0x0x1` (HIGH).** The axis is image-space, not anatomical, and one-axis restriction is not an accepted brainstem technique. Dropped the flag plus the misleading "pontomedullary sulcus" comments.

3. **Added winsorization (HIGH).** Added `--winsorize-image-intensities [0.005,0.995]` (antsRegistrationSyN.sh community standard) to the global registration command. Bounds are config-driven (`REG_WINSORIZE_LOWER`/`REG_WINSORIZE_UPPER`).

4. **Label-aware interpolation (MEDIUM).** `apply_transformation()` gains an `is_label` parameter (default false = current behavior) that overrides interpolation to `GenericLabel` for discrete label/atlas/mask warps, reserving Linear for intensity images. Atlas/mask/segmentation call-sites (`pipeline.sh`, `analysis.sh`, `segment_talairach.sh`, `enhanced_registration_validation.sh`, `qa.sh`, `utils.sh`) pass the flag. The FSL `apply_transform()` wrapper normalizes ANTs interpolation names to valid `flirt -interp` values so label warps fall back to `nearestneighbour`.

The quality preset / iteration schedule is unchanged (out of scope).

### New config vars (`config/default_config.sh`)
`REG_MI_BINS=32`, `REG_CC_RADIUS=4`, `REG_WINSORIZE_LOWER=0.005`, `REG_WINSORIZE_UPPER=0.995`, `REG_LABEL_INTERPOLATION=GenericLabel`.

## Code review

Ran the `code-review` skill. Two real findings, both fixed:
- Fixed modality was inferred from the global `PIPELINE_REFERENCE_MODALITY` instead of the actual fixed image → could mis-select CC on a T1→FLAIR fallback path. Now inferred from the fixed-image filename.
- `GenericLabel` could reach `flirt -interp` (which rejects it) via the FSL fallback under `USE_ANTS_SYN=false`. `apply_transform()` now normalizes ANTs names to FSL equivalents.

A third (low-confidence, pre-existing) finding — a bracketed `REG_METRIC_*` value would double-bracket the metric string — was left as-is: it predates this change in the rigid/affine stages, is not reachable on the live path (`optimize_ants_parameters` is never invoked), and matching the surrounding idiom was preferred.

## Testing
A full-data pipeline run needs real MRI + ANTs/FSL compute (not feasible here), so verified with the project CI checks plus targeted functional tests of the new logic:
- `bash -n` syntax: pass (all scripts)
- `shellcheck --severity=error`: pass (no new warnings in edited files)
- `tests/test_environment_unit.sh` (100/100), `tests/test_pipeline_control_unit.sh` (98/98), `tests/test_import_unit.sh` (29/29): pass
- `pipeline.sh --help` smoke test: pass
- Module-load + double-source no-op: pass
- Functional checks (mocked ANTs/FSL): confirmed assembled command uses `MI[...,1,32]` for cross-modality SyN, `CC[...,1,4]` for same-modality, includes `winsorize-image-intensities [0.005,0.995]`, omits `restrict-deformation`; `is_label=true` overrides to `GenericLabel`; fixed-modality inference picks T1 on the fallback path; flirt interp normalization maps `GenericLabel`→`nearestneighbour`.

The pre-existing `tests/test_atlas_positioning_fix.sh` failure is unrelated (it fails identically on the base commit; it expects refactoring in `segmentation.sh` that is not present at this HEAD).

🤖 Generated with [Claude Code](https://claude.com/claude-code)