### PR TITLE
FreeSurfer brainstem substructure segmentation (remove Talairach)

### DIFF
--- a/config/default_config.sh
+++ b/config/default_config.sh
@@ -73,11 +73,34 @@ export OUTPUT_DATATYPE="int"        # final int16
 # Atlas and template configuration
 export DEFAULT_TEMPLATE_RES="${DEFAULT_TEMPLATE_RES:-1mm}"
 
-# Joint fusion specific parameters
-export JOINT_FUSION_ALPHA="${JOINT_FUSION_ALPHA:-0.1}"      # Label smoothing
-export JOINT_FUSION_BETA="${JOINT_FUSION_BETA:-2.0}"        # Spatial regularization
-export JOINT_FUSION_PATCH_RADIUS="${JOINT_FUSION_PATCH_RADIUS:-2}"
-export JOINT_FUSION_SEARCH_RADIUS="${JOINT_FUSION_SEARCH_RADIUS:-3}"
+# ---------------------------------------------------------------------------
+# Brainstem segmentation method
+# ---------------------------------------------------------------------------
+# Controls how the brainstem and its substructures (midbrain/pons/medulla/SCP)
+# are obtained.
+#   freesurfer : recon-all + segmentBS (Iglesias 2015) for the substructures,
+#                with the Harvard-Oxford gross Brain-Stem mask as the extent and
+#                the FS<->HO agreement QC gate. Falls back gracefully to the HO
+#                gross mask when FreeSurfer/recon-all/license is unavailable or
+#                the FS<->HO agreement is too low.
+#   atlas      : Harvard-Oxford gross Brain-Stem mask only (no substructures).
+#                (alias: harvard_oxford)
+# Talairach has been removed entirely (single 1988 post-mortem brain; largest
+# MNI-mapping error inferiorly/posteriorly — worst exactly in the brainstem).
+export BRAINSTEM_SEGMENTATION_METHOD="${BRAINSTEM_SEGMENTATION_METHOD:-freesurfer}"
+
+# FreeSurfer brainstem-segmentation knobs (used by brainstem_freesurfer.sh).
+# FREESURFER_HOME / FS_LICENSE are honoured from the environment; the module
+# detects them and degrades to the HO gross mask when absent.
+export FS_RECON_ALL_FLAG="${FS_RECON_ALL_FLAG:--all}"   # recon-all level (segmentBS needs aseg/norm)
+# FS<->HO agreement gate (mirrors the existing brain-mask Dice QC style):
+export FS_BS_AGREEMENT_DICE_MIN="${FS_BS_AGREEMENT_DICE_MIN:-0.7}"        # min Dice(FS union, HO Brain-Stem)
+export FS_BS_AGREEMENT_LEAKAGE_MAX="${FS_BS_AGREEMENT_LEAKAGE_MAX:-0.2}"  # max fraction of FS union outside HO
+
+# Harvard-Oxford subcortical maxprob probability threshold for the gross
+# Brain-Stem extent. thr25 is tighter than the most-dilated thr0 variant; the
+# maxprob label index is independent of this threshold.
+export HO_SUB_MAXPROB_THR="${HO_SUB_MAXPROB_THR:-thr25}"
 
 # ANTs registration parameters (existing)
 # REG_TRANSFORM_TYPE is set in the "Registration & motion correction" section below

