### PR TITLE
Modality-aware denoising + full DWI MP-PCA preprocessing path

### DIFF
--- a/config/default_config.sh
+++ b/config/default_config.sh
@@ -277,6 +277,44 @@ export RESAMPLE_TO_ISOTROPIC=false
 #export ISOTROPIC_SPACING=1.0
 #unset ISOTROPIC_SPACING
 
+# ------------------------------------------------------------------------------
+# Modality-aware denoising routing
+# ------------------------------------------------------------------------------
+# The denoising dispatcher (dispatch_denoising in preprocess.sh) selects the
+# denoising method by detected modality:
+#   T1 / T2 / FLAIR  -> Rician Non-Local-Means (DenoiseImage)         [default]
+#   DWI / diffusion  -> MP-PCA (dwidenoise, MRtrix); NLM is INVALID for DWI
+#   SWI / TOF / angio -> SKIPPED by default (NLM smears microbleeds/vessels)
+#
+# When set to true, applies a gentle Rician NLM to SWI/TOF images instead of
+# skipping.  Leave false to preserve microbleeds (SWI) and small vessels (TOF).
+export SWI_TOF_DENOISE_ENABLED=false
+# When the modality cannot be detected, skip denoising instead of defaulting to
+# NLM.  Default false keeps the historical structural-assumption behaviour.
+export DENOISE_DEFAULT_SKIP=false
+
+# ------------------------------------------------------------------------------
+# DWI (diffusion) preprocessing path  (dwi_preprocess.sh)
+# ------------------------------------------------------------------------------
+# Master switch.  When false (default) the DWI path is never invoked and the
+# existing T1/FLAIR flow is completely unaffected.  When true, DWI inputs are
+# auto-detected in the preprocessing stage and routed through the MP-PCA path.
+export PROCESS_DWI=false
+# Optional Gibbs ringing removal (mrdegibbs) after MP-PCA denoising.
+export DWI_DEGIBBS=true
+# Bias-field correction for DWI: "ants" uses `dwibiascorrect ants`; otherwise an
+# N4 fallback is applied to the mean b0/DWI volume.  Set DWI_BIAS_CORRECT=false
+# to skip bias correction entirely.
+export DWI_BIAS_CORRECT=true
+export DWI_BIAS_METHOD="ants"
+# Eddy/motion/topup (dwifslpreproc) is OPTIONAL and OFF by default: it requires
+# acquisition parameters (phase-encode direction + readout time) and gradient
+# tables.  To enable, set DWI_RUN_EDDY=true and provide DWI_PE_DIR (e.g. "j-")
+# and DWI_READOUT_TIME (seconds) plus accompanying .bvec/.bval files.
+export DWI_RUN_EDDY=false
+export DWI_PE_DIR=""
+export DWI_READOUT_TIME=""
+
 # Scan selection options
 # Available modes:
 #   original - ONLY consider ORIGINAL acquisitions, ignore DERIVED scans

