### PR TITLE
Fix N4 field-strength knob; gentler & lesion-aware FLAIR N4

### DIFF
--- a/config/default_config.sh
+++ b/config/default_config.sh
@@ -82,13 +82,28 @@ export JOINT_FUSION_SEARCH_RADIUS="${JOINT_FUSION_SEARCH_RADIUS:-3}"
 # ANTs registration parameters (existing)
 # REG_TRANSFORM_TYPE is set in the "Registration & motion correction" section below
 # N4 Bias Field Correction presets: "iterations,convergence_threshold,spline_distance_mm,shrink_factor"
-# Spline distance: larger values = coarser fit = faster; smaller values = finer fit = slower
-export N4_PRESET_VERY_LOW="20x20x20,0.0001,1x1x3,2"
-export N4_PRESET_LOW="35x35x35,0.00025,2x2x3,2"
-export N4_PRESET_MEDIUM="70x70x70,0.0001,2x2x3,2"
-export N4_PRESET_HIGH="100x100x100,0.00005,2x2x3,2"
-export N4_PRESET_ULTRA="250x250x250x3,0.00001,2x2x3,2"
-export N4_PRESET_FLAIR="$N4_PRESET_HIGH"  # Use more conservative settings for FLAIR
+#
+# N4 -b CONVENTION (single source of truth for this pipeline):
+#   The 3rd field is the b-spline mesh element spacing expressed as a single
+#   ISOTROPIC SPLINE DISTANCE IN MM, fed to N4 as -b "[<spline_distance_mm>]".
+#   This is the ANTs-recommended convention (a single scalar mm value rather
+#   than a per-dimension mesh resolution like 2x2x3). For human brain the value
+#   should sit between ~100 and ~200 mm (ANTs N4 wiki / Tustison 2010).
+#   Larger distance = coarser/smoother bias field = faster; smaller distance =
+#   finer fit = slower and more detailed. The spline distance is HALVED at each
+#   subsequent convergence level (one level per "x"-separated iteration count).
+export N4_PRESET_VERY_LOW="20x20x20,0.0001,180,2"
+export N4_PRESET_LOW="35x35x35,0.00025,180,2"
+export N4_PRESET_MEDIUM="70x70x70,0.0001,150,2"
+export N4_PRESET_HIGH="100x100x100,0.00005,120,2"
+export N4_PRESET_ULTRA="250x250x250x3,0.00001,100,2"
+# FLAIR-specific N4 preset is derived per QUALITY_PRESET in the block below.
+# It is deliberately GENTLER than the matching general preset (coarser mesh =>
+# larger spline distance => smoother bias field, plus fewer iterations) because
+# N4 can absorb diffuse FLAIR lesion contrast into the estimated bias field under
+# lesion load (Valdes Hernandez 2016, PMC4846712). A smoother field is far less
+# likely to soak up real lesion signal. Placeholder default; overwritten below.
+export N4_PRESET_FLAIR="$N4_PRESET_HIGH"
 
 # DICOM-specific parallel processing (only affects DICOM import)
 export DICOM_IMPORT_PARALLEL=12
@@ -132,22 +147,28 @@ fi
 
 echo "QUALITY_PRESET: ${QUALITY_PRESET} ANTS_THREADS:${ANTS_THREADS}" >&2
 
-# Set default N4_PARAMS by QUALITY_PRESET
+# Set default N4_PARAMS by QUALITY_PRESET.
+#
+# FLAIR gets a GENUINELY gentler preset (NOT a copy of the general one): a larger
+# spline distance (coarser/smoother bias field) and fewer iterations than the
+# matching general preset, so the estimated field cannot absorb diffuse FLAIR
+# lesion contrast. Convergence threshold and shrink factor are kept aligned with
+# the general preset; only the field smoothness and effort are relaxed.
 if [ "$QUALITY_PRESET" == "ULTRA" ]; then
     export N4_PARAMS="$N4_PRESET_ULTRA"