--- a/src/modules/analysis.sh
+++ b/src/modules/analysis.sh
@@ -516,16 +516,20 @@ find_all_atlas_regions() {
     local -n regions_array=$1
     regions_array=()
     
-    log_message "Searching for ALL atlas-based segmentation regions..."
-    
-    # Primary locations for Talairach atlas regions
+    log_message "Searching for ALL brainstem substructure regions..."
+
+    # Primary locations for brainstem substructure masks. FreeSurfer parcels
+    # (brainstem_freesurfer.sh) are written to segmentation/detailed_brainstem.
     local search_dirs=(
         "${RESULTS_DIR}/segmentation/detailed_brainstem"
         "${RESULTS_DIR}/segmentation/pons"
         "${RESULTS_DIR}/comprehensive_analysis/original_space"
     )
-    
-    # Talairach region patterns to find
+
+    # Region patterns to find. These match the FreeSurfer parcel filenames
+    # (midbrain/pons/medulla/scp, with optional left/right hemisphere splits)
+    # written by brainstem_freesurfer.sh, e.g. <basename>_pons.nii.gz,
+    # <basename>_left_pons.nii.gz, <basename>_midbrain.nii.gz.
     local region_patterns=(
         "*left_medulla*.nii.gz"
         "*right_medulla*.nii.gz"
@@ -533,7 +537,12 @@ find_all_atlas_regions() {
         "*right_pons*.nii.gz"
         "*left_midbrain*.nii.gz"
         "*right_midbrain*.nii.gz"
+        "*left_scp*.nii.gz"
+        "*right_scp*.nii.gz"
         "*_pons.nii.gz"
+        "*_midbrain.nii.gz"
+        "*_medulla.nii.gz"
+        "*_scp.nii.gz"
     )
     
     # Search for all region masks
@@ -563,15 +572,43 @@ find_all_atlas_regions() {
         fi
     done
     
+    # Fallback: when no substructure parcels exist (e.g. FreeSurfer
+    # unavailable/low-confidence, or BRAINSTEM_SEGMENTATION_METHOD=atlas), fall
+    # back to the gross Harvard-Oxford Brain-Stem mask so per-region GMM still
+    # runs on the whole brainstem instead of aborting the analysis stage. This
+    # is a single, coarser region (no pons/midbrain/medulla split).
+    if [ ${#regions_array[@]} -eq 0 ]; then
+        log_formatted "WARNING" "No brainstem substructure parcels found; falling back to the gross brainstem mask (whole-brainstem region, no subdivision)"
+        local gross_candidates=(
+            "${RESULTS_DIR}/segmentation/brainstem/"*"_brainstem.nii.gz"
+            "${RESULTS_DIR}/segmentation/in_reference_space/"*"_brainstem.nii.gz"
+        )
+        local gross_file
+        for gross_file in "${gross_candidates[@]}"; do
+            [ -f "$gross_file" ] || continue
+            local gross_base=$(basename "$gross_file" .nii.gz)
+            # Skip intensity/derivative files
+            if [[ "$gross_base" == *"_intensity"* ]] || [[ "$gross_base" == *"_flair_"* ]] || [[ "$gross_base" == *"_mask"* ]]; then
+                continue
+            fi
+            local gross_vol=$(fslstats "$gross_file" -V | awk '{print $1}')
+            if [ "$gross_vol" -gt 10 ]; then
+                regions_array+=("$gross_file")
+                log_message "✓ Found gross brainstem region: $gross_base (${gross_vol} voxels)"
+                break
+            fi
+        done
+    fi
+
     # Remove duplicates and sort
     if [ ${#regions_array[@]} -gt 0 ]; then
         readarray -t regions_array < <(printf '%s\n' "${regions_array[@]}" | sort -u)
-        log_message "Found ${#regions_array[@]} unique atlas-based regions for analysis"
+        log_message "Found ${#regions_array[@]} unique brainstem regions for analysis"
     else
-        log_formatted "ERROR" "No atlas-based segmentation regions found"
+        log_formatted "ERROR" "No brainstem segmentation regions found"
         return 1
     fi
-    
+
     return 0
 }
 

--- a/src/modules/brainstem_freesurfer.sh
+++ b/src/modules/brainstem_freesurfer.sh
@@ -1,0 +1,542 @@
+#!/usr/bin/env bash
+#
+# brainstem_freesurfer.sh - FreeSurfer brainstem substructure segmentation
+#
+# Implements docs/brainstem_freesurfer_segmentation_spec.md:
+#   recon-all (structural reconstruction) -> segmentBS.sh / segment_subregions
+#   brainstem -> brainstemSsLabels (Iglesias 2015 Bayesian segmentation) ->
+#   midbrain / pons / medulla / SCP binary masks brought into subject native
+#   space.
+#
+# Honesty ceiling: parcel level only (pons/midbrain/medulla/SCP). The
+# inter-parcel boundary is FreeSurfer-asserted; dorsal/ventral pons is never
+# produced.
+#
+# Graceful degradation: when FreeSurfer (FREESURFER_HOME, recon-all,
+# segmentBS.sh / segment_subregions) or a FreeSurfer license is unavailable,
+# this module logs a clear, non-fatal message and signals the caller to fall
+# back to the Harvard-Oxford gross brainstem mask. It never hard-crashes the
+# pipeline.
+#
+set -e -u -o pipefail
+
+# Include guard
+if [ -n "${_BRAINSTEM_FS_LOADED:-}" ]; then
+    return 0 2>/dev/null || true
+fi
+_BRAINSTEM_FS_LOADED=1
+
+source "$(dirname "${BASH_SOURCE[0]}")/require_env.sh"
+
+# FreeSurfer brainstemSsLabels label values (FreeSurferColorLUT.txt):
+#   173 = Midbrain, 174 = Pons, 175 = Medulla, 178 = SCP
+export FS_BS_LABEL_MIDBRAIN="${FS_BS_LABEL_MIDBRAIN:-173}"
+export FS_BS_LABEL_PONS="${FS_BS_LABEL_PONS:-174}"
+export FS_BS_LABEL_MEDULLA="${FS_BS_LABEL_MEDULLA:-175}"
+export FS_BS_LABEL_SCP="${FS_BS_LABEL_SCP:-178}"
+
+# ---------------------------------------------------------------------------
+# fs_brainstem_available - detect FreeSurfer brainstem-segmentation capability
+#
+# Returns 0 if recon-all + (segmentBS.sh or segment_subregions) are available,
+# FREESURFER_HOME is set, and a license file exists. Returns 1 otherwise (the
+# caller should fall back to the atlas/HO gross mask).
+# ---------------------------------------------------------------------------
+fs_brainstem_available() {
+    log_message "Checking FreeSurfer brainstem-segmentation availability..."
+
+    if [ -z "${FREESURFER_HOME:-}" ]; then
+        log_formatted "WARNING" "FREESURFER_HOME is not set; FreeSurfer brainstem segmentation unavailable"
+        return 1
+    fi
+
+    if ! command -v recon-all >/dev/null 2>&1; then
+        log_formatted "WARNING" "recon-all not found on PATH; FreeSurfer brainstem segmentation unavailable"
+        return 1
+    fi
+
+    if ! command -v segmentBS.sh >/dev/null 2>&1 && ! command -v segment_subregions >/dev/null 2>&1; then
+        log_formatted "WARNING" "Neither segmentBS.sh nor segment_subregions found; FreeSurfer brainstem segmentation unavailable"
+        return 1
+    fi
+
+    # License: $FS_LICENSE, $FREESURFER_HOME/license.txt or .license
+    local license_file="${FS_LICENSE:-}"
+    if [ -z "$license_file" ]; then
+        if [ -f "${FREESURFER_HOME}/license.txt" ]; then
+            license_file="${FREESURFER_HOME}/license.txt"
+        elif [ -f "${FREESURFER_HOME}/.license" ]; then
+            license_file="${FREESURFER_HOME}/.license"
+        fi
+    fi
+    if [ -z "$license_file" ] || [ ! -f "$license_file" ]; then
+        log_formatted "WARNING" "FreeSurfer license not found (set FS_LICENSE or place license.txt in FREESURFER_HOME); FreeSurfer brainstem segmentation unavailable"
+        return 1
+    fi
+
+    # Export the resolved license so recon-all/segmentBS use the SAME file this
+    # check validated (otherwise the tools' own discovery could pick a different
+    # path and reject the run hours into recon-all).
+    export FS_LICENSE="$license_file"
+
+    log_message "  ✓ FreeSurfer brainstem segmentation available (FREESURFER_HOME=$FREESURFER_HOME, license=$license_file)"
+    return 0
+}
+
+# ---------------------------------------------------------------------------
+# fs_record_provenance - record FreeSurfer version for reproducibility
+# ---------------------------------------------------------------------------
+fs_record_provenance() {
+    local provenance_file="$1"
+
+    log_message "Recording FreeSurfer provenance..."
+
+    local fs_version="unknown"
+    if [ -f "${FREESURFER_HOME:-}/build-stamp.txt" ]; then
+        fs_version="$(cat "${FREESURFER_HOME}/build-stamp.txt" 2>/dev/null || echo unknown)"
+    elif command -v recon-all >/dev/null 2>&1; then
+        fs_version="$(recon-all --version 2>/dev/null | head -1 || echo unknown)"
+    fi
+
+    {
+        echo "FreeSurfer brainstem segmentation provenance"
+        echo "==========================================="
+        echo "Date: $(date)"
+        echo "FREESURFER_HOME: ${FREESURFER_HOME:-unset}"
+        echo "FreeSurfer version: ${fs_version}"
+        echo "Method: brainstemSsLabels (Iglesias 2015)"
+    } > "$provenance_file"
+
+    log_message "  ✓ Provenance: $provenance_file"
+    return 0
+}
+
+# ---------------------------------------------------------------------------
+# run_recon_all - run FreeSurfer structural reconstruction (cached/resumable)
+#
+# Args: <t1_file> <subjects_dir> <subject_id>
+# Skips if the recon outputs (aseg.mgz) already exist for the subject.
+# ---------------------------------------------------------------------------
+run_recon_all() {
+    local t1_file="$1"
+    local subjects_dir="$2"
+    local subject_id="$3"
+
+    log_message "Running FreeSurfer recon-all for subject '$subject_id'..."
+
+    local subject_dir="${subjects_dir}/${subject_id}"
+    # segmentBS / segment_subregions need a full recon (norm.mgz, aseg.mgz,
+    # talairach transform). Treat aseg.mgz as the completion marker.
+    local recon_marker="${subject_dir}/mri/aseg.mgz"
+
+    if [ -f "$recon_marker" ]; then
+        log_message "  ✓ recon-all outputs already exist (cached): $recon_marker"
+        return 0
+    fi
+
+    mkdir -p "$subjects_dir"
+
+    # recon-all level is configurable; default is a full recon (-all) because
+    # the brainstem segmentation needs aseg/norm. Apple-Silicon native builds
+    # reduce the runtime but it remains hours-long, hence the caching above.
+    local recon_flag="${FS_RECON_ALL_FLAG:--all}"
+    local recon_threads="${ANTS_THREADS:-4}"
+
+    log_message "  recon-all flag: $recon_flag (threads: $recon_threads)"
+    log_message "  This may take several hours; outputs are cached for resumption."
+
+    # SUBJECTS_DIR must point at our results-local subjects directory.
+    if ! SUBJECTS_DIR="$subjects_dir" recon-all \
+            -i "$t1_file" \
+            -s "$subject_id" \
+            "$recon_flag" \
+            -parallel -openmp "$recon_threads" \
+            -sd "$subjects_dir" >/dev/null 2>&1; then
+        log_formatted "ERROR" "recon-all failed for subject '$subject_id'"
+        return 1
+    fi
+
+    if [ ! -f "$recon_marker" ]; then
+        log_formatted "ERROR" "recon-all completed but expected output missing: $recon_marker"
+        return 1
+    fi
+
+    log_message "  ✓ recon-all completed: $subject_dir"
+    return 0
+}
+
+# ---------------------------------------------------------------------------
+# run_brainstem_substructures - run segmentBS / segment_subregions (cached)
+#
+# Args: <subjects_dir> <subject_id>
+# Produces $subject_dir/mri/brainstemSsLabels.*.mgz and echoes its path.
+# ---------------------------------------------------------------------------
+# fs_find_labels - first brainstemSsLabels*.mgz in an mri dir, SIGPIPE-safe.
+# `-print -quit` makes find itself stop after the first hit, so there is no
+# `| head` pipe to take SIGPIPE under `set -o pipefail`.
+fs_find_labels() {
+    local mri_dir="$1"
+    find "$mri_dir" -maxdepth 1 -name 'brainstemSsLabels*.mgz' -print -quit 2>/dev/null
+}
+
+run_brainstem_substructures() {
+    local subjects_dir="$1"
+    local subject_id="$2"
+
+    log_message "Running FreeSurfer brainstem substructure segmentation..."
+
+    local subject_dir="${subjects_dir}/${subject_id}"
+
+    # Find an existing brainstemSsLabels volume (cached)
+    local existing_labels
+    existing_labels=$(fs_find_labels "${subject_dir}/mri")
+    if [ -n "$existing_labels" ] && [ -f "$existing_labels" ]; then
+        log_message "  ✓ brainstemSsLabels already exists (cached): $existing_labels"
+        echo "$existing_labels"
+        return 0
+    fi
+
+    # Prefer segment_subregions (newer FS); fall back to segmentBS.sh.
+    if command -v segment_subregions >/dev/null 2>&1; then
+        log_message "  Using segment_subregions brainstem..."
+        if ! SUBJECTS_DIR="$subjects_dir" segment_subregions brainstem \
+                --cross "$subject_id" --sd "$subjects_dir" >/dev/null 2>&1; then
+            log_formatted "WARNING" "segment_subregions brainstem failed; trying segmentBS.sh"
+        fi
+    fi
+
+    existing_labels=$(fs_find_labels "${subject_dir}/mri")
+    if [ -z "$existing_labels" ] && command -v segmentBS.sh >/dev/null 2>&1; then
+        log_message "  Using segmentBS.sh..."
+        if ! SUBJECTS_DIR="$subjects_dir" segmentBS.sh "$subject_id" "$subjects_dir" >/dev/null 2>&1; then
+            log_formatted "ERROR" "segmentBS.sh failed for subject '$subject_id'"
+            return 1
+        fi
+        existing_labels=$(fs_find_labels "${subject_dir}/mri")
+    fi
+
+    if [ -z "$existing_labels" ] || [ ! -f "$existing_labels" ]; then
+        log_formatted "ERROR" "brainstemSsLabels not produced for subject '$subject_id'"
+        return 1
+    fi
+
+    log_message "  ✓ brainstemSsLabels: $existing_labels"
+    echo "$existing_labels"
+    return 0
+}
+
+# ---------------------------------------------------------------------------
+# fs_labels_to_subject_space - resample brainstemSsLabels into the input grid
+#
+# FreeSurfer segments the subject's own T1 (conformed 1mm space). Resample the
+# label volume back onto the pipeline's input grid using nearest-neighbour so
+# downstream masks share the input geometry.
+#
+# Args: <brainstemSsLabels.mgz> <input_file> <output_labels.nii.gz>
+# ---------------------------------------------------------------------------
+fs_labels_to_subject_space() {
+    local fs_labels="$1"
+    local input_file="$2"
+    local output_labels="$3"
+
+    log_message "Resampling brainstemSsLabels into subject input grid..."
+
+    if ! command -v mri_convert >/dev/null 2>&1; then
+        log_formatted "ERROR" "mri_convert not found; cannot resample FreeSurfer labels"
+        return 1
+    fi
+
+    # Resample to the input file's grid (nearest neighbour preserves labels).
+    if ! mri_convert -rl "$input_file" -rt nearest "$fs_labels" "$output_labels" >/dev/null 2>&1; then
+        log_formatted "ERROR" "mri_convert failed to resample brainstemSsLabels to subject space"
+        return 1
+    fi
+
+    if [ ! -f "$output_labels" ]; then
+        log_formatted "ERROR" "Resampled label volume not created: $output_labels"
+        return 1
+    fi
+
+    log_message "  ✓ Labels in subject space: $output_labels"
+    return 0
+}
+
+# ---------------------------------------------------------------------------
+# fs_split_parcels - split label volume into per-structure binary masks
+#
+# Writes masks under <detailed_dir> using the filenames the downstream GMM
+# per-region path expects:
+#   <basename>_midbrain.nii.gz, <basename>_pons.nii.gz,
+#   <basename>_medulla.nii.gz, <basename>_scp.nii.gz
+# plus left/right hemisphere splits (<basename>_left_pons.nii.gz, ...).
+#
+# Args: <labels_in_subject_space> <detailed_dir> <basename>
+# ---------------------------------------------------------------------------
+fs_split_parcels() {
+    local labels="$1"
+    local detailed_dir="$2"
+    local basename="$3"
+
+    log_message "Splitting FreeSurfer parcels into per-structure masks..."
+
+    mkdir -p "$detailed_dir"
+
+    # parcel name -> label value
+    declare -A fs_parcels=(
+        ["midbrain"]="$FS_BS_LABEL_MIDBRAIN"
+        ["pons"]="$FS_BS_LABEL_PONS"
+        ["medulla"]="$FS_BS_LABEL_MEDULLA"
+        ["scp"]="$FS_BS_LABEL_SCP"
+    )
+
+    # Determine midline x voxel for hemisphere splitting from the label grid.
+    local dim_x
+    dim_x=$(fslval "$labels" dim1)
+    local center_x
+    center_x=$(echo "$dim_x" | awk '{print int($1/2)}')
+    local remaining_x=$((dim_x - center_x))
+
+    local produced=0
+    local parcel
+    for parcel in "${!fs_parcels[@]}"; do
+        local label="${fs_parcels[$parcel]}"
+        local parcel_mask="${detailed_dir}/${basename}_${parcel}.nii.gz"
+
+        safe_fslmaths "FS parcel ${parcel}" "$labels" -thr "$label" -uthr "$label" -bin "$parcel_mask" || {
+            log_formatted "WARNING" "Failed to extract FS parcel: $parcel"
+            continue
+        }
+
+        local voxels
+        voxels=$(fslstats "$parcel_mask" -V | awk '{print $1}')
+        if [ -z "$voxels" ]; then voxels=0; fi
+
+        if [ "$voxels" -gt 0 ]; then
+            log_message "  ✓ ${parcel}: ${voxels} voxels"
+            produced=$((produced + 1))
+
+            # Left/right hemisphere splits (image x axis).
+            local left_mask="${detailed_dir}/${basename}_left_${parcel}.nii.gz"
+            local right_mask="${detailed_dir}/${basename}_right_${parcel}.nii.gz"
+            safe_fslmaths "FS ${parcel} left" "$parcel_mask" -roi 0 "$center_x" 0 -1 0 -1 0 -1 "$left_mask" || true
+            safe_fslmaths "FS ${parcel} right" "$parcel_mask" -roi "$center_x" "$remaining_x" 0 -1 0 -1 0 -1 "$right_mask" || true
+        else
+            log_formatted "WARNING" "  ${parcel}: 0 voxels (parcel absent or out of grid)"
+            rm -f "$parcel_mask"
+        fi
+    done
+
+    if [ "$produced" -eq 0 ]; then
+        log_formatted "ERROR" "No FreeSurfer brainstem parcels produced any voxels"
+        return 1
+    fi
+
+    log_message "  ✓ Produced $produced FreeSurfer brainstem parcels in $detailed_dir"
+    return 0
+}
+
+# ---------------------------------------------------------------------------
+# fs_brainstem_agreement_qc - FS-union vs HO Brain-Stem Dice + leakage gate
+#
+# Args: <detailed_dir> <basename> <ho_brainstem_mask> <qc_file>
+# Echoes the Dice value on success. Returns 0 if Dice >= threshold AND leakage
+# below the cap; returns 1 (low confidence -> caller falls back) otherwise.
+# ---------------------------------------------------------------------------
+fs_brainstem_agreement_qc() {
+    local detailed_dir="$1"
+    local basename="$2"
+    local ho_brainstem_mask="$3"
+    local qc_file="$4"
+
+    log_message "Computing FS-HO brainstem agreement QC..."
+
+    if [ ! -f "$ho_brainstem_mask" ]; then
+        log_formatted "WARNING" "Harvard-Oxford brainstem mask not found for agreement QC: $ho_brainstem_mask"
+        return 1
+    fi
+
+    local tmp_dir
+    tmp_dir=$(mktemp -d)
+    local fs_union="${tmp_dir}/fs_union.nii.gz"
+
+    # Build the FreeSurfer brainstem union from the parcel masks.
+    local first=1
+    local parcel
+    for parcel in midbrain pons medulla scp; do
+        local pmask="${detailed_dir}/${basename}_${parcel}.nii.gz"
+        [ -f "$pmask" ] || continue
+        if [ "$first" -eq 1 ]; then
+            safe_fslmaths "FS union init" "$pmask" -bin "$fs_union" || { rm -rf "$tmp_dir"; return 1; }
+            first=0
+        else
+            safe_fslmaths "FS union add" "$fs_union" -add "$pmask" -bin "$fs_union" || { rm -rf "$tmp_dir"; return 1; }
+        fi
+    done
+
+    if [ "$first" -eq 1 ] || [ ! -f "$fs_union" ]; then
+        log_formatted "WARNING" "No FreeSurfer parcels available to build union for QC"
+        rm -rf "$tmp_dir"
+        return 1
+    fi
+
+    # Binarise the HO blob once; reuse for both Dice and leakage. Computing Dice
+    # inline (intersection + the two volumes) keeps this module self-contained:
+    # no dependency on qa.sh's calculate_dice, and the FS-union volume measured
+    # here is reused for the leakage denominator.
+    local ho_bin="${tmp_dir}/ho_bin.nii.gz"
+    safe_fslmaths "HO bin" "$ho_brainstem_mask" -bin "$ho_bin" || { rm -rf "$tmp_dir"; return 1; }
+
+    local intersection="${tmp_dir}/fs_ho_intersection.nii.gz"
+    safe_fslmaths "FS-HO intersection" "$fs_union" -mul "$ho_bin" "$intersection" || { rm -rf "$tmp_dir"; return 1; }
+
+    # Leakage = fraction of FS union voxels falling OUTSIDE the HO blob.
+    local outside="${tmp_dir}/fs_outside_ho.nii.gz"
+    safe_fslmaths "FS outside HO" "$fs_union" -sub "$ho_bin" -thr 0.5 -bin "$outside" || { rm -rf "$tmp_dir"; return 1; }
+
+    local fs_voxels
+    fs_voxels=$(fslstats "$fs_union" -V | awk '{print $1}')
+    local ho_voxels
+    ho_voxels=$(fslstats "$ho_bin" -V | awk '{print $1}')
+    local inter_voxels
+    inter_voxels=$(fslstats "$intersection" -V | awk '{print $1}')
+    local outside_voxels
+    outside_voxels=$(fslstats "$outside" -V | awk '{print $1}')
+    if [ -z "$fs_voxels" ] || [ "$fs_voxels" -eq 0 ]; then fs_voxels=1; fi
+    if [ -z "$ho_voxels" ]; then ho_voxels=0; fi
+    if [ -z "$inter_voxels" ]; then inter_voxels=0; fi
+    if [ -z "$outside_voxels" ]; then outside_voxels=0; fi
+
+    # Dice(FS union, HO Brain-Stem) — independent methods, genuine corroboration.
+    local denom=$((fs_voxels + ho_voxels))
+    local dice="0"
+    if [ "$denom" -gt 0 ]; then
+        dice=$(echo "scale=4; 2 * $inter_voxels / $denom" | bc)
+    fi
+    local leakage
+    leakage=$(echo "scale=4; $outside_voxels / $fs_voxels" | bc)
+
+    local dice_min="${FS_BS_AGREEMENT_DICE_MIN:-0.7}"
+    local leakage_max="${FS_BS_AGREEMENT_LEAKAGE_MAX:-0.2}"
+
+    local status="PASS"
+    local agree=0
+    if (( $(echo "$dice < $dice_min" | bc -l) )) || (( $(echo "$leakage > $leakage_max" | bc -l) )); then
+        status="FAIL_LOW_AGREEMENT"
+        agree=1
+    fi
+
+    {
+        echo "FreeSurfer / Harvard-Oxford brainstem agreement QC"
+        echo "=================================================="
+        echo "Date: $(date)"
+        echo "FS union voxels: $fs_voxels"
+        echo "Dice(FS union, HO Brain-Stem): $dice (min: $dice_min)"
+        echo "Leakage (FS outside HO): $leakage (max: $leakage_max)"
+        echo "Status: $status"
+    } > "$qc_file"
+
+    rm -rf "$tmp_dir"
+
+    log_message "  Dice=$dice  Leakage=$leakage  Status=$status"
+    echo "$dice"
+
+    if [ "$agree" -eq 1 ]; then
+        log_formatted "WARNING" "FS-HO brainstem agreement is LOW (Dice=$dice, leakage=$leakage); FreeSurfer parcels are low-confidence"
+        return 1
+    fi
+
+    log_formatted "SUCCESS" "FS-HO brainstem agreement OK (Dice=$dice)"
+    return 0
+}
+
+# ---------------------------------------------------------------------------
+# extract_brainstem_freesurfer - top-level FreeSurfer brainstem segmentation
+#
+# Args: <input_file> <output_prefix> [<ho_brainstem_mask>]
+#   input_file        : subject T1 (segmentation reference)
+#   output_prefix     : <brainstem_dir>/<basename>
+#   ho_brainstem_mask : optional HO Brain-Stem mask for the agreement QC gate
+#
+# On success the per-parcel masks are written to
+# <RESULTS_DIR>/segmentation/detailed_brainstem/ using GMM-compatible names.
+# Returns 0 on success (parcels trusted), 1 if FreeSurfer is unavailable / the
+# segmentation failed / the agreement gate failed (caller must fall back).
+# ---------------------------------------------------------------------------
+extract_brainstem_freesurfer() {
+    local input_file="$1"
+    local output_prefix="$2"
+    local ho_brainstem_mask="${3:-}"
+
+    log_formatted "INFO" "=== FREESURFER BRAINSTEM SUBSTRUCTURE SEGMENTATION ==="
+    log_message "Input: $input_file"
+    log_message "Output prefix: $output_prefix"
+
+    if [ ! -f "$input_file" ]; then
+        log_formatted "ERROR" "Input file does not exist: $input_file"
+        return 1
+    fi
+
+    if ! fs_brainstem_available; then
+        log_formatted "WARNING" "FreeSurfer brainstem segmentation unavailable — falling back to atlas/HO gross mask"
+        return 1
+    fi
+
+    local basename
+    basename=$(basename "$output_prefix")
+    local subjects_dir="${RESULTS_DIR}/freesurfer"
+    local subject_id="${basename}"
+    local detailed_dir="${RESULTS_DIR}/segmentation/detailed_brainstem"
+    mkdir -p "$subjects_dir" "$detailed_dir"
+
+    if ! run_recon_all "$input_file" "$subjects_dir" "$subject_id"; then
+        log_formatted "WARNING" "recon-all failed — falling back to atlas/HO gross mask"
+        return 1
+    fi
+
+    local fs_labels
+    if ! fs_labels=$(run_brainstem_substructures "$subjects_dir" "$subject_id"); then
+        log_formatted "WARNING" "Brainstem substructure segmentation failed — falling back to atlas/HO gross mask"
+        return 1
+    fi
+
+    local labels_subject="${output_prefix}_brainstemSsLabels.nii.gz"
+    if ! fs_labels_to_subject_space "$fs_labels" "$input_file" "$labels_subject"; then
+        log_formatted "WARNING" "Failed to bring FreeSurfer labels to subject space — falling back"
+        return 1
+    fi
+
+    if ! fs_split_parcels "$labels_subject" "$detailed_dir" "$basename"; then
+        log_formatted "WARNING" "Failed to split FreeSurfer parcels — falling back"
+        return 1
+    fi
+
+    # FS-HO agreement gate (when an HO reference mask is available).
+    if [ -n "$ho_brainstem_mask" ] && [ -f "$ho_brainstem_mask" ]; then
+        local qc_file="${output_prefix}_fs_ho_agreement_qc.txt"
+        if ! fs_brainstem_agreement_qc "$detailed_dir" "$basename" "$ho_brainstem_mask" "$qc_file" >/dev/null; then
+            log_formatted "WARNING" "FS parcels disagree with HO gross extent — caller should fall back to HO gross mask (low confidence)"
+            return 1
+        fi
+    else
+        log_message "No HO reference mask supplied — skipping FS-HO agreement QC"
+    fi
+
+    # Record provenance only after the parcels are accepted, so the provenance
+    # file is never left behind asserting FreeSurfer was used on a fall-back run.
+    fs_record_provenance "${output_prefix}_freesurfer_provenance.txt" || true
+
+    log_formatted "SUCCESS" "FreeSurfer brainstem substructure segmentation completed"
+    return 0
+}
+
+export -f fs_brainstem_available
+export -f fs_record_provenance
+export -f run_recon_all
+export -f fs_find_labels
+export -f run_brainstem_substructures
+export -f fs_labels_to_subject_space
+export -f fs_split_parcels
+export -f fs_brainstem_agreement_qc
+export -f extract_brainstem_freesurfer
+
+log_message "FreeSurfer brainstem segmentation module loaded"

--- a/src/modules/hierarchical_joint_fusion.sh
+++ b/src/modules/hierarchical_joint_fusion.sh
@@ -1,80 +1,96 @@
-#!/bin/bash
-# src/modules/hierarchical_joint_fusion.sh - SIMPLIFIED
-# Harvard-Oxford brainstem extraction with optional Talairach subdivisions
+#!/usr/bin/env bash
+# src/modules/hierarchical_joint_fusion.sh
+#
+# Harvard-Oxford gross brainstem extraction (single-atlas SyN warp).
+#
+# NOTE ON NAMING: despite the historical "joint fusion" name, this module does
+# NOT run antsJointFusion. It performs a SINGLE antsRegistrationSyN.sh warp of
+# the MNI template into subject space and applies that transform to the
+# Harvard-Oxford subcortical atlas to recover the gross Brain-Stem extent. The
+# public entry point keeps the legacy name (execute_hierarchical_joint_fusion)
+# for backward compatibility with segmentation.sh callers; treat it as
+# "extract_harvard_oxford_gross_brainstem".
+#
+# The midbrain / pons / medulla / SCP subdivisions are NO LONGER derived here.
+# Talairach has been removed entirely (single 1988 post-mortem brain, largest
+# MNI-mapping error inferiorly/posteriorly — worst exactly in the brainstem).
+# Subdivisions come from FreeSurfer (brainstem_freesurfer.sh) when available.
+# This module produces ONLY the gross Brain-Stem mask.
+set -e -u -o pipefail
 
 source "$(dirname "${BASH_SOURCE[0]}")/require_env.sh"
 source ./config/default_config.sh
 TEMPLATE_RES="${DEFAULT_TEMPLATE_RES:-1mm}"
 
+# HarvardOxford subcortical maxprob probability threshold. thr25 is tighter than
+# thr0 (the most dilated variant) and avoids low-probability fringe voxels at
+# the brainstem boundary. The maxprob label index is independent of the
+# probability threshold, so the Brain-Stem index (8, see below) is unchanged.
+HO_SUB_MAXPROB_THR="${HO_SUB_MAXPROB_THR:-thr25}"
+
 execute_hierarchical_joint_fusion() {
     local input_file="$1"
     local output_prefix="$2"
     local temp_dir="$3"
-    
-    log_formatted "INFO" "=== HARVARD-OXFORD BRAINSTEM EXTRACTION ==="
+
+    log_formatted "INFO" "=== HARVARD-OXFORD GROSS BRAINSTEM EXTRACTION ==="
     log_message "Input: $input_file"
     log_message "Output prefix: $output_prefix"
     log_message "Template resolution: $TEMPLATE_RES"
-    
+
+    # Workspace dir name kept as joint_fusion for path stability with existing runs.
     local fusion_workspace="${temp_dir}/joint_fusion"
     mkdir -p "${fusion_workspace}"/{atlases,registration,labels,results}
-    
+
     prepare_atlas_ensemble "$fusion_workspace" || return 1
     extract_harvard_oxford_brainstem "$input_file" "$fusion_workspace" || return 1
     generate_segmentation_outputs "$fusion_workspace" "$output_prefix" "$input_file" || return 1
-    
+
     log_formatted "SUCCESS" "Label extraction completed successfully"
     return 0
 }
 
 prepare_atlas_ensemble() {
     local workspace="$1"
-    log_message "Preparing Harvard-Oxford and Talairach atlases..."
-    
-    local talairach_atlas="${FSLDIR}/data/atlases/Talairach/Talairach-labels-${TEMPLATE_RES}.nii.gz"
-    local harvard_oxford_atlas="${FSLDIR}/data/atlases/HarvardOxford/HarvardOxford-sub-maxprob-thr0-${TEMPLATE_RES}.nii.gz"
-    
-    if [[ ! -f "$talairach_atlas" ]]; then
-        log_formatted "ERROR" "Talairach atlas not found: $talairach_atlas"
-        return 1
-    fi
+    log_message "Preparing Harvard-Oxford subcortical atlas (${HO_SUB_MAXPROB_THR})..."
+
+    local harvard_oxford_atlas="${FSLDIR}/data/atlases/HarvardOxford/HarvardOxford-sub-maxprob-${HO_SUB_MAXPROB_THR}-${TEMPLATE_RES}.nii.gz"
+
     if [[ ! -f "$harvard_oxford_atlas" ]]; then
         log_formatted "ERROR" "Harvard-Oxford subcortical atlas not found: $harvard_oxford_atlas"
         return 1
     fi
-    
-    cp "$talairach_atlas" "${workspace}/atlases/talairach.nii.gz"
+
     cp "$harvard_oxford_atlas" "${workspace}/atlases/harvard_oxford_subcortical.nii.gz"
-    log_formatted "SUCCESS" "Atlases prepared"
+    log_formatted "SUCCESS" "Atlas prepared"
     return 0
 }
 
 extract_harvard_oxford_brainstem() {
     local input_file="$1"
     local workspace="$2"
-    
+
     log_message "Registering and extracting Harvard-Oxford brainstem label..."
-    
+
     local harvard_oxford_atlas="${workspace}/atlases/harvard_oxford_subcortical.nii.gz"
-    local talairach_atlas="${workspace}/atlases/talairach.nii.gz"
     local mni_template="${FSLDIR}/data/standard/MNI152_T1_${TEMPLATE_RES}_brain.nii.gz"
     local registration_dir="${workspace}/registration"
     local results_dir="${workspace}/results"
-    
+
     mkdir -p "$registration_dir"
 
     if [[ ! -f "$mni_template" ]]; then
         mni_template="${FSLDIR}/data/standard/MNI152_T1_${TEMPLATE_RES}.nii.gz"
     fi
     if [[ ! -f "$mni_template" ]]; then
-        log_formatted "ERROR" "MNI template not found for Talairach registration"
+        log_formatted "ERROR" "MNI template not found for Harvard-Oxford registration"
         return 1
     fi
-    
-    log_message "Registering MNI template to subject space..."
+
+    log_message "Registering MNI template to subject space (single SyN warp)..."
     log_message "Template: $mni_template"
     local atlas_prefix="${registration_dir}/mni_to_subject_"
-    
+
     antsRegistrationSyN.sh \
         -d 3 \
         -f "$input_file" \
@@ -83,27 +99,30 @@ extract_harvard_oxford_brainstem() {
         -t s \
         -j 1 \
         -n "${ANTS_THREADS}" >/dev/null 2>/dev/null
-    
+
     local atlas_affine="${atlas_prefix}0GenericAffine.mat"
     local atlas_warp="${atlas_prefix}1Warp.nii.gz"
-    
+
     if [[ ! -f "$atlas_affine" ]] || [[ ! -f "$atlas_warp" ]]; then
         log_formatted "ERROR" "MNI-to-subject registration failed"
         return 1
     fi
-    
+
     log_message "Warping Harvard-Oxford atlas to subject space..."
     local harvard_subject_space="${results_dir}/harvard_oxford_in_subject_space.nii.gz"
     antsApplyTransforms -d 3 -i "$harvard_oxford_atlas" -r "$input_file" \
         -o "$harvard_subject_space" \
         -t "$atlas_warp" -t "$atlas_affine" -n NearestNeighbor
-    
+
     if [[ ! -f "$harvard_subject_space" ]]; then
         log_formatted "ERROR" "Failed to warp Harvard-Oxford atlas to subject space"
         return 1
     fi
 
-    # Harvard-Oxford XML label index 7 is Brain-Stem; maxprob image stores index+1.
+    # Harvard-Oxford-Subcortical XML label index 7 is Brain-Stem; the maxprob
+    # image stores index+1, so the Brain-Stem voxel value is 8. This index is
+    # independent of the probability threshold (thr0/thr25/thr50), so it is
+    # unchanged by tightening HO_SUB_MAXPROB_THR.
     local brainstem_mask="${results_dir}/brainstem_mask.nii.gz"
     fslmaths "$harvard_subject_space" -thr 8 -uthr 8 -bin "$brainstem_mask"
     local brainstem_voxels=$(fslstats "$brainstem_mask" -V | awk '{print $1}')
@@ -114,37 +133,10 @@ extract_harvard_oxford_brainstem() {
         return 1
     fi
 
-    # Keep Talairach only as optional coarse subdivisions; do not use it as the
-    # primary brainstem mask.
-    log_message "Warping Talairach atlas for optional subdivisions..."
-    local talairach_subject_space="${results_dir}/talairach_in_subject_space.nii.gz"
-    antsApplyTransforms -d 3 -i "$talairach_atlas" -r "$input_file" \
-        -o "$talairach_subject_space" \
-        -t "$atlas_warp" -t "$atlas_affine" -n NearestNeighbor
-
-    log_message "Extracting optional Talairach coarse subdivisions..."
-    
-    # Pons (indices 71-72)
-    local pons_mask="${results_dir}/pons_mask.nii.gz"
-    fslmaths "$talairach_subject_space" -thr 71 -uthr 72 -bin "$pons_mask"
-    local pons_voxels=$(fslstats "$pons_mask" -V | awk '{print $1}')
-    log_message "  ✓ Pons: ${pons_voxels} voxels"
-    
-    # Medulla (indices 5-6)
-    local medulla_mask="${results_dir}/medulla_mask.nii.gz"
-    fslmaths "$talairach_subject_space" -thr 5 -uthr 6 -bin "$medulla_mask"
-    local medulla_voxels=$(fslstats "$medulla_mask" -V | awk '{print $1}')
-    log_message "  ✓ Medulla: ${medulla_voxels} voxels"
-    
-    # Midbrain (indices 215-216)
-    local midbrain_mask="${results_dir}/midbrain_mask.nii.gz"
-    fslmaths "$talairach_subject_space" -thr 215 -uthr 216 -bin "$midbrain_mask"
-    local midbrain_voxels=$(fslstats "$midbrain_mask" -V | awk '{print $1}')
-    log_message "  ✓ Midbrain: ${midbrain_voxels} voxels"
-    
-    # Create joint_fusion_labels for downstream compatibility
+    # Gross brainstem mask only. Midbrain/pons/medulla/SCP subdivisions come
+    # from FreeSurfer (brainstem_freesurfer.sh), not from this atlas warp.
     cp "$brainstem_mask" "${results_dir}/joint_fusion_labels.nii.gz"
-    
+
     log_formatted "SUCCESS" "Harvard-Oxford brainstem extraction completed"
     return 0
 }
@@ -169,17 +161,12 @@ generate_segmentation_outputs() {
         log_message "  ✓ FLAIR intensity mask: $brainstem_flair_intensity"
     fi
 
-    # Generate region subdivisions (non-fatal — these are optional detail masks)
-    generate_talairach_subdivisions "$workspace" "$output_prefix" "$input_file" || {
-        log_formatted "WARNING" "Talairach subdivision generation failed, continuing without subdivisions"
-    }
-
-    # Generate hemisphere masks
+    # Generate hemisphere masks (gross brainstem only).
     generate_hemisphere_masks "$brainstem_mask" "$output_prefix" || return 1
     validate_brainstem_mask_geometry "$brainstem_mask" "$output_prefix" || return 1
-    
+
     log_message "  ✓ Primary brainstem mask: $brainstem_mask"
-    
+
     log_formatted "SUCCESS" "Segmentation outputs generated successfully"
     return 0
 }
@@ -221,83 +208,28 @@ validate_brainstem_mask_geometry() {
     return 0
 }
 
-generate_talairach_subdivisions() {
-    local workspace="$1"
-    local output_prefix="$2"
-    local input_file="${3:-}"
-
-    log_message "Generating Talairach subdivision masks..."
-
-    if [[ -z "$input_file" ]] || [[ ! -f "$input_file" ]]; then
-        log_formatted "WARNING" "No input file provided for Talairach subdivisions, skipping"
-        return 1
-    fi
-
-    local talairach_atlas="${workspace}/atlases/talairach.nii.gz"
-    local talairach_affine="${workspace}/registration/mni_to_subject_0GenericAffine.mat"
-    local talairach_warp="${workspace}/registration/mni_to_subject_1Warp.nii.gz"
-    
-    declare -A TALAIRACH_REGIONS=(
-        ["left_medulla"]="5"
-        ["right_medulla"]="6"
-        ["left_pons"]="71"
-        ["right_pons"]="72"
-        ["left_midbrain"]="215"
-        ["right_midbrain"]="216"
-    )
-    
-    local subdivision_dir="$(dirname "$output_prefix")/talairach_subdivisions"
-    mkdir -p "$subdivision_dir"
-    
-    for region in "${!TALAIRACH_REGIONS[@]}"; do
-        local index="${TALAIRACH_REGIONS[$region]}"
-        local temp_region="${workspace}/temp_${region}.nii.gz"
-        local region_mask="${subdivision_dir}/${region}.nii.gz"
-        
-        fslmaths "$talairach_atlas" -thr "$index" -uthr "$index" -bin "$temp_region"
-        
-        antsApplyTransforms -d 3 -i "$temp_region" -r "$input_file" \
-            -o "$region_mask" \
-            -t "$talairach_warp" -t "$talairach_affine" \
-            -n NearestNeighbor 2>/dev/null
-        
-        local voxels=$(fslstats "$region_mask" -V 2>/dev/null | awk '{print $1}')
-        if [[ -z "$voxels" ]]; then voxels=0; fi
-        
-        if [[ "$voxels" -gt 0 ]]; then
-            log_message "  ✓ ${region}: ${voxels} voxels"
-        else
-            log_formatted "WARNING" "  ${region}: No voxels"
-        fi
-        
-        rm -f "$temp_region"
-    done
-    
-    return 0
-}
-
 generate_hemisphere_masks() {
     local brainstem_mask="$1"
     local output_prefix="$2"
-    
+
     log_message "Generating hemisphere masks..."
-    
+
     local dims=$(fslval "$brainstem_mask" dim1)
     local center_x=$(echo "$dims" | awk '{print int($1/2)}')
-    
+
     local left_hemisphere="${output_prefix}_left_hemisphere.nii.gz"
     fslmaths "$brainstem_mask" -roi 0 "$center_x" 0 -1 0 -1 0 -1 "$left_hemisphere"
-    
+
     local right_hemisphere="${output_prefix}_right_hemisphere.nii.gz"
     local remaining_x=$((dims - center_x))
     fslmaths "$brainstem_mask" -roi "$center_x" "$remaining_x" 0 -1 0 -1 0 -1 "$right_hemisphere"
-    
+
     local left_voxels=$(fslstats "$left_hemisphere" -V | awk '{print $1}')
     local right_voxels=$(fslstats "$right_hemisphere" -V | awk '{print $1}')
-    
+
     log_message "  ✓ Left hemisphere: ${left_voxels} voxels"
     log_message "  ✓ Right hemisphere: ${right_voxels} voxels"
-    
+
     return 0
 }
 
@@ -305,8 +237,7 @@ export -f execute_hierarchical_joint_fusion
 export -f prepare_atlas_ensemble
 export -f extract_harvard_oxford_brainstem
 export -f generate_segmentation_outputs
-export -f generate_talairach_subdivisions
 export -f generate_hemisphere_masks
 export -f validate_brainstem_mask_geometry
 
-log_message "Hierarchical joint fusion module loaded (simplified)"
+log_message "Harvard-Oxford gross brainstem extraction module loaded"

--- a/src/modules/segmentation.sh
+++ b/src/modules/segmentation.sh
@@ -1,19 +1,23 @@
-#!/bin/bash
-# src/modules/segmentation.sh - Updated to use hierarchical joint fusion
+#!/usr/bin/env bash
+# src/modules/segmentation.sh
+# Brainstem segmentation: Harvard-Oxford gross extent + FreeSurfer substructures.
+# (The legacy "hierarchical joint fusion" entry point is a single-atlas HO SyN
+#  warp — see hierarchical_joint_fusion.sh for the naming note.)
 
 source "$(dirname "${BASH_SOURCE[0]}")/require_env.sh"
 source "config/default_config.sh"
 
 source "$(dirname "${BASH_SOURCE[0]}")/utils.sh"
 source "$(dirname "${BASH_SOURCE[0]}")/hierarchical_joint_fusion.sh"
+source "$(dirname "${BASH_SOURCE[0]}")/brainstem_freesurfer.sh"
 
-# Main segmentation function - now using hierarchical joint fusion
+# Main segmentation function - Harvard-Oxford gross brainstem extraction
 extract_brainstem() {
     local input_file="$1"
     local input_basename="$2"
     local flair_file=""  # Optional FLAIR file
-    
-    log_formatted "INFO" "=== BRAINSTEM SEGMENTATION (HIERARCHICAL JOINT FUSION) ==="
+
+    log_formatted "INFO" "=== BRAINSTEM SEGMENTATION (HARVARD-OXFORD GROSS EXTENT) ==="
     log_message "Processing: $input_file"
     log_message "Basename: $input_basename"
     [[ -n "$flair_file" ]] && log_message "FLAIR file: $flair_file"
@@ -34,11 +38,12 @@ extract_brainstem() {
     # Set output prefix (directory + basename so files are named correctly)
     local output_prefix="${brainstem_dir}/${input_basename}"
     
-    # Execute hierarchical joint fusion
+    # Execute Harvard-Oxford gross brainstem extraction (single-atlas SyN warp;
+    # the function name is legacy — see hierarchical_joint_fusion.sh).
     if execute_hierarchical_joint_fusion "$input_file" "$output_prefix" "$temp_dir"; then
-        log_formatted "SUCCESS" "Hierarchical joint fusion segmentation completed"
+        log_formatted "SUCCESS" "Harvard-Oxford gross brainstem extraction completed"
     else
-        log_formatted "ERROR" "Hierarchical joint fusion segmentation failed"
+        log_formatted "ERROR" "Harvard-Oxford gross brainstem extraction failed"
         #srm -rf "$temp_dir"
         return 1
     fi
@@ -78,22 +83,23 @@ enhance_segmentation_with_flair() {
     
     # Create FLAIR intensity mask
     fslmaths "$flair_file" -mul "$brainstem_mask" "$flair_intensity"
-    
-    # Enhance Talairach subdivisions with FLAIR
-    local subdivision_dir="$(dirname "$output_prefix")/talairach_subdivisions"
-    if [[ -d "$subdivision_dir" ]]; then
-        local flair_subdivision_dir="${subdivision_dir}_flair"
-        mkdir -p "$flair_subdivision_dir"
-        
-        for region_mask in "$subdivision_dir"/*.nii.gz; do
+
+    # Enhance FreeSurfer brainstem parcels with FLAIR (when present).
+    local detailed_dir="${RESULTS_DIR}/segmentation/detailed_brainstem"
+    if [[ -d "$detailed_dir" ]]; then
+        local flair_detailed_dir="${detailed_dir}_flair"
+        mkdir -p "$flair_detailed_dir"
+
+        for region_mask in "$detailed_dir"/*.nii.gz; do
+            [[ -f "$region_mask" ]] || continue
             local region_name=$(basename "$region_mask" .nii.gz)
-            local flair_region="${flair_subdivision_dir}/${region_name}_flair.nii.gz"
+            local flair_region="${flair_detailed_dir}/${region_name}_flair.nii.gz"
             fslmaths "$flair_file" -mul "$region_mask" "$flair_region"
         done
-        
-        log_message "  ✓ FLAIR-enhanced subdivisions: $flair_subdivision_dir"
+
+        log_message "  ✓ FLAIR-enhanced parcels: $flair_detailed_dir"
     fi
-    
+
     log_message "  ✓ FLAIR intensity enhancement completed"
     return 0
 }
@@ -108,13 +114,16 @@ generate_segmentation_report() {
     local report_file="${output_prefix}_segmentation_report.txt"
     local brainstem_mask="${output_prefix}_brainstem.nii.gz"
     
+    local detailed_dir="${RESULTS_DIR}/segmentation/detailed_brainstem"
+
     cat > "$report_file" <<EOF
 ================================================================================
-HIERARCHICAL JOINT FUSION SEGMENTATION REPORT
+BRAINSTEM SEGMENTATION REPORT
 ================================================================================
 Generated: $(date)
 Subject: $(basename "$output_prefix")
 Template Resolution: ${DEFAULT_TEMPLATE_RES:-1mm}
+Brainstem method: ${BRAINSTEM_SEGMENTATION_METHOD:-freesurfer}
 
 INPUT FILES
 -----------
@@ -129,14 +138,13 @@ PRIMARY OUTPUTS
    - Left hemisphere: ${output_prefix}_left_hemisphere.nii.gz
    - Right hemisphere: ${output_prefix}_right_hemisphere.nii.gz
 
-3. Talairach Subdivisions:
-   Directory: $(dirname "$output_prefix")/talairach_subdivisions/
-   Regions: left_medulla, right_medulla, left_pons, right_pons, 
-            left_midbrain, right_midbrain
+3. Brainstem Substructures (FreeSurfer parcels, when available):
+   Directory: ${detailed_dir}/
+   Regions: midbrain, pons, medulla, scp (plus left/right splits)
 
 $([ -n "$flair_file" ] && echo "4. FLAIR-Enhanced Outputs:
    - FLAIR intensity mask: ${output_prefix}_brainstem_flair_intensity.nii.gz
-   - FLAIR subdivisions: $(dirname "$output_prefix")/talairach_subdivisions_flair/")
+   - FLAIR parcels: ${detailed_dir}_flair/")
 
 SEGMENTATION STATISTICS
 -----------------------
@@ -154,20 +162,20 @@ EOF
         echo "" >> "$report_file"
     fi
     
-    # Add subdivision statistics
-    local subdivision_dir="$(dirname "$output_prefix")/talairach_subdivisions"
-    if [[ -d "$subdivision_dir" ]]; then
-        echo "TALAIRACH SUBDIVISION STATISTICS" >> "$report_file"
-        echo "--------------------------------" >> "$report_file"
-        
-        for region_file in "$subdivision_dir"/*.nii.gz; do
+    # Add substructure statistics (FreeSurfer parcels)
+    if [[ -d "$detailed_dir" ]]; then
+        echo "BRAINSTEM SUBSTRUCTURE STATISTICS" >> "$report_file"
+        echo "---------------------------------" >> "$report_file"
+
+        for region_file in "$detailed_dir"/*.nii.gz; do
+            [[ -f "$region_file" ]] || continue
             local region_name=$(basename "$region_file" .nii.gz)
             local region_voxels=$(fslstats "$region_file" -V | awk '{print $1}')
             echo "  ${region_name}: ${region_voxels} voxels" >> "$report_file"
         done
         echo "" >> "$report_file"
     fi
-    
+
     cat >> "$report_file" <<EOF
 
 VISUALIZATION COMMANDS
@@ -180,8 +188,8 @@ fsleyes $input_file $brainstem_mask -cm red -a 0.5
 $([ -n "$flair_file" ] && echo "# Primary brainstem on FLAIR:
 fsleyes $flair_file $brainstem_mask -cm red -a 0.5")
 
-# Talairach subdivisions:
-fsleyes $input_file $(dirname "$output_prefix")/talairach_subdivisions/*.nii.gz -cm random -a 0.6
+# Brainstem substructures:
+fsleyes $input_file ${detailed_dir}/*.nii.gz -cm random -a 0.6
 
 ================================================================================
 EOF
@@ -218,31 +226,50 @@ extract_brainstem_with_flair() {
 extract_brainstem_final() {
     local input_file="$1"
     local input_basename=$(basename "$input_file" .nii.gz)
-    
+    local seg_method="${BRAINSTEM_SEGMENTATION_METHOD:-freesurfer}"
+
     log_formatted "INFO" "===== COMPREHENSIVE BRAINSTEM SEGMENTATION ====="
-    log_message "Using hierarchical joint fusion as primary method"
-    
+    log_message "Brainstem segmentation method: $seg_method"
+
     # Define output directory
     local brainstem_dir="${RESULTS_DIR}/segmentation/brainstem"
     mkdir -p "$brainstem_dir"
-    
-    # Execute hierarchical joint fusion
+
+    # Always produce the Harvard-Oxford gross brainstem extent. It is the
+    # fallback mask AND the reference for the FS-HO agreement QC gate.
     if extract_brainstem "$input_file" "$input_basename"; then
-        log_formatted "SUCCESS" "Hierarchical joint fusion segmentation successful"
+        log_formatted "SUCCESS" "Harvard-Oxford gross brainstem extraction successful"
     else
-        log_formatted "ERROR" "Hierarchical joint fusion segmentation failed"
+        log_formatted "ERROR" "Harvard-Oxford gross brainstem extraction failed"
         return 1
     fi
-    
+
     # Map files to expected names
     map_segmentation_files "$input_basename" "$brainstem_dir"
-    
+
+    # Brainstem substructures: FreeSurfer parcels when requested + available;
+    # otherwise the gross HO mask stands alone (subdivisions absent).
+    if [ "$seg_method" = "freesurfer" ]; then
+        local output_prefix="${brainstem_dir}/${input_basename}"
+        local ho_brainstem_mask="${output_prefix}_brainstem.nii.gz"
+
+        if extract_brainstem_freesurfer "$input_file" "$output_prefix" "$ho_brainstem_mask"; then
+            log_formatted "SUCCESS" "FreeSurfer brainstem substructures produced (pons/midbrain/medulla/scp)"
+        else
+            log_formatted "WARNING" "FreeSurfer brainstem substructures unavailable or low-confidence; using Harvard-Oxford gross mask only (no subdivisions, low spatial granularity)"
+        fi
+    elif [ "$seg_method" = "atlas" ] || [ "$seg_method" = "harvard_oxford" ]; then
+        log_message "Atlas method selected: Harvard-Oxford gross mask only (no FreeSurfer substructures)"
+    else
+        log_formatted "WARNING" "Unknown BRAINSTEM_SEGMENTATION_METHOD='$seg_method'; defaulting to Harvard-Oxford gross mask only"
+    fi
+
     # Validate segmentation
     validate_segmentation_outputs "$input_file" "$input_basename"
-    
+
     # Generate comprehensive visualization report
     generate_comprehensive_report "$input_file" "$input_basename"
-    
+
     log_formatted "SUCCESS" "Comprehensive segmentation complete"
     return 0
 }
@@ -385,7 +412,7 @@ Subject: $input_basename
 
 SEGMENTATION SUMMARY
 -------------------
-Method: Hierarchical Joint Fusion (Harvard-Oxford + Talairach + Juelich)
+Method: ${BRAINSTEM_SEGMENTATION_METHOD:-freesurfer} (gross extent: Harvard-Oxford; substructures: FreeSurfer brainstemSsLabels)
 Space: T1 Native Space
 Brainstem voxels: $brainstem_voxels
 
@@ -460,12 +487,12 @@ segment_tissues() {
 
 # Legacy function wrappers for backward compatibility
 extract_brainstem_harvard_oxford() {
-    log_formatted "INFO" "Using hierarchical joint fusion (Harvard-Oxford component)"
+    log_formatted "INFO" "Using Harvard-Oxford gross brainstem extraction"
     extract_brainstem "$@"
 }
 
 extract_brainstem_talairach() {
-    log_formatted "INFO" "Using hierarchical joint fusion (includes Talairach subdivisions)"
+    log_formatted "WARNING" "extract_brainstem_talairach is deprecated (Talairach removed). Using Harvard-Oxford gross extraction; substructures come from FreeSurfer."
     extract_brainstem "$@"
 }
 
@@ -528,4 +555,4 @@ export -f validate_segmentation
 export -f discover_and_map_segmentation_files
 export -f segment_brainstem
 
-log_message "Segmentation module loaded with hierarchical joint fusion"
+log_message "Segmentation module loaded (Harvard-Oxford gross extent + FreeSurfer substructures)"


### PR DESCRIPTION
## Summary

Replaces the Talairach atlas brainstem subdivision with **FreeSurfer brainstem substructures** (Iglesias 2015), implementing `docs/brainstem_freesurfer_segmentation_spec.md`. Talairach (a single 1988 post-mortem brain whose MNI-mapping error is largest inferiorly/posteriorly — worst exactly in the brainstem) is removed entirely from the active brainstem path. Harvard-Oxford is kept as the gross brainstem extent only.

## Changes

- **NEW `src/modules/brainstem_freesurfer.sh`** — `recon-all` + `segmentBS.sh` / `segment_subregions brainstem` → `brainstemSsLabels` → per-parcel masks (midbrain/pons/medulla/SCP + left/right splits) resampled into subject native space (`mri_convert -rl`). Cached/resumable (skips when `brainstemSsLabels`/`aseg.mgz` already exist). Graceful, non-fatal fallback to the Harvard-Oxford gross mask when FreeSurfer / `recon-all` / `segmentBS` / the license is unavailable (detected via `FREESURFER_HOME`, `command -v`, and license file). Records FreeSurfer version provenance (only on accepted runs).
- **FS↔HO agreement QC gate** — inline `Dice(FS union, HO Brain-Stem)` + leakage (fraction of FS union outside the HO blob). On low agreement, logs `WARNING` and the caller falls back to the HO gross mask (low confidence). Independent methods → genuine corroboration.
- **`hierarchical_joint_fusion.sh`** — removed Talairach entirely (warp + subdivision index ranges + `generate_talairach_subdivisions`); tightened HO from `maxprob-thr0` to `maxprob-thr25` (Brain-Stem maxprob label index 8 is independent of the probability threshold, confirmed against the FSL XML); clarified the misleading "joint fusion" naming (it is a single-atlas SyN warp — no `antsJointFusion`). Entry point name kept for backward compatibility.
- **`segmentation.sh`** — `extract_brainstem_final` dispatches on `BRAINSTEM_SEGMENTATION_METHOD`; FreeSurfer parcels write to the same `segmentation/detailed_brainstem/` filenames the GMM per-region path already expects, so analysis keeps working unchanged. Removed Talairach references in reports/FLAIR-enhancement.
- **`analysis.sh`** (region-discovery only) — `find_all_atlas_regions` now discovers FreeSurfer parcels (added `*_midbrain`, `*_medulla`, `*_scp` patterns) and, when no parcels exist, falls back to the gross brainstem mask so per-region GMM runs on the whole brainstem instead of aborting the analysis stage. Edits localized to avoid conflicts with the parallel detection/GMM unit.
- **`config/default_config.sh`** — added `BRAINSTEM_SEGMENTATION_METHOD` (default `freesurfer`, with `atlas`/`harvard_oxford` alias), `FS_BS_AGREEMENT_DICE_MIN`, `FS_BS_AGREEMENT_LEAKAGE_MAX`, `FS_RECON_ALL_FLAG`, `HO_SUB_MAXPROB_THR`; removed the dead `JOINT_FUSION_*` vars.

Honesty ceiling: parcel level only (pons/midbrain/medulla/SCP); no dorsal/ventral pons.

## Verification

CI checks all pass:
- `bash -n` and `shellcheck --severity=error` clean across the whole repo.
- `test_environment_unit.sh`, `test_pipeline_control_unit.sh`, `test_import_unit.sh` — 100% pass.
- Pipeline `--help` smoke test passes.
- Module load: new functions defined, include guard makes double-sourcing a no-op, FreeSurfer-absent detection logs a graceful atlas fallback. No remaining Talairach refs in the active brainstem path; no `JOINT_FUSION_*` refs.
- Functional (synthetic NIfTI): `fs_split_parcels` produces the correct GMM-compatible filenames; the FS↔HO agreement gate returns PASS (Dice 1.0) on perfect agreement and FAIL on disagreement; `find_all_atlas_regions` discovers parcels and falls back to the gross brainstem mask when parcels are absent.

Real `recon-all`/`segmentBS` (T1 + hours of compute) was not run here per the unit's e2e recipe.

## Code review

Ran the `code-review` skill (extra-high effort). Fixed: FreeSurfer-absent fallback would have aborted the analysis stage (now `find_all_atlas_regions` falls back to the gross mask); `find | head` SIGPIPE under `pipefail` (now `find -print -quit`); removed the latent `calculate_dice`/qa.sh coupling (Dice computed inline, reusing volumes); provenance written only after parcels are accepted; exported the resolved `FS_LICENSE` so the check and the tools agree.

🤖 Generated with [Claude Code](https://claude.com/claude-code)