--- a/src/modules/dwi_preprocess.sh
+++ b/src/modules/dwi_preprocess.sh
@@ -1,0 +1,440 @@
+#!/usr/bin/env bash
+#
+# dwi_preprocess.sh - Diffusion-weighted imaging (DWI) preprocessing
+#
+# This module implements a proper, modality-appropriate DWI preprocessing path
+# for the brainstem/pons pipeline.  Diffusion data must NOT be denoised with
+# Rician non-local-means (NLM): NLM removes real signal and inflates the noise
+# floor.  The correct approach (Veraart 2016; MRtrix dwidenoise/dwibiascorrect
+# docs) is:
+#
+#   1. MP-PCA denoising         (dwidenoise)        -- FIRST, before anything else
+#   2. Gibbs ringing removal    (mrdegibbs)         -- optional
+#   3. Eddy/motion/topup        (dwifslpreproc)     -- OPTIONAL: needs acq params
+#   4. Bias-field correction    (dwibiascorrect ants / N4 on mean b0)
+#   5. Derived volumes          (mean b0 / mean DWI) for downstream brainstem use
+#
+# Every external tool (MRtrix / FSL) is detected at the point of use and a
+# missing tool degrades gracefully (clear non-fatal log + skip), never a crash.
+#
+
+# Include guard
+if [ -n "${_DWI_PREPROCESS_LOADED:-}" ]; then
+    return 0 2>/dev/null || true
+fi
+_DWI_PREPROCESS_LOADED=1
+
+# Environment guard (fast no-op when pipeline environment already loaded)
+source "$(dirname "${BASH_SOURCE[0]}")/require_env.sh"
+
+# ----------------------------------------------------------------------------
+# Helper: locate the gradient table (bvec/bval) that accompanies a DWI image.
+# Echoes the bvec path and the bval path on SEPARATE lines (newline-delimited)
+# so that paths containing spaces survive; nothing is echoed if either is
+# missing.  Returns 0 when both are found, 1 otherwise.
+# ----------------------------------------------------------------------------
+find_dwi_gradients() {
+  local file="$1"
+  local stem="${file%.nii.gz}"
+  stem="${stem%.nii}"
+
+  local bvec="" bval=""
+  if [ -f "${stem}.bvec" ]; then bvec="${stem}.bvec"; fi
+  if [ -f "${stem}.bval" ]; then bval="${stem}.bval"; fi
+
+  if [ -n "$bvec" ] && [ -n "$bval" ]; then
+    printf '%s\n%s\n' "$bvec" "$bval"
+    return 0
+  fi
+  return 1
+}
+
+# ----------------------------------------------------------------------------
+# Step 1: MP-PCA denoising (dwidenoise).
+# Echoes the denoised file path on stdout; falls back to a pass-through link if
+# dwidenoise is unavailable.  NEVER applies Rician NLM.
+# ----------------------------------------------------------------------------
+denoise_dwi_mppca() {
+  local file="$1"
+
+  if ! validate_nifti "$file" "Input DWI for MP-PCA denoising"; then
+    log_formatted "ERROR" "Invalid input DWI for MP-PCA denoising: $file"
+    return $ERR_DATA_CORRUPT
+  fi
+
+  local basename
+  basename=$(basename "$file" .nii.gz)
+  create_module_dir "denoised" >/dev/null
+  local output_file
+  output_file=$(get_output_path "denoised" "$basename" "_denoised")
+
+  log_message "DWI MP-PCA denoising (dwidenoise): $file"
+
+  if ! command -v dwidenoise &> /dev/null; then
+    log_formatted "WARNING" "dwidenoise (MRtrix MP-PCA) not available - skipping DWI denoising (NLM is NOT a valid substitute for diffusion)"
+    ln -sf "$(realpath "$file")" "$output_file"
+    echo "$output_file"
+    return 0
+  fi
+
+  # Optional noise map output (useful for QA); kept alongside the denoised image.
+  local noise_map="${output_file%.nii.gz}_noise.nii.gz"
+
+  # Redirect the tool's stdout to stderr: execute_with_logging does NOT redirect
+  # command stdout, and this function's only stdout output must be the final
+  # echoed path so callers capturing $(denoise_dwi_mppca ...) get a clean path.
+  execute_with_logging \
+    "dwidenoise -force \"$file\" \"$output_file\" -noise \"$noise_map\"" \
+    "dwidenoise" >&2
+  local status=$?
+
+  if [ $status -ne 0 ] || [ ! -f "$output_file" ]; then
+    log_formatted "ERROR" "dwidenoise failed (status $status) for: $file"
+    log_formatted "WARNING" "Falling back to pass-through (no denoising) for DWI"
+    ln -sf "$(realpath "$file")" "$output_file"
+    echo "$output_file"
+    return 0
+  fi
+
+  log_message "Saved MP-PCA denoised DWI: $output_file"
+  echo "$output_file"
+  return 0
+}
+
+# ----------------------------------------------------------------------------
+# Step 2: Gibbs ringing removal (mrdegibbs) - optional, gated by DWI_DEGIBBS.
+# Echoes the (possibly unchanged) file path on stdout.
+# ----------------------------------------------------------------------------
+degibbs_dwi() {
+  local file="$1"
+
+  if [ "${DWI_DEGIBBS:-true}" != "true" ]; then
+    log_message "Gibbs unringing disabled (DWI_DEGIBBS=false) - skipping"
+    echo "$file"
+    return 0
+  fi
+
+  local basename
+  basename=$(basename "$file" .nii.gz)
+  create_module_dir "denoised" >/dev/null
+  local output_file
+  output_file=$(get_output_path "denoised" "$basename" "_degibbs")
+
+  log_message "DWI Gibbs unringing (mrdegibbs): $file"
+
+  if ! command -v mrdegibbs &> /dev/null; then
+    log_formatted "WARNING" "mrdegibbs not available - skipping Gibbs unringing"
+    echo "$file"
+    return 0
+  fi
+
+  # Redirect tool stdout to stderr (see denoise_dwi_mppca note) so the only
+  # stdout this function emits is the final echoed path.
+  execute_with_logging \
+    "mrdegibbs -force \"$file\" \"$output_file\"" \
+    "mrdegibbs" >&2
+  local status=$?
+
+  if [ $status -ne 0 ] || [ ! -f "$output_file" ]; then
+    log_formatted "WARNING" "mrdegibbs failed (status $status) - continuing with un-deringed image"
+    echo "$file"
+    return 0
+  fi
+
+  log_message "Saved Gibbs-unringed DWI: $output_file"
+  echo "$output_file"
+  return 0
+}
+
+# ----------------------------------------------------------------------------
+# Step 3 (OPTIONAL): eddy/motion/topup via dwifslpreproc.
+# This requires acquisition parameters (phase-encode direction, readout time)
+# and gradient files.  Runs only if DWI_RUN_EDDY=true AND the needed inputs are
+# present; otherwise logs a clear skip and returns the input unchanged.
+# Echoes the (possibly unchanged) file path on stdout.
+# ----------------------------------------------------------------------------
+eddy_correct_dwi() {
+  local file="$1"
+
+  if [ "${DWI_RUN_EDDY:-false}" != "true" ]; then
+    log_message "Eddy/motion/topup correction disabled (DWI_RUN_EDDY=false) - skipping"
+    echo "$file"
+    return 0
+  fi
+
+  log_message "DWI eddy/motion correction (dwifslpreproc): $file"
+
+  if ! command -v dwifslpreproc &> /dev/null; then
+    log_formatted "WARNING" "dwifslpreproc not available - skipping eddy/motion correction"
+    echo "$file"
+    return 0
+  fi
+
+  # Gradient table is mandatory for eddy.  Read bvec/bval on separate lines so
+  # paths containing spaces are preserved.
+  local bvec="" bval=""
+  if ! { IFS= read -r bvec && IFS= read -r bval; } < <(find_dwi_gradients "$file"); then
+    log_formatted "WARNING" "No bvec/bval found for $file - cannot run dwifslpreproc/eddy; skipping (see DWI_RUN_EDDY docs)"
+    echo "$file"
+    return 0
+  fi
+
+  # Phase-encode direction + readout time are required.  If not configured, skip
+  # cleanly rather than guessing (a wrong PE direction corrupts the data).
+  local pe_dir="${DWI_PE_DIR:-}"
+  local readout="${DWI_READOUT_TIME:-}"
+  if [ -z "$pe_dir" ] || [ -z "$readout" ]; then
+    log_formatted "WARNING" "DWI_PE_DIR / DWI_READOUT_TIME not set - cannot run eddy safely; skipping. Set these in config to enable dwifslpreproc."
+    echo "$file"
+    return 0
+  fi
+
+  local basename
+  basename=$(basename "$file" .nii.gz)
+  create_module_dir "denoised" >/dev/null
+  local output_file
+  output_file=$(get_output_path "denoised" "$basename" "_eddy")
+
+  # Redirect tool stdout to stderr (see denoise_dwi_mppca note).
+  execute_with_logging \
+    "dwifslpreproc \"$file\" \"$output_file\" -rpe_none -pe_dir \"$pe_dir\" -readout_time \"$readout\" -fslgrad \"$bvec\" \"$bval\"" \
+    "dwifslpreproc" >&2
+  local status=$?
+
+  if [ $status -ne 0 ] || [ ! -f "$output_file" ]; then
+    log_formatted "WARNING" "dwifslpreproc failed (status $status) - continuing without eddy correction"
+    echo "$file"
+    return 0
+  fi
+
+  log_message "Saved eddy/motion-corrected DWI: $output_file"
+  echo "$output_file"
+  return 0
+}
+
+# ----------------------------------------------------------------------------
+# Step 4: bias-field correction appropriate to DWI.
+# Prefers `dwibiascorrect ants` (needs gradients); otherwise falls back to N4 on
+# the mean b0 / mean DWI volume.  Echoes the (possibly unchanged) file path.
+# ----------------------------------------------------------------------------
+biascorrect_dwi() {
+  local file="$1"
+
+  if [ "${DWI_BIAS_CORRECT:-true}" != "true" ]; then
+    log_message "DWI bias correction disabled (DWI_BIAS_CORRECT=false) - skipping"
+    echo "$file"
+    return 0
+  fi
+
+  local basename
+  basename=$(basename "$file" .nii.gz)
+  create_module_dir "bias_corrected" >/dev/null
+  local output_file
+  output_file=$(get_output_path "bias_corrected" "$basename" "_n4")
+
+  log_message "DWI bias-field correction: $file"
+
+  # Preferred path: dwibiascorrect ants (operates on the 4D series with grads).
+  # Read bvec/bval on separate lines so paths with spaces survive.
+  local bvec="" bval="" have_grads=false
+  if { IFS= read -r bvec && IFS= read -r bval; } < <(find_dwi_gradients "$file"); then
+    have_grads=true
+  fi
+  if [ "${DWI_BIAS_METHOD:-ants}" = "ants" ] && command -v dwibiascorrect &> /dev/null && [ "$have_grads" = "true" ]; then
+    # Redirect tool stdout to stderr so the only stdout is the final echoed path.
+    execute_with_logging \
+      "dwibiascorrect ants \"$file\" \"$output_file\" -force -fslgrad \"$bvec\" \"$bval\"" \
+      "dwibiascorrect" >&2
+    local status=$?
+    if [ $status -eq 0 ] && [ -f "$output_file" ]; then
+      log_message "Saved dwibiascorrect (ANTs) corrected DWI: $output_file"
+      echo "$output_file"
+      return 0
+    fi
+    log_formatted "WARNING" "dwibiascorrect failed (status $status) - falling back to N4 on mean b0"
+  else
+    log_message "dwibiascorrect unavailable or no gradients - using N4 on mean b0 fallback"
+  fi
+
+  # Fallback: N4 on the mean volume (a single-volume bias estimate is better
+  # than none).  Requires N4BiasFieldCorrection + a mean volume.
+  if ! command -v N4BiasFieldCorrection &> /dev/null; then
+    log_formatted "WARNING" "N4BiasFieldCorrection not available - skipping DWI bias correction"
+    echo "$file"
+    return 0
+  fi
+
+  local mean_vol
+  mean_vol=$(compute_dwi_mean "$file")
+  if [ -z "$mean_vol" ] || [ ! -f "$mean_vol" ]; then
+    log_formatted "WARNING" "Could not compute mean DWI volume - skipping bias correction"
+    echo "$file"
+    return 0
+  fi
+
+  # Estimate the bias field on the mean volume only (do not warp the 4D series
+  # incorrectly); produce a corrected mean for downstream brainstem registration.
+  local corrected_mean="${output_file%.nii.gz}_mean.nii.gz"
+  execute_ants_command "dwi_n4_meanb0" "N4 bias correction on mean DWI/b0 volume" \
+    N4BiasFieldCorrection \
+    -d 3 \
+    -i "$mean_vol" \
+    -o "$corrected_mean" >&2
+  local status=$?
+  if [ $status -ne 0 ] || [ ! -f "$corrected_mean" ]; then
+    log_formatted "WARNING" "N4 on mean DWI failed (status $status) - skipping bias correction"
+    echo "$file"
+    return 0
+  fi
+
+  log_message "Saved N4-corrected mean DWI volume: $corrected_mean"
+  # The 4D series cannot be bias-corrected from a single-volume field here, so
+  # the N4-corrected MEAN is the downstream-usable bias-corrected representation.
+  # Return it (not the uncorrected 4D series) so callers actually use it.
+  echo "$corrected_mean"
+  return 0
+}
+
+# ----------------------------------------------------------------------------
+# Compute a mean volume from the (4D) DWI series for downstream brainstem use.
+# Echoes the path to the mean volume on stdout.
+# ----------------------------------------------------------------------------
+compute_dwi_mean() {
+  local file="$1"
+  local basename
+  basename=$(basename "$file" .nii.gz)
+  create_module_dir "bias_corrected" >/dev/null
+  local mean_file
+  mean_file=$(get_output_path "bias_corrected" "$basename" "_mean")
+
+  # Resumability / avoid redundant -Tmean over multi-GB 4D data: reuse a mean
+  # already produced for this exact input in a prior step or run.
+  if [ -f "$mean_file" ]; then
+    log_message "Reusing existing mean DWI volume: $mean_file"
+    echo "$mean_file"
+    return 0
+  fi
+
+  # Use the macOS-safe fslmaths wrapper for new mask/volume arithmetic.
+  if command -v fslmaths &> /dev/null; then
+    safe_fslmaths "Compute mean DWI volume" "$file" -Tmean "$mean_file" >/dev/null 2>&1 || {
+      log_formatted "WARNING" "Failed to compute mean DWI volume for: $file"
+      echo ""
+      return 1
+    }
+    echo "$mean_file"
+    return 0
+  fi
+
+  log_formatted "WARNING" "fslmaths not available - cannot compute mean DWI volume"
+  echo ""
+  return 1
+}
+
+# ----------------------------------------------------------------------------
+# Top-level DWI preprocessing orchestrator.
+# Order: MP-PCA -> Gibbs -> (optional) eddy -> bias correction -> mean volume.
+# Returns 0 on success (graceful skips are not failures).
+# ----------------------------------------------------------------------------
+run_dwi_preprocessing() {
+  local file="$1"
+
+  log_formatted "INFO" "===== DWI PREPROCESSING (MP-PCA path) ====="
+  log_message "Input DWI: $file"
+
+  if ! validate_nifti "$file" "Input DWI"; then
+    log_formatted "ERROR" "Invalid input DWI: $file"
+    return $ERR_DATA_CORRUPT
+  fi
+
+  # Step 1: MP-PCA denoising FIRST (mandatory ordering for diffusion).
+  local current
+  current=$(denoise_dwi_mppca "$file")
+  if [ -z "$current" ] || [ ! -f "$current" ]; then
+    log_formatted "ERROR" "MP-PCA denoising produced no output for: $file"
+    return $ERR_PREPROC
+  fi
+
+  # Step 2: Gibbs unringing (optional).
+  current=$(degibbs_dwi "$current")
+
+  # Step 3: eddy/motion/topup (optional; only if params present).
+  current=$(eddy_correct_dwi "$current")
+
+  # Step 5 (computed before bias correction): derived mean volume from the
+  # denoised/eddy-corrected 4D series, for downstream brainstem registration.
+  # Done here so the mean is taken from the diffusion series itself, and so it is
+  # not re-derived from a 3D bias-corrected mean (which would double the suffix
+  # and waste a -Tmean pass).
+  local mean_vol
+  mean_vol=$(compute_dwi_mean "$current")
+  if [ -n "$mean_vol" ] && [ -f "$mean_vol" ]; then
+    log_message "DWI mean volume for downstream use: $mean_vol"
+  fi
+
+  # Step 4: bias-field correction (dwibiascorrect ants on the 4D series, or N4
+  # on the mean b0 fallback).  The returned path is the bias-corrected
+  # representation usable downstream.
+  local bias_corrected
+  bias_corrected=$(biascorrect_dwi "$current")
+  if [ -n "$bias_corrected" ] && [ -f "$bias_corrected" ]; then
+    log_message "DWI bias-corrected output for downstream use: $bias_corrected"
+    current="$bias_corrected"
+  fi
+
+  log_formatted "SUCCESS" "DWI preprocessing complete: $current"
+  return 0
+}
+
+# Auto-detect DWI inputs in a directory and run the DWI path on each.
+# Returns 0 if no DWI present (additive: never affects the T1/FLAIR flow).
+run_dwi_preprocessing_auto() {
+  local input_dir="${1:-$EXTRACT_DIR}"
+  local max_depth="${2:-1}"
+
+  if [ "${PROCESS_DWI:-false}" != "true" ]; then
+    log_message "DWI preprocessing disabled (PROCESS_DWI=false) - skipping DWI auto-detection"
+    return 0
+  fi
+
+  if [ ! -d "$input_dir" ]; then
+    log_formatted "WARNING" "DWI auto-detect: input directory not found: $input_dir"
+    return 0
+  fi
+
+  log_message "Auto-detecting DWI inputs in: $input_dir"
+
+  # Collect candidate NIfTI files and route only the diffusion ones.
+  local found=0
+  local f
+  while IFS= read -r f; do
+    [ -z "$f" ] && continue
+    local modality=""
+    if declare -F detect_modality &> /dev/null; then
+      modality=$(detect_modality "$f")
+    fi
+    if [ "$modality" = "DWI" ]; then
+      found=$((found + 1))
+      run_dwi_preprocessing "$f" || log_formatted "WARNING" "DWI preprocessing reported an issue for: $f"
+    fi
+  done < <(find "$input_dir" -maxdepth "$max_depth" -name "*.nii.gz" 2>/dev/null | sort)
+
+  if [ "$found" -eq 0 ]; then
+    log_message "No DWI inputs detected in $input_dir - nothing to do"
+  else
+    log_formatted "SUCCESS" "DWI auto-detection processed $found DWI input(s)"
+  fi
+  return 0
+}
+
+# Export functions
+export -f find_dwi_gradients
+export -f denoise_dwi_mppca
+export -f degibbs_dwi
+export -f eddy_correct_dwi
+export -f biascorrect_dwi
+export -f compute_dwi_mean
+export -f run_dwi_preprocessing
+export -f run_dwi_preprocessing_auto
+
+log_message "DWI preprocessing module (MP-PCA + Gibbs + eddy + bias correction) loaded"