-    export N4_PRESET_FLAIR="$N4_PRESET_ULTRA"
+    export N4_PRESET_FLAIR="150x150x150,0.00001,160,2"
 elif [ "$QUALITY_PRESET" == "HIGH" ]; then
     export N4_PARAMS="$N4_PRESET_HIGH"
-    export N4_PRESET_FLAIR="$N4_PRESET_HIGH"
+    export N4_PRESET_FLAIR="75x75x75,0.00005,180,2"
 elif [ "$QUALITY_PRESET" == "MEDIUM" ]; then
     export N4_PARAMS="$N4_PRESET_MEDIUM"
-    export N4_PRESET_FLAIR="$N4_PRESET_MEDIUM"
+    export N4_PRESET_FLAIR="50x50x50,0.0001,200,2"
 elif [ "$QUALITY_PRESET" == "LOW" ]; then
     export N4_PARAMS="$N4_PRESET_MEDIUM"
-    export N4_PRESET_FLAIR="$N4_PRESET_MEDIUM"
+    export N4_PRESET_FLAIR="50x50x50,0.0001,200,2"
 else
     export N4_PARAMS="$N4_PRESET_VERY_LOW"
-    export N4_PRESET_FLAIR="$N4_PRESET_VERY_LOW"
+    export N4_PRESET_FLAIR="15x15x15,0.0001,200,2"
 fi
 # Parse out the fields for general sequences
 export N4_ITERATIONS=$(echo "$N4_PARAMS"      | cut -d',' -f1)
@@ -160,6 +181,20 @@ export N4_ITERATIONS_FLAIR=$(echo "$N4_PRESET_FLAIR"  | cut -d',' -f1)
 export N4_CONVERGENCE_FLAIR=$(echo "$N4_PRESET_FLAIR" | cut -d',' -f2)
 export N4_BSPLINE_FLAIR=$(echo "$N4_PRESET_FLAIR"     | cut -d',' -f3)
 export N4_SHRINK_FLAIR=$(echo "$N4_PRESET_FLAIR"      | cut -d',' -f4)
+
+# Optional lesion-weight mask for FLAIR N4 (two-pass workflow).
+#   Default empty => FLAIR N4 just uses the gentler preset above.
+#   When set to a path to an existing NIfTI weight image, it is passed to N4 as
+#   -w <mask> so high-weight (lesion) voxels are DOWN-weighted during bias-field
+#   estimation, preventing N4 from fitting the field to lesion contrast.
+# Intended two-pass workflow (lesions are unknown at first preprocessing):
+#   1. Run the pipeline once with N4_FLAIR_LESION_MASK="" (gentler preset only).
+#   2. Detect lesions on the first-pass output (analysis.sh).
+#   3. Re-run preprocessing with N4_FLAIR_LESION_MASK=<lesion-derived weight>
+#      so the second-pass bias field ignores lesion voxels.
+# The weight image must already be in the same space/geometry as the FLAIR being
+# corrected (i.e. the denoised, oriented FLAIR fed to N4).
+export N4_FLAIR_LESION_MASK="${N4_FLAIR_LESION_MASK:-}"
 
 # Multi-axial integration parameters (antsMultivariateTemplateConstruction2.sh)
 export TEMPLATE_ITERATIONS=3
@@ -321,11 +356,10 @@ export CONVERT_MASKS_TO_UINT8=true  # Convert binary masks to UINT8
 
 #export ORIGINAL_ACQUISITION_WEIGHT=1000
 
