### PR TITLE
Fix Pipeline Smoke Test: provide dummy FSL config in CI

### DIFF
--- a/.github/workflows/validate-scripts.yml
+++ b/.github/workflows/validate-scripts.yml
@@ -93,6 +93,12 @@ jobs:
 
       - name: Verify pipeline.sh --help works
         run: |
+          # Provide a dummy FSL config so the early `source $FSLDIR/etc/fslconf/fsl.sh`
+          # in pipeline.sh succeeds under `set -e` (no real FSL install in CI).
+          export FSLDIR=/tmp/fake_fsl
+          mkdir -p "$FSLDIR/etc/fslconf"
+          printf '# dummy FSL config for CI smoke test\n' > "$FSLDIR/etc/fslconf/fsl.sh"
+
           output=$(bash src/pipeline.sh --help 2>&1)
           echo "$output"
           echo ""
@@ -108,6 +114,11 @@ jobs:
           # dependency check stage — that's exactly what we want to verify.
           export FSLDIR=/tmp/fake_fsl
           export ANTS_PATH=/tmp/fake_ants
+
+          # Provide a dummy FSL config so the early `source $FSLDIR/etc/fslconf/fsl.sh`
+          # in pipeline.sh succeeds under `set -e` (no real FSL install in CI).
+          mkdir -p "$FSLDIR/etc/fslconf"
+          printf '# dummy FSL config for CI smoke test\n' > "$FSLDIR/etc/fslconf/fsl.sh"
 
           echo "Running pipeline.sh with no input data..."
           output=$(bash src/pipeline.sh 2>&1 || true)


### PR DESCRIPTION
## Problem

The **Pipeline Smoke Test** job has been failing on `main` (not caused by recent PRs). `src/pipeline.sh`'s first executable statement is:

```bash
source ${FSLDIR}/etc/fslconf/fsl.sh
```

The smoke job sets `FSLDIR=/tmp/fake_fsl` (a nonexistent dir), so this `source` of a missing file aborts the script under `set -e` **before any module loads**. As a result all 9 assertions (module-loaded strings, "Arguments parsed:", "Comprehensive Pipeline Dependency Check", "Dependency Check Summary") report missing — the pipeline never reaches them.

## Fix

Per the request to "dummy the fsl command it's looking for in the CI test", this edits **only** `.github/workflows/validate-scripts.yml`. In each smoke-test `run:` block that invokes `bash src/pipeline.sh`, it creates a stub FSL config so the early `source` succeeds:

```bash
export FSLDIR=/tmp/fake_fsl
mkdir -p "$FSLDIR/etc/fslconf"
printf '# dummy FSL config for CI smoke test\n' > "$FSLDIR/etc/fslconf/fsl.sh"
```

Each `run:` block is a fresh shell, so the stub is created in both steps. `ANTS_PATH=/tmp/fake_ants` is left as-is (it is only a variable, never sourced). `src/pipeline.sh` is unchanged — real runs still legitimately require a real FSL install.

## Verification

- `bash -n src/pipeline.sh` unaffected; workflow YAML parses.
- Reproduced the failure mode (`source` of missing file aborts under `set -e`) and confirmed the dummy file makes it succeed.
- Ran the smoke step locally with the dummy config: all 9 expected assertion strings are emitted and the pipeline reaches the dependency-check stage.

🤖 Generated with [Claude Code](https://claude.com/claude-code)