--- a/src/modules/preprocess.sh
+++ b/src/modules/preprocess.sh
@@ -142,10 +142,147 @@ standardize_orientation() {
     return 0
 }
 
+# Function to detect the modality of an image from its filename.
+# Returns one of: T1, T2, FLAIR, DWI, SWI, TOF, UNKNOWN
+# Detection is case-insensitive and intentionally conservative so that the
+# default structural (T1/FLAIR) flow is never mis-routed.
+detect_modality() {
+  local file="$1"
+  local name
+  name=$(basename "$file")
+  # Lowercase for case-insensitive matching
+  local lname
+  lname=$(printf '%s' "$name" | tr '[:upper:]' '[:lower:]')
+
+  # Diffusion: DWI / DTI / diffusion / ADC / trace / b-value tags
+  case "$lname" in
+    *dwi*|*dti*|*diffusion*|*_adc*|*adc_*|*trace*|*bval*|*bvec*)
+      echo "DWI"; return 0 ;;
+  esac
+
+  # Susceptibility-weighted / susceptibility / microbleed imaging
+  case "$lname" in
+    *swi*|*susceptib*|*_swan*|*swan_*|*venobold*|*mip_swi*)
+      echo "SWI"; return 0 ;;
+  esac
+
+  # Time-of-flight / angiography
+  case "$lname" in
+    *tof*|*angio*|*_mra*|*mra_*|*time_of_flight*)
+      echo "TOF"; return 0 ;;
+  esac
+
+  # FLAIR (check before generic T2 since FLAIR is a T2-weighted variant)
+  case "$lname" in
+    *flair*)
+      echo "FLAIR"; return 0 ;;
+  esac
+
+  # T1-weighted (MPRAGE/SPGR/T1)
+  case "$lname" in
+    *t1*|*mprage*|*spgr*|*mp2rage*)
+      echo "T1"; return 0 ;;
+  esac
+
+  # T2-weighted (SPACE/CISS/T2) — checked after FLAIR
+  case "$lname" in
+    *t2*|*space*|*ciss*)
+      echo "T2"; return 0 ;;
+  esac
+
+  echo "UNKNOWN"
+  return 0
+}
+
+# Modality-aware denoising dispatcher.
+#
+# Routes each file to the correct denoising method based on its modality:
+#   - T1 / T2 / FLAIR  -> Rician Non-Local-Means (DenoiseImage), structural default
+#   - DWI / diffusion  -> MP-PCA (dwidenoise) via the DWI module; NEVER NLM
+#   - SWI / TOF / angio -> SKIP denoising by default (smears microbleeds/vessels)
+#   - UNKNOWN          -> conservative default (NLM) unless DENOISE_DEFAULT_SKIP=true
+#
+# Behaviour is config-driven (see DENOISE_* / SWI_TOF_* / DWI_* vars in
+# config/default_config.sh).  The function always echoes the resulting output
+# file path to stdout (so callers can capture it) and logs which method was used.
+dispatch_denoising() {
+  local file="$1"
+  local modality="${2:-}"
+
+  # Validate input file
+  if ! validate_nifti "$file" "Input file for denoising dispatch"; then
+    log_formatted "ERROR" "Invalid input file for denoising dispatch: $file"
+    return $ERR_DATA_CORRUPT
+  fi
+
+  # Auto-detect modality if not explicitly provided
+  if [ -z "$modality" ]; then
+    modality=$(detect_modality "$file")
+  fi
+
+  log_message "Denoising dispatch: file=$(basename "$file") modality=$modality"
+
+  case "$modality" in
+    DWI)
+      log_formatted "INFO" "Routing DWI to MP-PCA (dwidenoise) — NLM is invalid for diffusion data"
+      # Prefer the dedicated DWI denoise step (MP-PCA).  Degrade gracefully if
+      # the DWI module / tool is unavailable.
+      if command -v dwidenoise &> /dev/null && declare -F denoise_dwi_mppca &> /dev/null; then
+        denoise_dwi_mppca "$file"
+        return $?
+      fi
+      log_formatted "WARNING" "dwidenoise (MP-PCA) unavailable — skipping denoising for DWI (NLM is NOT a valid substitute)"
+      _dispatch_denoise_passthrough "$file"
+      return $?
+      ;;
+    SWI|TOF)
+      if [ "${SWI_TOF_DENOISE_ENABLED:-false}" = "true" ]; then
+        log_formatted "INFO" "SWI/TOF denoising explicitly enabled — applying gentle NLM (may smear microbleeds/small vessels)"
+        process_rician_nlm_denoising "$file"
+        return $?
+      fi
+      log_message "Skipping denoising for $modality (default) to preserve microbleeds / small vessels"
+      _dispatch_denoise_passthrough "$file"
+      return $?
+      ;;
+    T1|T2|FLAIR)
+      log_message "Routing $modality to Rician NLM denoising"
+      process_rician_nlm_denoising "$file"
+      return $?
+      ;;
+    *)
+      if [ "${DENOISE_DEFAULT_SKIP:-false}" = "true" ]; then
+        log_formatted "WARNING" "Unknown modality for $(basename "$file") — skipping denoising (DENOISE_DEFAULT_SKIP=true)"
+        _dispatch_denoise_passthrough "$file"
+        return $?
+      fi
+      log_formatted "WARNING" "Unknown modality for $(basename "$file") — defaulting to Rician NLM (structural assumption)"
+      process_rician_nlm_denoising "$file"
+      return $?
+      ;;
+  esac
+}
+
+# Helper: produce a "denoised" output path that is a pass-through (symlink) of
+# the input, used when denoising is intentionally skipped so that downstream
+# stages which expect a *_denoised.nii.gz file continue to work unchanged.
+_dispatch_denoise_passthrough() {
+  local file="$1"
+  local basename
+  basename=$(basename "$file" .nii.gz)
+  create_module_dir "denoised" >/dev/null
+  local output_file
+  output_file=$(get_output_path "denoised" "$basename" "_denoised")
+  ln -sf "$(realpath "$file")" "$output_file"
+  log_message "Denoising skipped — pass-through link created: $output_file"
+  echo "$output_file"
+  return 0
+}
+
 # Function to process Rican NLM denoising
 process_rician_nlm_denoising() {
   local file="$1"
-  
+
   # Validate input file
   if ! validate_nifti "$file" "Input file for Rician NLM denoising"; then
     log_formatted "ERROR" "Invalid input file for Rician NLM denoising: $file"
@@ -341,12 +478,15 @@ process_n4_correction() {
   
   log_message "Using orientation-standardized image: $oriented_file"
   
-  # Step 2: Apply Rician NLM denoising on oriented image
-  local denoised_file=$(process_rician_nlm_denoising "$oriented_file")
+  # Step 2: Apply modality-aware denoising on oriented image.
+  # The dispatcher routes T1/T2/FLAIR -> Rician NLM (unchanged behaviour),
+  # DWI -> MP-PCA, and SWI/TOF -> skip.  For the structural T1/FLAIR inputs
+  # that reach process_n4_correction today, this is identical to before.
+  local denoised_file=$(dispatch_denoising "$oriented_file")
   local denoise_status=$?
   denoised_file="$RESULTS_DIR/denoised/${basename}_oriented_denoised.nii.gz"
   if [ $denoise_status -ne 0 ] || [ ! -f "$denoised_file" ]; then
-    log_formatted "ERROR" "Rician NLM denoising failed for: $file (status: $denoise_status file: $denoised_file)"
+    log_formatted "ERROR" "Denoising failed for: $file (status: $denoise_status file: $denoised_file)"
     return $ERR_PREPROC
   fi
   
@@ -423,44 +563,97 @@ process_n4_correction() {
   return 0
 }
 
+# Modality-aware wrapper used by the parallel runner.
+#
+# This GUARDS the broad "*.nii.gz" pattern: even if the caller points the
+# parallel runner at a directory that contains DWI/SWI/TOF images, those are
+# NEVER routed through Rician NLM + structural N4 (which would smear microbleeds
+# on SWI, small vessels on TOF, and inflate the noise floor on DWI).
+#
+#   - DWI       -> dedicated MP-PCA DWI path (run_dwi_preprocessing) if enabled
+#                  + tools present; otherwise a clear non-fatal skip.
+#   - SWI / TOF -> skipped (structural N4/NLM is inappropriate).
+#   - T1/T2/FLAIR/UNKNOWN -> existing process_n4_correction (denoise via
+#                  dispatch_denoising, then N4) — unchanged behaviour.
+process_modality_aware_correction() {
+  local file="$1"
+  local modality
+  modality=$(detect_modality "$file")
+
+  log_message "Modality-aware correction: file=$(basename "$file") modality=$modality"
+
+  case "$modality" in
+    DWI)
+      if [ "${PROCESS_DWI:-false}" = "true" ] && declare -F run_dwi_preprocessing &> /dev/null; then
+        log_formatted "INFO" "Routing $(basename "$file") to dedicated DWI preprocessing (MP-PCA path)"
+        run_dwi_preprocessing "$file"
+        return $?
+      fi
+      log_formatted "WARNING" "Skipping DWI file in N4 runner: $(basename "$file") (structural N4/NLM is invalid for diffusion; enable PROCESS_DWI for the MP-PCA path)"
+      return 0
+      ;;
+    SWI|TOF)
+      log_formatted "WARNING" "Skipping $modality file in N4 runner: $(basename "$file") (structural N4/NLM would smear microbleeds/vessels)"
+      return 0
+      ;;
+    *)
+      process_n4_correction "$file"
+      return $?
+      ;;
+  esac
+}
+
 # Function to run N4 bias field correction in parallel
 run_parallel_n4_correction() {
   local input_dir="${1:-$EXTRACT_DIR}"
   local pattern="${2:-*.nii.gz}"
   local jobs="${3:-$PARALLEL_JOBS}"
   local max_depth="${4:-1}"
-  
-  log_message "Running N4 bias correction with Rician NLM denoising in parallel on files matching '$pattern' in $input_dir"
-  
+
+  log_message "Running modality-aware N4/denoising in parallel on files matching '$pattern' in $input_dir"
+
   # Ensure output directories exist
   create_module_dir "denoised"
   create_module_dir "bias_corrected"
-  
+
   # Export required functions for parallel execution
+  export -f process_modality_aware_correction detect_modality dispatch_denoising _dispatch_denoise_passthrough
   export -f process_n4_correction process_rician_nlm_denoising get_n4_parameters standardize_orientation
   export -f log_message log_formatted validate_nifti validate_file
   export -f get_output_path get_module_dir create_module_dir
   export -f log_diagnostic execute_with_logging execute_ants_command
-  
-  # Run in parallel using the common function
-  run_parallel "process_n4_correction" "$pattern" "$input_dir" "$jobs" "$max_depth"
+  # Export the full DWI path if it has been loaded so parallel workers can route
+  # DWI through every step (run_dwi_preprocessing calls the whole chain).
+  if declare -F run_dwi_preprocessing &> /dev/null; then
+    export -f run_dwi_preprocessing run_dwi_preprocessing_auto \
+      denoise_dwi_mppca degibbs_dwi eddy_correct_dwi biascorrect_dwi \
+      compute_dwi_mean find_dwi_gradients 2>/dev/null || true
+  fi
+
+  # Run in parallel using the common function, going through the modality-aware
+  # wrapper so DWI/SWI/TOF are never routed to Rician NLM + structural N4.
+  run_parallel "process_modality_aware_correction" "$pattern" "$input_dir" "$jobs" "$max_depth"
   local status=$?
-  
+
   if [ $status -ne 0 ]; then
-    log_formatted "ERROR" "Parallel N4 bias correction with denoising failed with status $status"
+    log_formatted "ERROR" "Parallel modality-aware N4/denoising failed with status $status"
     return $status
   fi
-  
-  log_formatted "SUCCESS" "Completed parallel N4 bias correction with Rician NLM denoising"
+
+  log_formatted "SUCCESS" "Completed parallel modality-aware N4 bias correction / denoising"
   return 0
 }
 
 # Export functions
 export -f standardize_orientation