-# Parse out FLAIR-specific fields
-N4_ITERATIONS_FLAIR=$(echo "$N4_PRESET_FLAIR"  | cut -d',' -f1)
-N4_CONVERGENCE_FLAIR=$(echo "$N4_PRESET_FLAIR" | cut -d',' -f2)
-N4_BSPLINE_FLAIR=$(echo "$N4_PRESET_FLAIR"     | cut -d',' -f3)
-N4_SHRINK_FLAIR=$(echo "$N4_PRESET_FLAIR"      | cut -d',' -f4)
+# NOTE: FLAIR-specific N4 fields (N4_ITERATIONS_FLAIR/.../N4_SHRINK_FLAIR) are
+# parsed and exported once in the N4 preset section above. The duplicate
+# non-exported parse that used to live here has been removed to keep a single
+# source of truth for the N4 -b convention.
 
 # White matter guided registration parameters
 export WM_GUIDED_DEFAULT=true  # Default to use white matter guided registration

--- a/src/modules/preprocess.sh
+++ b/src/modules/preprocess.sh
@@ -231,9 +231,19 @@ process_rician_nlm_denoising() {
 }
 
 # Function to get N4 parameters
+#
+# Emits four whitespace-separated fields in EXACTLY the order the N4 command in
+# process_n4_correction() consumes them: "<iters> <conv> <bspl> <shrk>" where
+#   iters = -c iteration counts (e.g. 100x100x100)
+#   conv  = -c convergence threshold (stopping criterion)
+#   bspl  = -b spline distance in mm (single isotropic scalar; see default_config.sh)
+#   shrk  = -s shrink factor
+# For FLAIR inputs (filename contains "FLAIR") it returns the GENUINELY gentler
+# FLAIR preset (larger spline distance => smoother bias field + fewer iterations)
+# so N4 does not absorb diffuse FLAIR lesion contrast into the bias field.
 get_n4_parameters() {
   local file="$1"
-  
+
   # Validate input file exists but don't stop on error
   if [ ! -f "$file" ]; then
     log_formatted "WARNING" "File not found for parameter determination: $file - using defaults"
@@ -244,6 +254,7 @@ get_n4_parameters() {
   local shrk="$N4_SHRINK"
 
   if [[ "$file" == *"FLAIR"* ]]; then
+    # Gentler, lesion-safe FLAIR N4 (see N4_PRESET_FLAIR in default_config.sh).
     iters="$N4_ITERATIONS_FLAIR"
     conv="$N4_CONVERGENCE_FLAIR"
     bspl="$N4_BSPLINE_FLAIR"
@@ -287,14 +298,30 @@ EOF
     IS_SOLA=0
   fi
 
+  # Field-strength optimization acts on the N4 b-spline MESH SPACING (-b), NOT on
+  # the convergence threshold. The convergence threshold is purely a STOPPING
+  # criterion (the old 0.000001 vs 0.000005 split was cosmetic - both just
+  # iterated to the cap), so we leave it at the single value already derived from
+  # the quality preset (N4_CONVERGENCE) for BOTH field strengths. The real
+  # field-strength lever is the spline distance (N4_BSPLINE, a single isotropic
+  # spline distance in mm; see the N4 -b convention in default_config.sh):
+  #   - 1.5T: weaker, smoother bias field -> COARSER mesh (LARGER spline distance)
+  #   - 3T:   stronger, more spatially varying field -> FINER mesh (smaller dist.)
   if (( $(echo "$FIELD_STRENGTH > 2.5" | bc -l) )); then
     log_message "Optimizing for 3T field strength ($FIELD_STRENGTH T)"
-    N4_CONVERGENCE="0.000001"
+    # 3T: ensure a FINER mesh to capture the stronger, more spatially varying
+    # bias field. Only tighten if the preset distance is coarser than 120mm so we
+    # never accidentally make 3T coarser than intended. The numeric guard keeps
+    # this safe if N4_BSPLINE is ever empty or a non-scalar (e.g. a custom preset
+    # missing the spline field) - we simply leave the preset value untouched.
+    if [[ "$N4_BSPLINE" =~ ^[0-9]+$ ]] && (( $(echo "$N4_BSPLINE > 120" | bc -l) )); then
+      N4_BSPLINE=120
+    fi
     REG_METRIC_CROSS_MODALITY="MI"
   else
     log_message "Optimizing for 1.5T field strength ($FIELD_STRENGTH T)"
-    # 1.5T adjustments
-    N4_CONVERGENCE="0.000005"
+    # 1.5T adjustments: COARSER mesh => smoother bias field. 200 is a blessed
+    # value, applied here CONSISTENTLY as an isotropic spline DISTANCE in mm.
     N4_BSPLINE=200
     REG_METRIC_CROSS_MODALITY="MI[32,Regular,0.3]"
     ATROPOS_MRF="[0.15,1x1x1]"
@@ -304,6 +331,7 @@ EOF
     log_message "Applying specific optimizations for MAGNETOM Sola"
     REG_TRANSFORM_TYPE=3
     REG_METRIC_CROSS_MODALITY="MI[32,Regular,0.25]"
+    # Blessed 200mm spline distance for Sola (same -b convention as everywhere).
     N4_BSPLINE=200
   fi
   log_message "ANTs parameters optimized from metadata"
@@ -379,10 +407,10 @@ process_n4_correction() {
 
   # Run N4 bias correction on denoised image with our enhanced ANTs command function
   log_message "Running N4 bias correction on denoised image"
-  
+
   # Determine ANTs bin path
   local ants_bin="${ANTS_BIN:-${ANTS_PATH}/bin}"
-  
+
   # Check if N4BiasFieldCorrection is available
   if ! command -v N4BiasFieldCorrection &> /dev/null; then
     log_formatted "WARNING" "N4BiasFieldCorrection not available - skipping bias field correction"
@@ -392,17 +420,40 @@ process_n4_correction() {
     log_message "Saved (no bias correction): $output_file"
     return 0
   fi
-  
+
+  # Assemble N4 arguments. -b is an isotropic spline DISTANCE in mm wrapped as
+  # "[<dist>]" (single source-of-truth convention; see default_config.sh).
+  local n4_args=(
+    -d 3
+    -i "$denoised_file"
+    -x "$brain_mask"
+    -o "$output_file"
+    -b "[$bspl]"
+    -s "$shrk"
+    -c "[$iters,$conv]"
+  )
+
+  # OPTIONAL lesion-weight mask for FLAIR (two-pass workflow). N4's -w weight
+  # image down-weights high-weight voxels during bias-field ESTIMATION, so a
+  # lesion mask here keeps lesion contrast out of the estimated field.
+  # Lesions are unknown at first preprocessing, so the intended workflow is:
+  #   pass 1: N4_FLAIR_LESION_MASK="" -> gentler preset only (this same code)
+  #   detect lesions on the pass-1 output (analysis.sh)
+  #   pass 2: re-run with N4_FLAIR_LESION_MASK=<lesion weight in FLAIR space>
+  # The weight image must already match the denoised/oriented FLAIR geometry.
+  if [[ "$file" == *"FLAIR"* ]] && [ -n "${N4_FLAIR_LESION_MASK:-}" ]; then
+    if [ -f "$N4_FLAIR_LESION_MASK" ]; then
+      log_message "Applying FLAIR lesion weight mask to N4 (-w): $N4_FLAIR_LESION_MASK"
+      n4_args+=(-w "$N4_FLAIR_LESION_MASK")
+    else
+      log_formatted "WARNING" "N4_FLAIR_LESION_MASK set but file not found: $N4_FLAIR_LESION_MASK - running N4 without weight image"
+    fi
+  fi
+
   # Execute N4 using enhanced ANTs command execution (on denoised image)
   execute_ants_command "n4_bias_correction" "Non-uniform intensity (bias field) correction on denoised image" \
     N4BiasFieldCorrection \
-    -d 3 \
-    -i "$denoised_file" \
-    -x "$brain_mask" \
-    -o "$output_file" \
-    -b "[$bspl]" \
-    -s "$shrk" \
-    -c "[$iters,$conv]"
+    "${n4_args[@]}"
 
   local n4_status=$?
   if [ $n4_status -ne 0 ]; then


### PR DESCRIPTION
## Summary

Fixes the N4 bias-correction parameterization to match N4ITK best practice (Tustison 2010) and to protect FLAIR lesion signal. Scope: `src/modules/preprocess.sh` (`get_n4_parameters`, `optimize_ants_parameters`, the N4 command block in `process_n4_correction`) and the N4 preset/parse section of `config/default_config.sh`.

## Changes

1. **Unified `-b` convention (bug fix).** All N4 presets, the field-strength/Sola overrides, and the N4 command now express `-b` as a single isotropic **spline distance in mm** wrapped `-b "[<dist>]"` — the ANTs-recommended convention (100-200mm for human brain). Previously presets used a per-dimension mesh resolution (`2x2x3`) while the 1.5T/Sola overrides used a scalar `200`, feeding two different `-b` semantics into the same slot. The mislabeled `spline_distance_mm` comment now matches reality.

2. **Convergence split removed; field strength moved to `-b`.** `optimize_ants_parameters` no longer sets two different `N4_CONVERGENCE` values (`0.000001` vs `0.000005`) — convergence is a stopping criterion and both values just iterated to the cap. Field strength now adjusts the b-spline spacing: **coarser mesh (200mm) at 1.5T** (weaker, smoother field), **finer mesh (≤120mm) at 3T**. Convergence is a single preset-derived threshold for both. A numeric guard keeps the 3T tightening safe if `N4_BSPLINE` is empty/non-scalar.

3. **Genuinely gentler FLAIR N4.** FLAIR N4 was a byte-identical copy of general N4 (`N4_PRESET_FLAIR="$N4_PARAMS"` for every quality level). It now uses a **larger spline distance + fewer iterations** per quality level (strictly gentler than general on both axes at ULTRA/HIGH/MEDIUM/LOW/VERY_LOW), so the estimated field stays smooth and does not absorb diffuse FLAIR lesion contrast (Valdés Hernández 2016, PMC4846712).

4. **Optional lesion-weight mask.** New `N4_FLAIR_LESION_MASK` config var (default empty). When set to an existing weight image it is passed to N4 as `-w <mask>` for FLAIR only, down-weighting lesion voxels during bias-field estimation. Intended **two-pass workflow** (documented in code): pass 1 with no mask → detect lesions → pass 2 with the lesion-derived weight. Absent → just the gentler preset.

5. **Cleanup.** Removed the duplicate non-exported FLAIR parse block in config (single source of truth).

## Verification

- `bash -n` and `shellcheck --severity=error` pass on all shell scripts.
- Unit suites pass: `test_environment_unit` (100/100), `test_pipeline_control_unit` (98/98), `test_import_unit` (29/29).
- `--help` smoke test passes.
- Param-sanity check confirms: (a) FLAIR is strictly gentler than general on both `-b` and iterations at every quality level; (b) the emitted `-b` is valid scalar-mm `[...]` syntax everywhere; (c) `optimize_ants_parameters` emits one convergence value for both 1.5T and 3T (3T→`-b [120]`, 1.5T/Sola→`-b [200]`).

Full N4 data run (real MRI + ANTs compute) was not feasible in CI; verified via the project's CI checks + param-sanity harness.

## Reviewer notes (out of scope, pre-existing)

- `src/modules/utils.sh` has a separate N4 invocation in `perform_brain_extraction` that already uses `-b "[$N4_BSPLINE]"` (so it remains **format-compatible** with this change) but is not FLAIR-aware and has no `-w` support. Unifying it is out of this unit's scope.
- `optimize_ants_parameters` has no call site in the current pipeline (pre-existing); this PR fixes its logic per the assigned unit but does not change pipeline wiring.

🤖 Generated with [Claude Code](https://claude.com/claude-code)