+export -f detect_modality
+export -f dispatch_denoising
+export -f _dispatch_denoise_passthrough
 export -f process_rician_nlm_denoising
 export -f get_n4_parameters
 export -f optimize_ants_parameters
 export -f process_n4_correction
+export -f process_modality_aware_correction
 export -f run_parallel_n4_correction
 
-log_message "Preprocessing module (orientation + denoising + N4) loaded"
+log_message "Preprocessing module (orientation + modality-aware denoising + N4) loaded"

--- a/src/pipeline.sh
+++ b/src/pipeline.sh
@@ -91,6 +91,7 @@ source "${PIPELINE_DIR}/modules/dicom_analysis.sh"
 source "${PIPELINE_DIR}/modules/dicom_cluster_mapping.sh"
 source "${PIPELINE_DIR}/modules/import.sh"
 source "${PIPELINE_DIR}/modules/preprocess.sh"
+source "${PIPELINE_DIR}/modules/dwi_preprocess.sh"
 source "${PIPELINE_DIR}/modules/brain_extraction.sh"
 source "${PIPELINE_DIR}/modules/registration.sh"
 source "${PIPELINE_DIR}/modules/segmentation.sh"
@@ -509,7 +510,15 @@ run_pipeline() {
   
   # Validate bias correction step
   validate_step "N4 bias correction with Rician denoising" "$(basename "$t1_file"),$(basename "$flair_file")" "bias_corrected"
-  
+
+  # Optional, additive DWI preprocessing path (MP-PCA via dwidenoise FIRST).
+  # Gated behind PROCESS_DWI and auto-detects diffusion inputs, so the default
+  # T1/FLAIR behaviour above is never affected when no DWI is present/enabled.
+  if [ "${PROCESS_DWI:-false}" = "true" ] && declare -F run_dwi_preprocessing_auto &> /dev/null; then
+    log_formatted "INFO" "PROCESS_DWI enabled - running DWI preprocessing path"
+    run_dwi_preprocessing_auto "$EXTRACT_DIR" || log_formatted "WARNING" "DWI preprocessing reported issues (non-fatal)"
+  fi
+
   else
     log_message "Skipping Step 2 (Preprocessing) as requested"
     log_message "Checking if import data exists..."


### PR DESCRIPTION
## Summary

Makes denoising modality-appropriate and adds a proper DWI preprocessing path. Rician non-local-means (NLM) was applied **unconditionally** to every modality, which is wrong for diffusion (use MP-PCA `dwidenoise` first; Veraart 2016) and questionable for SWI/TOF (smears microbleeds / small vessels). DWI/SWI/TOF were also never preprocessed and could be swept into NLM by the broad `*.nii.gz` parallel runner pattern.

## Changes

**`src/modules/preprocess.sh`**
- `detect_modality()` — case-insensitive filename classification (T1/T2/FLAIR/DWI/SWI/TOF/UNKNOWN), FLAIR checked before T2, diffusion/susceptibility/angio checked first.
- `dispatch_denoising()` — routes by modality: T1/T2/FLAIR -> Rician NLM (**unchanged**), DWI -> MP-PCA (`denoise_dwi_mppca`), SWI/TOF -> skip (config-toggleable via `SWI_TOF_DENOISE_ENABLED`). The Step 2 call in `process_n4_correction` now goes through the dispatcher, identical behaviour for structural inputs.
- `process_modality_aware_correction()` — wraps the parallel N4 runner so DWI/SWI/TOF are **never** routed to Rician NLM + structural N4 even with a broad `*.nii.gz` pattern.

**`src/modules/dwi_preprocess.sh` (new)**
- Full DWI path: MP-PCA (`dwidenoise`) **first**, optional Gibbs unringing (`mrdegibbs`), optional eddy/motion/topup (`dwifslpreproc`, gated on acquisition params), bias correction (`dwibiascorrect ants` or N4 on the mean b0), and a derived mean volume for downstream brainstem use.
- Include guard + `source require_env.sh`. Every MRtrix/FSL tool is detected at point of use and **degrades gracefully** (clear non-fatal log + skip), never crashes.

**`src/pipeline.sh`**
- Sources `dwi_preprocess.sh`; invokes `run_dwi_preprocessing_auto` in the preprocess stage, gated behind `PROCESS_DWI` (default `false`) and auto-detecting DWI inputs, so the existing T1/FLAIR flow is unaffected when no DWI is present/enabled.

**`config/default_config.sh`**
- Commented block for denoise routing (`SWI_TOF_DENOISE_ENABLED`, `DENOISE_DEFAULT_SKIP`) and DWI vars (`PROCESS_DWI`, `DWI_DEGIBBS`, `DWI_BIAS_CORRECT`/`DWI_BIAS_METHOD`, `DWI_RUN_EDDY`/`DWI_PE_DIR`/`DWI_READOUT_TIME`). All default-safe — no change to current T1/FLAIR results.

## Review fixes applied
- DWI sub-functions redirect external-tool stdout to stderr so captured paths aren't corrupted (`execute_with_logging` does not redirect command stdout).
- N4-on-mean-b0 fallback now returns the corrected mean (was returning the uncorrected 4D series).
- Gradient (bvec/bval) lookup is newline-delimited so paths with spaces survive.
- `compute_dwi_mean` reuses an existing mean (resumability; avoids redundant `-Tmean` on multi-GB 4D data); mean is computed from the diffusion series, not re-derived from a 3D bias-corrected mean.
- Parallel runner exports the full DWI call graph.

## Verification
- `bash -n` over all `.sh` — clean
- `shellcheck --severity=error` over all `.sh` — clean
- `test_environment_unit.sh` (100/100), `test_pipeline_control_unit.sh` (98/98), `test_import_unit.sh` (29/29) — all pass
- `src/pipeline.sh --help | grep Usage:` — pass
- Dispatcher routing check with synthetic `foo_{T1,FLAIR,DWI,SWI,TOF}.nii.gz`: T1/FLAIR->NLM, DWI->MP-PCA, SWI/TOF->skip, all rc=0 with graceful skip when `dwidenoise` absent; full `run_dwi_preprocessing` runs end-to-end and completes with SUCCESS.

Running real `dwidenoise`/DWI requires MRtrix + diffusion data, not feasible in CI here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)