### PR TITLE
Docs: surgical updates for merged best-practice batch (FreeSurfer brainstem, SynthStrip, modality-aware denoise/DWI, MI registration, CSF/PV, WMH modules)

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,7 +55,7 @@ source ~/.bash_profile && src/pipeline.sh -i ../DiCOM -o ../mri_results -s patie
 The pipeline consists of 8 resumable stages:
 
 1. **import** - DICOM import and conversion
-2. **preprocess** - Rician denoising + N4 bias correction
+2. **preprocess** - Modality-aware denoising (Rician NLM for T1/T2/FLAIR, MP-PCA for DWI) + N4 bias correction
 3. **brain_extraction** - Brain extraction and standardization
 4. **registration** - Multi-stage alignment to standard space
 5. **segmentation** - Brainstem and pons region extraction
@@ -81,8 +81,8 @@ Active development as of June 2026. While functional, improvements are ongoing. 
 This pipeline leverages established neuroimaging tools:
 - **ANTs** - Advanced Normalizations Tools
 - **FSL** - FMRIB Software Library
-- **FreeSurfer** - 3D visualization
-- **Harvard-Oxford & Talairach Atlases** - Brainstem segmentation
+- **FreeSurfer** - Brainstem substructure segmentation (Iglesias 2015 `segmentBS`) + 3D visualization
+- **Harvard-Oxford Atlas** - Gross brainstem extent mask
 - **MNI152 Templates** - Registration targets
 
 ## License

--- a/docs/README.md
+++ b/docs/README.md
@@ -34,9 +34,10 @@ For a minimal pure-python implemention with synthetic data generation, LLM repor
 - Orientation standardization
   - Uses `fslswapdim` + `fslorient` then ANTs transform to enforce RAS orientation
   - Fallback for missing/ambiguous header fields via header-driven heuristics in `src/modules/preprocess.sh`
-- Adaptive Rician denoising
-  - Iterative patch-based NLM via `antsDenoiseImage` tuned by local variance
-  - Auto-switch to FSL SUSAN when ANTs binaries are unavailable or memory-constrained
+- Modality-aware denoising
+  - T1/T2/FLAIR → iterative patch-based Rician NLM via `antsDenoiseImage` tuned by local variance; DWI → MP-PCA (`dwidenoise`, MRtrix); SWI/TOF skipped
+  - Full DWI preprocessing path (`dwi_preprocess.sh`: dwidenoise → optional Gibbs → bias correction), gated by `PROCESS_DWI`
+  - Auto-switch to FSL SUSAN for structural NLM when ANTs binaries are unavailable or memory-constrained
 - Metadata-driven parameter tuning
   - Python metadata extractor reads DICOM tags to set N4 smoothing and denoising patch sizes dynamically
   - Ensures consistency across scanners/field strengths without manual config
@@ -52,9 +53,9 @@ For a minimal pure-python implemention with synthetic data generation, LLM repor
   - DICOM backtrace JSON mapping results into original scanner coordinates for PACS validation
 
 ### Advanced Segmentation
-- **Harvard-Oxford subcortical atlas** (index 7 for brainstem) as the gold standard primary method
-- **Talairach atlas** for detailed brainstem subdivision (left/right medulla, pons, midbrain)
-- **Atlas-to-subject transformation** preserving native resolution by bringing MNI atlases to subject space
+- **FreeSurfer brainstem substructures** (Iglesias 2015 `segmentBS`/`brainstemSsLabels`) for the detailed subdivision into midbrain / pons / medulla / SCP, selected via `BRAINSTEM_SEGMENTATION_METHOD` (default `freesurfer`, fallback `atlas`)
+- **Harvard-Oxford subcortical atlas** (index 7, tightened to `maxprob-thr25`) used only for the gross brainstem extent mask and as the FreeSurfer fallback
+- **Atlas-to-subject transformation** preserving native resolution by bringing the MNI HO atlas to subject space; FreeSurfer segments the subject's own T1 directly
 - **Subject-specific brainstem refinement** using tissue segmentation to address shape variance in pathological cases
 - **FLAIR integration** for enhanced multi-modal segmentation with intensity information
 - Quantified "quality assessment" of the brain extraction, registration quality and segmentation accuracy with an extremely "over-the-top" QA module
@@ -71,21 +72,22 @@ For a minimal pure-python implemention with synthetic data generation, LLM repor
 
 #### Preprocessing (preprocess.sh)
 - **RAS/LPS orientation enforcement** with header-heuristic fallback for missing/ambiguous DICOM orientation fields
-- **Iterative Rician NLM denoising** with automatic patch selection based on local image variance and noise characteristics
-- **N4 bias-field correction** with dynamic shrink-factor and convergence settings optimized per acquisition protocol
-- **Brain extraction** via ANTs BrainExtraction.sh with tissue-specific masks and morphological refinement
+- **Modality-aware denoising** with Rician NLM for T1/T2/FLAIR, MP-PCA (`dwidenoise`) for DWI, and SWI/TOF skipped; automatic patch selection based on local image variance and noise characteristics
+- **N4 bias-field correction** where field strength adjusts the b-spline mesh / spline distance (`-b`); FLAIR uses a gentler, lesion-aware preset so diffuse lesion contrast is not absorbed into the bias field
+- **Brain extraction** via SynthStrip (FreeSurfer `mri_synthstrip`, contrast-agnostic) primary, with an automatic SynthStrip → ANTs(Otsu) → BET fallback chain, a shared `robustfov` neck-removal pre-step, modality-specific BET `-f`, and a posterior-fossa QC gate (`BRAIN_EXTRACTION_METHOD`)
 - **Scanner metadata parameter optimization** automatically adjusts processing parameters based on field strength, vendor, and acquisition settings
 
 #### Registration Pipeline (registration.sh)
 - **Template & resolution detection** automatically selects MNI152 or custom atlas templates based on input voxel dimensions
 - **Multi-resolution registration stages** with white-matter mask weighting for improved anatomical correspondence
+- **Modality-aware SyN metric** Mutual Information for cross-modality (FLAIR↔T1), cross-correlation for same-modality, with `--winsorize-image-intensities`; atlases/masks warped with label-aware `GenericLabel` interpolation
 - **Emergency fallback triggers** using quantitative QA metrics (mutual information, cross-correlation thresholds) to switch methods
 - **Transform validation** outputs detailed QA plots and metrics for each registration stage with comprehensive error handling
 
 #### Enhanced Validation & Hyperintensity Analysis (enhanced_registration_validation.sh)
 - **Extended registration metrics** including cross-correlation, normalized mutual information, and histogram skewness analysis
 - **Coordinate-space and file-integrity checks** performed before each major processing step with detailed error reporting
-- **Multi-atlas intensity mask creation** across Harvard-Oxford subcortical and Talairach atlases
+- **Regional intensity mask creation** over the Harvard-Oxford gross brainstem extent and the FreeSurfer brainstem substructures
 - **Comprehensive cluster analysis** with volume quantification, morphological characterization, and interactive HTML visualization
 - **DICOM coordinate backtrace** maintains mapping between processed results and original scanner coordinate systems
 
@@ -104,6 +106,7 @@ For a minimal pure-python implemention with synthetic data generation, LLM repor
 - **Cross-sequence compatibility analysis** calculates voxel similarity and aspect ratio matching between T1/FLAIR sequences
 
 #### Advanced Brain Extraction & Standardization (brain_extraction.sh)
+- **SynthStrip-primary extraction** (FreeSurfer `mri_synthstrip`, contrast-agnostic) with an automatic SynthStrip → ANTs(Otsu) → BET fallback chain, a shared `robustfov` neck-removal pre-step, modality-specific BET `-f` (T1 0.3 / FLAIR 0.2), and a posterior-fossa QC gate; selected via `BRAIN_EXTRACTION_METHOD`
 - **3D isotropic sequence detection** automatically identifies MPRAGE, SPACE, VISTA sequences to prevent quality degradation from multi-axial combination
 - **Enhanced resolution quality metrics** considers voxel anisotropy, total volume, and in-plane resolution for optimal processing path selection
 - **Multi-axial template construction** combines SAG/COR/AX orientations using antsMultivariateTemplateConstruction2.sh for 2D sequences
@@ -113,21 +116,24 @@ For a minimal pure-python implemention with synthetic data generation, LLM repor
 #### Additional Pipeline Modules
 
 #### Advanced Segmentation (segmentation.sh)
-- **Harvard-Oxford atlas segmentation** using subcortical index 7 (brainstem) as the gold standard primary method
-- **Talairach atlas subdivision** for detailed brainstem regions: left/right medulla, pons, midbrain
-- **Atlas-to-subject transformation** preserving native resolution by bringing MNI atlases to subject space
+- **Harvard-Oxford gross brainstem extent** using subcortical index 7, tightened to `maxprob-thr25`, as the extent mask and the fallback
+- **FreeSurfer brainstem substructures** (Iglesias 2015 `segmentBS`/`brainstemSsLabels`) for the detailed subdivision into midbrain / pons / medulla / SCP, selected via `BRAINSTEM_SEGMENTATION_METHOD` (default `freesurfer`, fallback `atlas`) and gated by an FS↔HO agreement (Dice + leakage) QC check
+- **Atlas-to-subject transformation** preserving native resolution by bringing the MNI HO atlas to subject space; FreeSurfer segments the subject's own T1 directly
 - **Subject-specific refinement** using tissue segmentation (Atropos/FAST) to address shape variance in hydrocephalus & Chiari cases
 - **FLAIR enhancement integration** creating both T1 and FLAIR intensity versions for multi-modal analysis
 - **Native space preservation** maintains segmentation accuracy in subject's original high-resolution space rather than downsampling to template resolution
 
 #### Comprehensive Analysis Pipeline (analysis.sh, gmm_threshold.py)
-- **Atlas-based regional analysis** using all available Talairach brainstem regions for per-region hyperintensity detection
+- **Region-based analysis** using the FreeSurfer brainstem substructures (midbrain/pons/medulla/SCP) for per-region hyperintensity detection (falls back to the HO gross brainstem mask when substructures are absent)
 - **Standalone GMM threshold estimation** via `src/modules/gmm_threshold.py` — reads z-score and region mask NIfTI files directly, fits an adaptive Gaussian Mixture Model (2–3 components based on data density), and returns threshold parameters to the calling bash process via stdout (no intermediate files)
-- **Centralized configuration** — all 12 GMM tuning parameters (component limits, SD multipliers, weight cutoffs, floor/fallback percentiles) are set in `config/default_config.sh` and passed as CLI arguments, with defaults that match the config for standalone use
+- **CSF / partial-volume exclusion** subtracts a CSF mask derived from the FSL FAST CSF PVE map (posterior-fossa CSF is the dominant false-positive source) before thresholding
+- **Single authoritative fallback SD multiplier** (`THRESHOLD_WM_SD_MULTIPLIER`) reconciled across the bash path and `gmm_threshold.py`, applied when GMM is skipped
+- **Centralized configuration** — all GMM tuning parameters (component limits, SD multipliers, weight cutoffs, floor/fallback percentiles) are set in `config/default_config.sh` and passed as CLI arguments, with defaults that match the config for standalone use
 - **Per-region z-score normalization** addressing tissue inhomogeneity across different brainstem regions
 - **Connectivity weighting** for refined detection using 3D morphological operations (fslmaths)
 - **Multi-threshold hyperintensity detection** with configurable standard deviation multipliers and minimum cluster size filtering
 - **Cross-modality validation** analyzes both FLAIR hyperintensities and T1 hypointensities with statistical correlation
+- **Optional supervised WMH modules** (default-off): FSL BIANCA (`wmh_bianca.sh`) and LST-AI + FreeSurfer SAMSEG (`wmh_lst_samseg.sh`), each intersecting results with the brainstem mask
 
 #### Advanced Visualization & QA (visualization.sh, qa.sh)
 - **Interactive 3D rendering** creates volume renderings of hyperintensity clusters with customizable opacity and color mapping
@@ -165,17 +171,18 @@ For a minimal pure-python implemention with synthetic data generation, LLM repor
 ### Actual Implementation Details
 
 #### Segmentation Module (segmentation.sh)
-The segmentation module implements a **two-tier atlas approach**:
+The segmentation module implements a **two-tier approach** (gross extent + substructures):
 
-1. **Harvard-Oxford Subcortical Atlas (Primary)**
-   - Uses index 7 specifically for brainstem segmentation
-   - Applied via `antsApplyTransforms` with trilinear interpolation + 0.5 thresholding
-   - Creates both `_brainstem.nii.gz` and `_brainstem_flair_intensity.nii.gz` versions
+1. **Harvard-Oxford Subcortical Atlas (Gross Extent)**
+   - Uses index 7 for the gross brainstem extent, tightened to `maxprob-thr25` (`HO_SUB_MAXPROB_THR`)
+   - Warped into subject space; creates both `_brainstem.nii.gz` and `_brainstem_flair_intensity.nii.gz`
+   - Always produced — serves as the FreeSurfer fallback and the reference for the FS↔HO agreement QC gate
 
-2. **Talairach Atlas (Detailed Subdivision)**
-   - Six brainstem regions: Left/Right Medulla, Pons, Midbrain
-   - Atlas indices: 172-177 for comprehensive brainstem coverage
-   - Same transformation methodology preserving partial volumes
+2. **FreeSurfer Brainstem Substructures (Detailed Subdivision)**
+   - Iglesias 2015 `segmentBS`/`brainstemSsLabels` → midbrain / pons / medulla / SCP masks in subject space (FreeSurfer segments the subject's own T1, no warp)
+   - Selected via `BRAINSTEM_SEGMENTATION_METHOD` (default `freesurfer`; `atlas`/`harvard_oxford` = gross mask only)
+   - Gated by an FS↔HO agreement check (Dice + leakage); on disagreement or missing FreeSurfer/license, falls back to the HO gross mask and flags low confidence
+   - Talairach has been removed entirely (single 1988 post-mortem brain; largest MNI-mapping error inferiorly/posteriorly — worst exactly in the brainstem)
 
 3. **Subject-Specific Refinement**
    - Uses ANTs Atropos or FSL FAST tissue segmentation as fallback
@@ -183,26 +190,34 @@ The segmentation module implements a **two-tier atlas approach**:
    - Integrates CSF, gray matter, and white matter probability maps
 
 #### Analysis Module (analysis.sh + gmm_threshold.py)
-The analysis module implements **atlas-based regional hyperintensity detection**:
+The analysis module implements **region-based hyperintensity detection**:
 
 1. **GMM Threshold Estimation** (`src/modules/gmm_threshold.py`)
-   - Standalone Python script invoked per Talairach brainstem region
+   - Standalone Python script invoked per FreeSurfer brainstem substructure (falls back to the HO gross mask when substructures are absent)
    - Reads z-score NIfTI + region mask directly (no intermediate text files)
    - Adaptive component count (2–3) based on voxel density within each region
    - Weight-aware threshold adjustment: small hyperintense populations trigger more conservative thresholds to reduce false positives
    - Floor percentile prevents unreasonably low thresholds; data-driven fallback when GMM fit fails
    - All parameters configurable via `config/default_config.sh` (`GMM_*` variables)
+   - Single authoritative fallback SD multiplier (`THRESHOLD_WM_SD_MULTIPLIER`) reconciled across bash and Python, applied when GMM is skipped
    - Results emitted as key=value on stdout; diagnostics to stderr — no filesystem IPC
 
-2. **Multi-Modal Integration**
+2. **CSF / Partial-Volume Exclusion**
+   - Builds a CSF exclusion mask from the FSL FAST CSF PVE map (computed once per subject, reused per region)
+   - Removes posterior-fossa CSF (4th ventricle, basal cisterns), the dominant false-positive source, before thresholding
+
+3. **Multi-Modal Integration**
    - FLAIR hyperintensity detection with configurable SD thresholds
    - T1 hypointensity correlation analysis
    - Cross-modal validation using statistical correlation
 
-3. **Cluster Filtering**
+4. **Cluster Filtering**
    - 3D connectivity analysis with 26-neighbor connectivity (fslmaths)
    - Minimum cluster size filtering (configurable via `MIN_HYPERINTENSITY_SIZE`)
    - Morphological closing operations to eliminate noise
+
+5. **Optional Supervised WMH Modules** (default-off)
+   - FSL BIANCA (`wmh_bianca.sh`) and LST-AI + FreeSurfer SAMSEG (`wmh_lst_samseg.sh`), each intersecting results with the brainstem mask
 
 #### QA Module (qa.sh)
 The QA module performs **20+ comprehensive validation checks**:
@@ -297,36 +312,40 @@ The pipeline implements a sophisticated 8-stage processing workflow with intelli
 - **Intelligent metadata extraction** captures scanner parameters, field strength, acquisition settings for downstream optimization
 - **Quality assessment** validates DICOM integrity and performs initial sequence classification
 
-#### Stage 2: Preprocessing (Rician Denoising + N4 Bias Correction)
+#### Stage 2: Preprocessing (Modality-Aware Denoising + N4 Bias Correction)
 - **Adaptive reference space selection** analyzes scan quality and chooses optimal T1/FLAIR combination using [`select_optimal_reference_space()`](src/modules/reference_space_selection.sh:1)
 - **Registration-optimized scan selection** with multiple modes: `original`, `highest_resolution`, `registration_optimized`, `matched_dimensions`
-- **Enhanced N4 bias correction** with scanner-specific parameter optimization and iterative convergence
+- **Modality-aware denoising** routes T1/T2/FLAIR to Rician NLM, DWI to MP-PCA (`dwidenoise`), skips SWI/TOF; a full DWI path (`dwi_preprocess.sh`) is gated by `PROCESS_DWI`
+- **Enhanced N4 bias correction** where field strength tunes the b-spline mesh / spline distance (`-b`); FLAIR uses a gentler, lesion-aware preset
 - **Orientation consistency validation** performs detailed sform/qform matrix comparison with comprehensive error reporting
 
 #### Stage 3: Brain Extraction, Standardization & Cropping
 - **Smart resolution detection** via [`detect_optimal_resolution()`](src/modules/brain_extraction.sh:214) analyzes voxel dimensions across sequences
 - **Reference grid standardization** ensures T1 and FLAIR have identical matrix dimensions while preserving highest resolution
-- **Enhanced ANTs brain extraction** with tissue-specific masks and morphological refinement
+- **SynthStrip-primary brain extraction** (FreeSurfer `mri_synthstrip`, contrast-agnostic) with an automatic SynthStrip → ANTs(Otsu) → BET fallback chain, a shared `robustfov` neck-removal pre-step, modality-specific BET `-f`, and a posterior-fossa QC gate (`BRAIN_EXTRACTION_METHOD`)
 - **3D isotropic sequence detection** prevents quality degradation from unnecessary multi-axial combination
 
 #### Stage 4: Registration with Bidirectional Transform Management
 - **Multi-stage ANTs registration** Rigid → Affine → SyN with white-matter guided initialization
+- **Modality-aware SyN metric** Mutual Information for cross-modality (FLAIR↔T1), cross-correlation for same-modality, with `--winsorize-image-intensities`; atlases/masks warped with label-aware `GenericLabel` interpolation
 - **Bidirectional space mapping** calculates native ↔ MNI transforms without resampling high-resolution data
 - **Emergency fallback system** automatic SyNQuick or FSL FLIRT when quality metrics drop below thresholds
 - **Enhanced registration validation** comprehensive metrics including cross-correlation, mutual information, normalized CC
 
-#### Stage 5: Multi-Atlas Segmentation
-- **Harvard-Oxford gold standard** subcortical atlas (index 7) for reliable brainstem boundaries
-- **Talairach detailed subdivision** for left/right medulla, pons, midbrain regions
+#### Stage 5: Brainstem Segmentation
+- **Harvard-Oxford gross extent** subcortical atlas (index 7, `maxprob-thr25`) for the brainstem boundary mask and as the fallback
+- **FreeSurfer brainstem substructures** (Iglesias 2015 `segmentBS`) for midbrain / pons / medulla / SCP, selected via `BRAINSTEM_SEGMENTATION_METHOD` (default `freesurfer`, fallback `atlas`) and gated by an FS↔HO agreement QC check
 - **Subject-specific refinement** using tissue segmentation to address shape variance in pathological cases
 - **Native space preservation** maintains segmentation accuracy in subject's original high-resolution space
 - **FLAIR integration** creates both T1 and FLAIR intensity versions for comprehensive analysis
 - **Volume consistency validation** with anatomical location verification and comprehensive QA reporting
 
 #### Stage 6: Comprehensive Hyperintensity Analysis
-- **Per-region GMM thresholding** via standalone `gmm_threshold.py` — adaptive 2–3 component Gaussian Mixture Models fitted per Talairach brainstem region, with all tuning parameters driven from `config/default_config.sh`
+- **Per-region GMM thresholding** via standalone `gmm_threshold.py` — adaptive 2–3 component Gaussian Mixture Models fitted per FreeSurfer brainstem substructure, with all tuning parameters driven from `config/default_config.sh` and a single authoritative fallback SD multiplier (`THRESHOLD_WM_SD_MULTIPLIER`)
+- **CSF / partial-volume exclusion** using the FSL FAST CSF PVE map before thresholding
 - **Multi-threshold detection** configurable SD multipliers with minimum cluster size filtering
 - **Cross-modality validation** analyzes hyperintensity patterns across T1/T2/FLAIR with statistical correlation
+- **Optional supervised WMH** FSL BIANCA and LST-AI + FreeSurfer SAMSEG modules (default-off), intersected with the brainstem mask
 - **Native-to-standard space mapping** enables analysis in both subject native and standardized coordinates
 - **DICOM cluster backtrace** creates coordinate lookup tables for medical imaging viewer navigation
 
@@ -352,7 +371,7 @@ The pipeline implements a sophisticated 8-stage processing workflow with intelli
 - Advanced Brain Extraction & Standardization → [`src/modules/brain_extraction.sh`](src/modules/brain_extraction.sh:1)
 - Preprocessing → [`src/modules/preprocess.sh`](src/modules/preprocess.sh:1)
 - Registration → [`src/modules/registration.sh`](src/modules/registration.sh:1)
-- Multi-Atlas Segmentation → [`src/modules/segmentation.sh`](src/modules/segmentation.sh:1)
+- Brainstem Segmentation (HO gross extent + FreeSurfer substructures) → [`src/modules/segmentation.sh`](src/modules/segmentation.sh:1), [`src/modules/brainstem_freesurfer.sh`](src/modules/brainstem_freesurfer.sh:1)
 - Comprehensive Analysis → [`src/modules/analysis.sh`](src/modules/analysis.sh:1), [`src/modules/gmm_threshold.py`](src/modules/gmm_threshold.py:1)
 - Enhanced Registration Validation → [`src/modules/enhanced_registration_validation.sh`](src/modules/enhanced_registration_validation.sh:1)
 - Advanced Visualization → [`src/modules/visualization.sh`](src/modules/visualization.sh:1)
@@ -481,8 +500,8 @@ BrainStem X leverages established neuroimaging tools, reinventing very little bu
 
 ### Atlases & Templates
 
-- **Harvard-Oxford Subcortical Structural Atlas** - Primary brainstem segmentation (index 7)
-- **Talairach Atlas** - Detailed brainstem subdivision (medulla, pons, midbrain)
+- **Harvard-Oxford Subcortical Structural Atlas** - Gross brainstem extent mask (index 7, `maxprob-thr25`)
+- **FreeSurfer brainstem substructures** (Iglesias 2015 `segmentBS`) - Detailed subdivision (midbrain, pons, medulla, SCP)
 - **MNI152 Standard Space Templates** - Registration targets with automatic resolution selection
 
 ### Programming Resources / Libraries (including..)

--- a/docs/README_tests.md
+++ b/docs/README_tests.md
@@ -252,9 +252,9 @@ bash tests/test_import_unit.sh
 6. **Integration** - Full segmentation workflow testing
 
 **Expected Results**:
-- All segmentation functions available (`extract_brainstem_standardspace`, `extract_brainstem_talairach`, etc.)
-- Proper handling of missing FSL tools
-- Graceful fallback when atlases unavailable
+- Core segmentation functions available — `extract_brainstem` (Harvard-Oxford gross extent), `extract_brainstem_final` (method dispatch), `extract_brainstem_freesurfer` (Iglesias 2015 `segmentBS` substructures), `validate_segmentation`, etc. (the legacy `extract_brainstem_talairach` is retained only as a removed/legacy code path and is no longer the brainstem-subdivision method)
+- Proper handling of missing FSL/FreeSurfer tools
+- Graceful fallback to the HO gross brainstem mask when FreeSurfer/recon-all/license is unavailable
 - Correct output directory structure creation
 
 **Special Implementation Notes**:

--- a/docs/TECHNICAL_OVERVIEW.md
+++ b/docs/TECHNICAL_OVERVIEW.md
@@ -35,9 +35,10 @@ Brainstem regions can present clinically with very subtle variations below the c
 - Uses `fslswapdim` + `fslorient` then ANTs transform to enforce RAS orientation
 - Fallback for missing/ambiguous header fields via header-driven heuristics in `src/modules/preprocess.sh`
 
-#### Adaptive Rician Denoising
-- Iterative patch-based NLM via `antsDenoiseImage` tuned by local variance
-- Auto-switch to FSL SUSAN when ANTs binaries are unavailable or memory-constrained
+#### Modality-Aware Denoising
+- Dispatcher routes by modality: T1/T2/FLAIR → Rician NLM (ANTs `DenoiseImage`); DWI → MP-PCA (`dwidenoise`, MRtrix); SWI/TOF → skipped
+- Full DWI preprocessing path (`dwi_preprocess.sh`: dwidenoise → optional Gibbs → bias correction), gated by `PROCESS_DWI`
+- Auto-switch to FSL SUSAN for structural NLM when ANTs binaries are unavailable or memory-constrained
 
 #### Metadata-Driven Parameter Tuning
 - Python metadata extractor reads DICOM tags to set N4 smoothing and denoising patch sizes dynamically
@@ -58,10 +59,10 @@ Brainstem regions can present clinically with very subtle variations below the c
 
 ### Advanced Segmentation
 
-#### Atlas-Based Approaches
-- **Harvard-Oxford subcortical atlas** (index 7 for brainstem) as the gold standard primary method
-- **Talairach atlas** for detailed brainstem subdivision (left/right medulla, pons, midbrain)
-- **Atlas-to-subject transformation** preserving native resolution by bringing MNI atlases to subject space
+#### Brainstem Segmentation Approaches
+- **FreeSurfer brainstem substructures** (Iglesias 2015 `segmentBS`/`brainstemSsLabels`) for the detailed subdivision into midbrain / pons / medulla / SCP, selected via `BRAINSTEM_SEGMENTATION_METHOD` (default `freesurfer`)
+- **Harvard-Oxford subcortical atlas** (index 7, tightened to `maxprob-thr25`) used only for the gross brainstem extent mask — also the fallback when FreeSurfer/recon-all/license is unavailable (`BRAINSTEM_SEGMENTATION_METHOD=atlas`)
+- **Atlas-to-subject transformation** preserving native resolution by bringing the MNI HO atlas to subject space; FreeSurfer segments the subject's own T1 directly
 
 #### Subject-Specific Refinement
 - Uses tissue segmentation to address shape variance in pathological cases
@@ -82,15 +83,17 @@ Brainstem regions can present clinically with very subtle variations below the c
 ### Preprocessing (preprocess.sh)
 
 - **RAS/LPS orientation enforcement** with header-heuristic fallback for missing/ambiguous DICOM orientation fields
-- **Iterative Rician NLM denoising** with automatic patch selection based on local image variance and noise characteristics
-- **N4 bias-field correction** with dynamic shrink-factor and convergence settings optimized per acquisition protocol
-- **Brain extraction** via ANTs BrainExtraction.sh with tissue-specific masks and morphological refinement
+- **Modality-aware denoising** with Rician NLM for T1/T2/FLAIR, MP-PCA (`dwidenoise`) for DWI, and SWI/TOF skipped; automatic patch selection based on local image variance and noise characteristics
+- **N4 bias-field correction** where field strength adjusts the b-spline mesh / spline distance (`-b`); FLAIR uses a gentler, lesion-aware preset (optional lesion-weight mask) so diffuse lesion contrast is not absorbed into the bias field
+- **Brain extraction** via SynthStrip (FreeSurfer `mri_synthstrip`, contrast-agnostic) as primary, with an automatic fallback chain SynthStrip → ANTs(Otsu) → BET, a shared `robustfov` neck-removal pre-step, modality-specific BET `-f` (T1 0.3 / FLAIR 0.2), and a posterior-fossa QC gate; selected via `BRAIN_EXTRACTION_METHOD`
 - **Scanner metadata parameter optimization** automatically adjusts processing parameters based on field strength, vendor, and acquisition settings
 
 ### Registration Pipeline (registration.sh)
 
 - **Template & resolution detection** automatically selects MNI152 or custom atlas templates based on input voxel dimensions
 - **Multi-resolution registration stages** with white-matter mask weighting for improved anatomical correspondence
+- **Modality-aware SyN metric** — cross-modality pairs (FLAIR↔T1) use Mutual Information; same-modality pairs use cross-correlation, with `--winsorize-image-intensities` to suppress intensity outliers
+- **Label-aware warping** uses `GenericLabel` interpolation when applying transforms to atlases / masks to avoid label blurring
 - **Emergency fallback triggers** using quantitative QA metrics (mutual information, cross-correlation thresholds) to switch methods
 - **Transform validation** outputs detailed QA plots and metrics for each registration stage with comprehensive error handling
 
@@ -98,7 +101,7 @@ Brainstem regions can present clinically with very subtle variations below the c
 
 - **Extended registration metrics** including cross-correlation, normalized mutual information, and histogram skewness analysis
 - **Coordinate-space and file-integrity checks** performed before each major processing step with detailed error reporting
-- **Multi-atlas intensity mask creation** across Harvard-Oxford subcortical and Talairach atlases
+- **Regional intensity mask creation** over the Harvard-Oxford gross brainstem extent and the FreeSurfer brainstem substructures (midbrain/pons/medulla/SCP)
 - **Comprehensive cluster analysis** with volume quantification, morphological characterization, and interactive HTML visualization
 - **DICOM coordinate backtrace** maintains mapping between processed results and original scanner coordinate systems
 
@@ -128,21 +131,24 @@ Brainstem regions can present clinically with very subtle variations below the c
 
 ### Advanced Segmentation (segmentation.sh)
 
-- **Harvard-Oxford atlas segmentation** using subcortical index 7 (brainstem) as the gold standard primary method
-- **Talairach atlas subdivision** for detailed brainstem regions: left/right medulla, pons, midbrain
-- **Atlas-to-subject transformation** preserving native resolution by bringing MNI atlases to subject space
+- **Harvard-Oxford gross brainstem extent** using subcortical index 7, tightened to `maxprob-thr25`, as the extent mask and the fallback when FreeSurfer is unavailable
+- **FreeSurfer brainstem substructures** (Iglesias 2015 `segmentBS`/`brainstemSsLabels`) for the detailed subdivision into midbrain / pons / medulla / SCP, selected via `BRAINSTEM_SEGMENTATION_METHOD` (default `freesurfer`, fallback `atlas`); gated by an FS↔HO agreement (Dice + leakage) QC check
+- **Atlas-to-subject transformation** preserving native resolution by bringing the MNI HO atlas to subject space; FreeSurfer segments the subject's own T1 directly
 - **Subject-specific refinement** using tissue segmentation (Atropos/FAST) to address shape variance in hydrocephalus & Chiari cases
 - **FLAIR enhancement integration** creating both T1 and FLAIR intensity versions for multi-modal analysis
 - **Native space preservation** maintains segmentation accuracy in subject's original high-resolution space rather than downsampling to template resolution
 
 ### Comprehensive Analysis Pipeline (analysis.sh)
 
-- **Atlas-based regional analysis** using all available Talairach brainstem regions for per-region hyperintensity detection
-- **Gaussian Mixture Model (GMM) thresholding** with 3-component analysis for intelligent threshold selection
+- **Region-based analysis** using the FreeSurfer brainstem substructures (midbrain/pons/medulla/SCP) for per-region hyperintensity detection (falls back to the HO gross brainstem mask when substructures are absent)
+- **Gaussian Mixture Model (GMM) thresholding** with adaptive 2–3-component analysis for intelligent threshold selection
+- **CSF / partial-volume exclusion** subtracts a CSF mask derived from the FSL FAST CSF PVE map (posterior-fossa CSF is the dominant false-positive source) before thresholding
+- **Single authoritative fallback SD multiplier** (`THRESHOLD_WM_SD_MULTIPLIER`) reconciled across the bash path and `gmm_threshold.py` so the GMM-skip fallback is consistent
 - **Per-region z-score normalization** addressing tissue inhomogeneity across different brainstem regions
 - **Connectivity weighting** for refined detection using 3D morphological operations
 - **Multi-threshold hyperintensity detection** with configurable standard deviation multipliers and minimum cluster size filtering
 - **Cross-modality validation** analyzes both FLAIR hyperintensities and T1 hypointensities with statistical correlation
+- **Optional supervised WMH modules** (default-off): FSL BIANCA (`wmh_bianca.sh`) and LST-AI + FreeSurfer SAMSEG (`wmh_lst_samseg.sh`), each intersecting results with the brainstem mask
 
 ### Advanced Visualization & QA (visualization.sh, qa.sh)
 
@@ -202,35 +208,40 @@ Brainstem regions can present clinically with very subtle variations below the c
 - **Intelligent metadata extraction** captures scanner parameters, field strength, acquisition settings for downstream optimization
 - **Quality assessment** validates DICOM integrity and performs initial sequence classification
 
-### Stage 2: Preprocessing (Rician Denoising + N4 Bias Correction)
+### Stage 2: Preprocessing (Modality-Aware Denoising + N4 Bias Correction)
 - **Adaptive reference space selection** analyzes scan quality and chooses optimal T1/FLAIR combination using [`select_optimal_reference_space()`](../src/modules/reference_space_selection.sh:1)
 - **Registration-optimized scan selection** with multiple modes: `original`, `highest_resolution`, `registration_optimized`, `matched_dimensions`
-- **Enhanced N4 bias correction** with scanner-specific parameter optimization and iterative convergence
+- **Modality-aware denoising** routes T1/T2/FLAIR to Rician NLM, DWI to MP-PCA (`dwidenoise`), and skips SWI/TOF; a full DWI path (`dwi_preprocess.sh`) is gated by `PROCESS_DWI`
+- **Enhanced N4 bias correction** where field strength tunes the b-spline mesh / spline distance (`-b`); FLAIR uses a gentler, lesion-aware preset
 - **Orientation consistency validation** performs detailed sform/qform matrix comparison with comprehensive error reporting
 
 ### Stage 3: Brain Extraction, Standardization & Cropping
 - **Smart resolution detection** via [`detect_optimal_resolution()`](../src/modules/brain_extraction.sh:214) analyzes voxel dimensions across sequences
 - **Reference grid standardization** ensures T1 and FLAIR have identical matrix dimensions while preserving highest resolution
-- **Enhanced ANTs brain extraction** with tissue-specific masks and morphological refinement
+- **SynthStrip-primary brain extraction** (FreeSurfer `mri_synthstrip`, contrast-agnostic) with an automatic SynthStrip → ANTs(Otsu) → BET fallback chain, a shared `robustfov` neck-removal pre-step, modality-specific BET `-f`, and a posterior-fossa QC gate; selected via `BRAIN_EXTRACTION_METHOD`
 - **3D isotropic sequence detection** prevents quality degradation from unnecessary multi-axial combination
 
 ### Stage 4: Registration with Bidirectional Transform Management
 - **Multi-stage ANTs registration** Rigid → Affine → SyN with white-matter guided initialization
+- **Modality-aware SyN metric** Mutual Information for cross-modality (FLAIR↔T1) and cross-correlation for same-modality pairs, with `--winsorize-image-intensities`; atlases/masks warped with label-aware `GenericLabel` interpolation
 - **Bidirectional space mapping** calculates native ↔ MNI transforms without resampling high-resolution data
 - **Emergency fallback system** automatic SyNQuick or FSL FLIRT when quality metrics drop below thresholds
 - **Enhanced registration validation** comprehensive metrics including cross-correlation, mutual information, normalized CC
 
-### Stage 5: Multi-Atlas Segmentation
-- **Harvard-Oxford gold standard** subcortical atlas (index 7) for reliable brainstem boundaries
-- **Talairach detailed subdivision** for left/right medulla, pons, midbrain regions
+### Stage 5: Brainstem Segmentation
+- **Harvard-Oxford gross extent** subcortical atlas (index 7, `maxprob-thr25`) for the brainstem boundary mask and as the fallback
+- **FreeSurfer brainstem substructures** (Iglesias 2015 `segmentBS`) for midbrain / pons / medulla / SCP, selected via `BRAINSTEM_SEGMENTATION_METHOD` (default `freesurfer`, fallback `atlas`) and gated by an FS↔HO agreement QC check
 - **Subject-specific refinement** using tissue segmentation to address shape variance in pathological cases
 - **Native space preservation** maintains segmentation accuracy in subject's original high-resolution space
 - **FLAIR integration** creates both T1 and FLAIR intensity versions for comprehensive analysis
 - **Volume consistency validation** with anatomical location verification and comprehensive QA reporting
 
 ### Stage 6: Comprehensive Hyperintensity Analysis
+- **Per-region GMM thresholding** over the FreeSurfer brainstem substructures with adaptive 2–3-component models and a single authoritative fallback SD multiplier (`THRESHOLD_WM_SD_MULTIPLIER`)
+- **CSF / partial-volume exclusion** using the FSL FAST CSF PVE map before thresholding
 - **Multi-threshold detection** configurable SD multipliers (1.5-3.0) with minimum cluster size filtering
 - **Cross-modality validation** analyzes hyperintensity patterns across T1/T2/FLAIR with statistical correlation
+- **Optional supervised WMH** FSL BIANCA and LST-AI + FreeSurfer SAMSEG modules (default-off), intersected with the brainstem mask
 - **Native-to-standard space mapping** enables analysis in both subject native and standardized coordinates
 - **DICOM cluster backtrace** creates coordinate lookup tables for medical imaging viewer navigation
 
@@ -257,7 +268,7 @@ Brainstem regions can present clinically with very subtle variations below the c
 - Advanced Brain Extraction & Standardization → [`src/modules/brain_extraction.sh`](../src/modules/brain_extraction.sh:1)
 - Preprocessing → [`src/modules/preprocess.sh`](../src/modules/preprocess.sh:1)
 - Registration → [`src/modules/registration.sh`](../src/modules/registration.sh:1)
-- Multi-Atlas Segmentation → [`src/modules/segmentation.sh`](../src/modules/segmentation.sh:1)
+- Brainstem Segmentation (HO gross extent + FreeSurfer substructures) → [`src/modules/segmentation.sh`](../src/modules/segmentation.sh:1), [`src/modules/brainstem_freesurfer.sh`](../src/modules/brainstem_freesurfer.sh:1)
 - Comprehensive Analysis → [`src/modules/analysis.sh`](../src/modules/analysis.sh:1)
 - Enhanced Registration Validation → [`src/modules/enhanced_registration_validation.sh`](../src/modules/enhanced_registration_validation.sh:1)
 - Advanced Visualization → [`src/modules/visualization.sh`](../src/modules/visualization.sh:1)
@@ -318,17 +329,18 @@ graph TD
 ## Detailed Segmentation Implementation
 
 ### Segmentation Module (segmentation.sh)
-The segmentation module implements a **two-tier atlas approach**:
+The segmentation module implements a **two-tier approach** (gross extent + substructures):
 
-1. **Harvard-Oxford Subcortical Atlas (Primary)**
-   - Uses index 7 specifically for brainstem segmentation
-   - Applied via `antsApplyTransforms` with trilinear interpolation + 0.5 thresholding
-   - Creates both `_brainstem.nii.gz` and `_brainstem_flair_intensity.nii.gz` versions
+1. **Harvard-Oxford Subcortical Atlas (Gross Extent)**
+   - Uses index 7 specifically for the gross brainstem extent, tightened to `maxprob-thr25` (`HO_SUB_MAXPROB_THR`)
+   - Warped into subject space; creates both `_brainstem.nii.gz` and `_brainstem_flair_intensity.nii.gz`
+   - Always produced — serves as the FreeSurfer fallback and the reference for the FS↔HO agreement QC gate
 
-2. **Talairach Atlas (Detailed Subdivision)**
-   - Six brainstem regions: Left/Right Medulla, Pons, Midbrain
-   - Atlas indices: 172-177 for comprehensive brainstem coverage
-   - Same transformation methodology preserving partial volumes
+2. **FreeSurfer Brainstem Substructures (Detailed Subdivision)**
+   - Iglesias 2015 `segmentBS`/`brainstemSsLabels` → midbrain / pons / medulla / SCP masks in subject space (FreeSurfer segments the subject's own T1, no warp)
+   - Selected via `BRAINSTEM_SEGMENTATION_METHOD` (default `freesurfer`; `atlas`/`harvard_oxford` = gross mask only)
+   - Gated by an FS↔HO agreement check (Dice + leakage); on disagreement or missing FreeSurfer/license, falls back to the HO gross mask and flags low confidence
+   - Talairach has been removed entirely (single 1988 post-mortem brain; largest MNI-mapping error inferiorly/posteriorly — worst exactly in the brainstem)
 
 3. **Subject-Specific Refinement**
    - Uses ANTs Atropos or FSL FAST tissue segmentation as fallback
@@ -338,22 +350,30 @@ The segmentation module implements a **two-tier atlas approach**:
 ## Detailed Analysis Implementation
 
 ### Analysis Module (analysis.sh)
-The analysis module implements **atlas-based regional hyperintensity detection**:
+The analysis module implements **region-based hyperintensity detection**:
 
 1. **Gaussian Mixture Model (GMM) Analysis**
-   - 3-component GMM for each Talairach brainstem region
+   - Adaptive 2–3-component GMM for each FreeSurfer brainstem substructure (falls back to the HO gross mask when substructures are absent)
    - Intelligent threshold selection beyond simple z-score methods
    - Per-region normalization addressing tissue inhomogeneity
+   - Single authoritative fallback SD multiplier (`THRESHOLD_WM_SD_MULTIPLIER`), reconciled across the bash path and `gmm_threshold.py`, used when GMM is skipped
 
-2. **Multi-Modal Integration**
+2. **CSF / Partial-Volume Exclusion**
+   - Builds a CSF exclusion mask from the FSL FAST CSF PVE map (computed once per subject, reused per region)
+   - Removes posterior-fossa CSF (4th ventricle, basal cisterns), the dominant false-positive source, before thresholding
+
+3. **Multi-Modal Integration**
    - FLAIR hyperintensity detection with configurable SD thresholds
    - T1 hypointensity correlation analysis
    - Cross-modal validation using statistical correlation
 
-3. **Morphological Refinement**
+4. **Morphological Refinement**
    - 3D connectivity analysis with 26-neighbor connectivity
    - Minimum cluster size filtering (configurable, default 27 voxels)
    - Morphological closing operations to eliminate noise
+
+5. **Optional Supervised WMH Modules** (default-off)
+   - FSL BIANCA (`wmh_bianca.sh`) and LST-AI + FreeSurfer SAMSEG (`wmh_lst_samseg.sh`), each intersecting results with the brainstem mask
 
 ## Quality Assurance Details
 
@@ -499,7 +519,7 @@ This project is released under the MIT License.
 - **ANTs**: BSD-style license
 - **FSL**: Custom FSL license (free for academic use)
 - **FreeSurfer**: FreeSurfer Software License
-- **Harvard-Oxford & Talairach Atlases**: Various academic licenses
+- **Harvard-Oxford Atlas**: Various academic licenses
 - **MNI152 Templates**: MNI license (free for research)
 
 ## Acknowledgments
@@ -516,8 +536,8 @@ BrainStem X leverages established neuroimaging tools, reinventing very little bu
 - **ITK-SNAP**: Recommended for visualization and manual segmentation
 
 ### Atlases & Templates
-- **Harvard-Oxford Subcortical Structural Atlas** - Primary brainstem segmentation (index 7)
-- **Talairach Atlas** - Detailed brainstem subdivision (medulla, pons, midbrain)
+- **Harvard-Oxford Subcortical Structural Atlas** - Gross brainstem extent mask (index 7, `maxprob-thr25`)
+- **FreeSurfer brainstem substructures** (Iglesias 2015 `segmentBS`) - Detailed subdivision (midbrain, pons, medulla, SCP)
 - **MNI152 Standard Space Templates** - Registration targets with automatic resolution selection
 
 ### Programming Resources

--- a/docs/brainstem_freesurfer_segmentation_spec.md
+++ b/docs/brainstem_freesurfer_segmentation_spec.md
@@ -1,0 +1,83 @@
+# Spec: FreeSurfer brainstem substructures for BrainStemX (replace Talairach)
+
+> **Status: IMPLEMENTED** in `src/modules/brainstem_freesurfer.sh` (Iglesias 2015 `segmentBS`/`brainstemSsLabels` → midbrain/pons/medulla/SCP), wired through `src/modules/segmentation.sh` and the per-region GMM in `src/modules/analysis.sh`, merged via PR #119 ("Replace Talairach brainstem subdivisions with FreeSurfer substructures"). Talairach has been **removed entirely** from the brainstem-subdivision path. The remaining sections below are the original design spec, retained for rationale/provenance; a few details differ from the as-built code and are flagged inline:
+> - **Config default:** the spec proposed `BRAINSTEM_SEGMENTATION_METHOD=fusion` as the default; the merged code defaults to **`freesurfer`** (substructures) with **`atlas`** (Harvard-Oxford gross mask only; alias `harvard_oxford`) as the fallback — there is no `fusion` mode.
+> - **HO extent:** the Harvard-Oxford gross Brain-Stem extent is tightened to `maxprob-thr25` (`HO_SUB_MAXPROB_THR`).
+> - **Agreement gate config:** `FS_BS_AGREEMENT_DICE_MIN` and `FS_BS_AGREEMENT_LEAKAGE_MAX` (plus `FS_RECON_ALL_FLAG`, `FS_BS_LABEL_*`) live in `config/default_config.sh`.
+
+Status: DRAFT (original design). Owner: David. Scope: `src/modules/segmentation.sh` / `hierarchical_joint_fusion.sh`, `src/modules/analysis.sh` (per-region GMM), `config/default_config.sh`, a new `src/modules/brainstem_freesurfer.sh`. Sibling approach to the document_processor `subject_space_localization_spec.md §3h` — this is the **deterministic-pipeline** counterpart.
+
+## 1. Goal & grounding
+
+BrainStemX is a brainstem/pons hyperintensity pipeline, so the brainstem parcellation is the *core*, not a side-pass — and it currently leans on **Talairach** for the brainstem subdivision (via `execute_hierarchical_joint_fusion` = Harvard-Oxford + Talairach + Juelich, plus `talairach_subdivisions`). Talairach is the weakest link: single-subject (one 1988 post-mortem brain), reaching MNI via an approximate transform whose offsets are *largest inferiorly/posteriorly* — worst exactly in the brainstem you care about. And HO alone can't replace it: HO has a single `Brain-Stem` label, no pons/midbrain/medulla.
+
+This spec replaces Talairach's brainstem-subdivision role with **FreeSurfer brainstem substructures** (Iglesias 2015 — Bayesian segmentation into midbrain / pons / medulla / SCP), keeps Harvard-Oxford, and uses an **FS↔HO agreement cross-check** as a QC/confidence gate. The payoff is concrete and downstream: the FS parcels become the regions for the **per-region GMM** (`analysis.sh`), so a pontine hyperintensity is z-scored against *pons-specific* normal statistics instead of whole-brainstem or Talairach-subdivision stats.
+
+It fits the deterministic ethos: FS-BS is a deterministic Bayesian segmentation (given fixed inputs + pinned FS version), unlike registration which needs a seed.
+
+**The honesty ceiling is the same as the document_processor spec:** trust to the **parcel level** (pons/midbrain/medulla/SCP); the inter-parcel boundary is FS-asserted/uncorroborated; **dorsal vs ventral pons is never emitted** — no atlas or off-the-shelf segmentation supports it (geometric estimation was crude; a custom ML model is the future frontier, out of scope here).
+
+## 2. Current state
+
+- **Brainstem segmentation:** `segmentation.sh` → `execute_hierarchical_joint_fusion` (`hierarchical_joint_fusion.sh`) fusing **HO + Talairach + Juelich** (`JOINT_FUSION_*` params in `default_config.sh`); `talairach_subdivisions/` is the brainstem subdivision artifact. Subject-space (atlases warped into the subject via the registration stage; validated by `segmentation_validate_atlas_in_subject_space.sh`).
+- **Per-region analysis:** `analysis.sh` → `find_all_atlas_regions` → `apply_per_region_gmm_analysis` (`ATLAS_GMM`) z-scores hyperintensity per atlas region; `GMM_MIN_VOXELS=20` gates GMM vs the `THRESHOLD_WM_SD_MULTIPLIER` fallback. Pons mask looked up from `segmentation/detailed_brainstem/…`.
+- **FreeSurfer:** binaries present (`environment.sh` checks `mri_convert`/`freeview`), but **recon-all is not currently run** — the pipeline uses ANTs/FSL. FS-BS needs recon-all outputs.
+
+## 3. The change
+
+### 3a. Drop Talairach as the brainstem-subdivision source
+Remove Talairach from the brainstem path in `hierarchical_joint_fusion.sh` / retire `talairach_subdivisions` as the subdivision artifact. Keep **HO** (gross `Brain-Stem` extent + supratentorial). **Juelich** is orthogonal (cytoarchitectonic/WM, not a brainstem subdivision) — out of scope for this change; revisit separately.
+
+### 3b. New stage — FreeSurfer brainstem substructures (`brainstem_freesurfer.sh`)
+- Run `recon-all` on the chosen structural reference (the pipeline's existing reference T1), then `segmentBS.sh` (`mri_segment_brainstem`) → `brainstemSsLabels.*` → split into **pons / midbrain / medulla / SCP** masks, in **subject space** (no warp — FS segments the subject's own T1, which suits BrainStemX's subject-space paradigm).
+- **Deterministic + pinned:** record the FreeSurfer version in provenance; FS-BS is reproducible given fixed T1 + version.
+- **Prereqs/cost:** requires `FREESURFER_HOME` + a **FreeSurfer license** (`$FS_LICENSE`) — guard for it and fail with a clear `ERR_*` if absent. recon-all is *hours* (or use `-brainstem-structures` on an existing recon); so this is a **resumable, cached** stage — skip if `brainstemSsLabels` exists for the subject; never recompute.
+
+### 3c. FS↔HO agreement cross-check (the QC gate)
+- **Metric = `Dice(FS-brainstem-union, HO-`Brain-Stem`-in-subject-space)` + leakage** (fraction of FS parcels falling outside the HO blob). **Not** tautological pons-in-brainstem containment (anatomically guaranteed). These structures are small, so even modest mislocalization (esp. HO's warp mislanding posteriorly) tanks the union-Dice / shows leakage → a sensitive check. Implement alongside `segmentation_validate_atlas_in_subject_space.sh`.
+- **Independent methods:** FS-BS = segmentation on the subject T1 (no registration); HO = warped template. Agreement is genuine corroboration (unlike Talairach+HO, which shared registration error).
+- **Gate:** agree (Dice ≥ threshold, low leakage) → trust FS parcels, emit pons/midbrain/medulla/SCP with confidence. Disagree → fall back to HO `Brain-Stem` gross mask, flag low-confidence in the report. Threshold calibrated like the existing brain-mask-Dice QC.
+
+### 3d. Feed FS parcels into the per-region GMM (`analysis.sh`)
+- `find_all_atlas_regions` picks up the FS parcels as the brainstem regions; `apply_per_region_gmm_analysis` then z-scores hyperintensity **per parcel** (pons-normal, midbrain-normal…) — tighter and more sensitive than whole-brainstem or Talairach-subdivision stats. This is the deterministic-pipeline payoff.
+- **Small-parcel caveat:** SCP (and partial-coverage parcels) may fall below `GMM_MIN_VOXELS=20` → GMM skips and the `THRESHOLD_WM_SD_MULTIPLIER` fallback applies. Ensure that fallback is sane per-parcel; log when a parcel uses fallback.
+
+### 3e. Label semantics
+Parcel-level only: **pons / midbrain / medulla / SCP**. The inter-parcel boundary is FS-asserted (uncorroborated). **Dorsal/ventral pons is never produced** — neither FS nor any atlas supports it.
+
+## 4. Deterministic-pipeline integration (BrainStemX conventions)
+
+- **Module:** new `src/modules/brainstem_freesurfer.sh` — `#!/usr/bin/env bash`, `set -e -u -o pipefail`, include guard (`if [ -n "${_BRAINSTEM_FS_LOADED:-}" ]; then return 0; fi`), `source require_env.sh`, `log_message`/`log_formatted`/`log_error` at entry, `ERR_*` constants (e.g. a new `ERR_FREESURFER` or reuse `ERR_PREPROC`), macOS-safe (`safe_fslmaths`, no `timeout`). Python helpers via `uv run` (FS itself is its own binaries).
+- **Config (`default_config.sh`, with the `_DEFAULT_CONFIG_LOADED` guard):**
+  `export BRAINSTEM_SEGMENTATION_METHOD="${BRAINSTEM_SEGMENTATION_METHOD:-fusion}"` (`fusion` = current, default; `freesurfer` = this approach; `harvard_oxford` = gross-only). Plus `FREESURFER_HOME`/`FS_LICENSE` checks and `FS_BS_AGREEMENT_DICE_MIN` (mirror the existing Dice-QC threshold style).
+- **Stage + resumability:** slot as a brainstem-segmentation alternative selectable by `BRAINSTEM_SEGMENTATION_METHOD`; recover all file-path vars from disk on skip (per the pipeline's stage-resumability rule); cache recon-all + `brainstemSsLabels` so re-runs skip the hours-long step.
+- **CI/tests:** add a parcel-sanity + agreement-Dice test next to `test_atlas_positioning_*`; keep `bash -n` / shellcheck-error clean.
+
+## 5. Guardrails
+
+1. **Honesty ceiling at the parcel.** Pons/midbrain/medulla/SCP, never finer; boundary FS-asserted; no dorsal/ventral pons.
+2. **Agreement-gated.** FS parcels are trusted only when they agree with HO's gross brainstem extent; disagreement → fall back + flag, never silently emit a mislocalized parcel.
+3. **Opt-in, default unchanged.** `BRAINSTEM_SEGMENTATION_METHOD=fusion` stays the default; `freesurfer` is opt-in so existing runs are untouched.
+4. **Deterministic + version-pinned.** Record FS version; FS-BS reproducible given fixed inputs.
+5. **License/abstain.** No FS license / recon-all unavailable → clear error or fall back to HO gross, never a half-segmentation.
+
+## 6. Risks & open items
+
+1. **recon-all cost (hours) — reduced on Apple Silicon, not eliminated.** Two levers: (a) the **native `darwin_arm64` FreeSurfer build** removes the Rosetta-x86 penalty (still CPU-bound surface recon, so "less-slow hours"); (b) **FastSurfer with `--device mps` + `PYTORCH_ENABLE_MPS_FALLBACK=1`** (≥2× CPU; op-gaps like `aten::max_unpool2d` fall to CPU) does the segmentation in minutes — the **same MPS pattern as the Prima spec**, so the Mac Studio MPS setup serves both. **Open verification (gates M1):** FastSurfer's fast aseg gives a single `Brain-Stem` label (HO-equivalent, no subdivision) — the Iglesias pons/midbrain/medulla parcels come from `segmentBS`, so confirm whether FastSurfer outputs satisfy the brainstem module's inputs or whether full (native-ARM) recon-all is still required for it. Either way, cache/resume; consider `-brainstem-structures` on an existing recon to skip a full re-run.
+2. **FreeSurfer license** required — environment guard + actionable error.
+3. **FS version reproducibility** — different FS versions can shift parcel boundaries; pin + record.
+4. **Small-parcel GMM fallback** (SCP) — verify the SD-multiplier fallback is appropriate at small voxel counts.
+5. **T1 quality / pathology** — FS-BS is robust but a heavily distorted brainstem (mass, severe atrophy) can mis-segment; the FS↔HO gate catches gross failures, not subtle ones.
+6. **Boundary uncorroborated** — downstream consumers must treat pons↔midbrain as approximate; don't build a sub-pontine claim on it.
+
+## 7. Milestones
+
+- **M0 — Apple-Silicon path probe (do first).** On the Mac: confirm the native `darwin_arm64` FreeSurfer build; time FastSurfer `--device mps` (+`PYTORCH_ENABLE_MPS_FALLBACK=1`) on one subject; and settle the open question — do FastSurfer outputs feed `segmentBS`, or is full native-ARM recon-all still needed for the brainstem module? Determines M1's cost path. Check whether a recon already exists for the validation subjects (skip the hours).
+- **M1 — FS-BS stage.** `brainstem_freesurfer.sh`: (FastSurfer-MPS and/or native-ARM recon-all, cached) → `segmentBS.sh` → pons/midbrain/medulla/SCP masks in subject space, behind `BRAINSTEM_SEGMENTATION_METHOD=freesurfer`. Accept: parcels produced + cached; license/abstain handled.
+- **M2 — Agreement cross-check.** FS-union-vs-HO-blob Dice + leakage → confidence flag in the report; disagreement falls back to HO gross. Accept: agreement reported per subject; a deliberately mis-registered case flags/falls back.
+- **M3 — Per-region GMM on FS parcels.** `find_all_atlas_regions`/`apply_per_region_gmm_analysis` consume the FS parcels; per-parcel z-scoring; small-parcel fallback logged. Accept: hyperintensity thresholded per pons/midbrain/medulla; results comparable to (or better-localized than) the Talairach-subdivision baseline on a known case.
+- **M4 — Talairach retired + docs/tests.** Drop Talairach from the brainstem path; parcel-sanity + agreement test; `bash -n`/shellcheck clean; maintain the project log per the global rule.
+
+## 8. Out of scope
+
+Dorsal/ventral pons or any sub-parcel granularity (custom-ML frontier); Juelich reassessment; supratentorial labeling changes (HO stays); replacing the registration/GMM machinery itself (only swapping the brainstem-subdivision source and feeding the GMM); cross-study/longitudinal subject space (that's the document_processor spec's concern).

--- a/docs/complete_pipeline_analysis_and_fix_plan.md
+++ b/docs/complete_pipeline_analysis_and_fix_plan.md
@@ -1,0 +1,267 @@
+# Complete Pipeline Analysis & MNI Dependency Fix Plan
+
+> **Status update (best-practice batch merged on `main`):** several items below are now addressed and are marked **✅ DONE** inline where they apply. In particular the brain-extraction / MNI-dependency rework landed via the brain-extraction overhaul (PR #111): SynthStrip is now the primary, contrast-agnostic extractor with an automatic SynthStrip → ANTs(Otsu) → BET fallback chain, a shared `robustfov` neck-removal pre-step, and a posterior-fossa QC gate (`BRAIN_EXTRACTION_METHOD`), removing the hard MNI-template dependency in the default path. Related merged work in the same batch: modality-aware denoising + DWI MP-PCA (#118), N4 b-spline field-strength knob + lesion-aware FLAIR (#115), modernized registration metrics/interpolation (#112), CSF/PV exclusion + reconciled fallback SD multiplier (#114), FreeSurfer brainstem substructures replacing Talairach (#119), and the supervised WMH modules (#113, #116). Items **not** marked DONE remain open as written.
+
+## Current Pipeline Flow Analysis
+
+After carefully analyzing both `pipeline.sh` and `reference_space_selection.sh`, I've identified a more complex issue than just the MNI dependency in brain extraction.
+
+### Current Workflow (Steps 2-5)
+
+#### Step 2: Preprocessing & Reference Space Selection (Lines 364-388)
+```bash
+# Line 365: Adaptive reference space selection
+local selection_result=$(select_optimal_reference_space "$SRC_DIR" "$EXTRACT_DIR" "${REFERENCE_SPACE_SELECTION_MODE:-adaptive}")
+
+# Lines 367-370: Parse result
+local selected_modality=$(echo "$selection_result" | cut -d'|' -f1)  # "T1" or "FLAIR"
+local selected_file=$(echo "$selection_result" | cut -d'|' -f2)
+local selection_rationale=$(echo "$selection_result" | cut -d'|' -f3)
+
+# Lines 376-388: File assignment based on selection
+if [ "$selected_modality" = "T1" ]; then
+    local t1_file="$selected_file"
+    local flair_file=$(select_best_scan "FLAIR" "*FLAIR*.nii.gz" "$EXTRACT_DIR" "$t1_file" ...)
+elif [ "$selected_modality" = "FLAIR" ]; then
+    local flair_file="$selected_file" 
+    local t1_file=$(select_best_scan "T1" "*T1*.nii.gz" "$EXTRACT_DIR" "$flair_file" ...)
+fi
+```
+
+#### Step 3: Brain Extraction & Standardization (Lines 533-600)
+```bash
+# Lines 545-566: Determine reference based on resolution comparison (NOT reference space selection!)
+local t1_inplane=$(calculate_inplane_resolution "$t1_brain")
+local flair_inplane=$(calculate_inplane_resolution "$flair_brain")
+
+if (( $(echo "$t1_inplane <= $flair_inplane" | bc -l) )); then
+    reference_image="$t1_brain"      # T1 has higher resolution
+    reference_modality="T1"
+else
+    reference_image="$flair_brain"   # FLAIR has higher resolution  
+    reference_modality="FLAIR"
+fi
+
+# Lines 574-586: Standardization
+standardize_dimensions "$reference_image" "$optimal_resolution"
+standardize_dimensions "$moving_image" "" "$reference_std"
+
+# Lines 588-595: File assignment
+if [ "$reference_modality" = "T1" ]; then
+    t1_std="$reference_std"
+    flair_std="$moving_std"
+else
+    t1_std="$moving_std"
+    flair_std="$reference_std"
+fi
+```
+
+#### Step 4: Registration (Lines 695-701)
+```bash
+# HARDCODED: Always registers FLAIR to T1!
+log_message "Running FLAIR to T1 registration..."
+register_to_reference "$t1_std" "$flair_std" "FLAIR" "$reg_prefix"
+```
+
+#### Step 5: Segmentation (Lines 807, 827-852)
+```bash
+# Line 807: Always done on T1
+extract_brainstem_final "$t1_std"
+
+# Lines 827-852: Transform to reference space if T1 wasn't reference
+if [ "$reference_modality" != "T1" ]; then
+    # Transform T1-based segmentations to reference space
+    apply_transformation "$mask_file" "$flair_std" "$out_mask" ...
+fi
+```
+
+## **Critical Issues Identified**
+
+### Issue 1: MNI Template Dependency — ✅ DONE (PR #111)
+- **Location**: `src/modules/utils.sh:perform_brain_extraction()`
+- **Problem**: `antsBrainExtraction.sh` has hardcoded MNI template dependencies
+- **Impact**: Pipeline fails when MNI templates are not available
+- **Resolution**: Default extraction now uses SynthStrip (FreeSurfer `mri_synthstrip`, contrast-agnostic, no MNI template) with a SynthStrip → ANTs(Otsu) → BET fallback chain and `robustfov` neck removal, selected via `BRAIN_EXTRACTION_METHOD`. See `src/modules/brain_extraction.sh`.
+
+### Issue 2: Inconsistent Reference Space Logic
+- **Problem**: Three different reference selection methods that can conflict:
+  1. **Step 2**: `select_optimal_reference_space()` selects based on quality metrics
+  2. **Step 3**: Resolution-based selection overwrites Step 2 decision
+  3. **Step 4**: Hardcoded FLAIR→T1 registration ignores both previous decisions
+
+### Issue 3: Incorrect Registration Direction
+- **Problem**: Registration always goes FLAIR→T1, regardless of selected reference space
+- **Impact**: If FLAIR was selected as reference, we should register T1→FLAIR
+
+### Issue 4: Complex Segmentation Transformation
+- **Problem**: Segmentation done on T1, then transformed to reference space
+- **Better approach**: Register appropriately so segmentation can be done in reference space
+
+## **Complete Fix Plan**
+
+### Phase 1: Fix MNI Dependency (Immediate) — ✅ DONE (PR #111)
+Replace `perform_brain_extraction()` in `src/modules/utils.sh` with template-free implementation. Done via the SynthStrip-primary extractor + ANTs(Otsu)/BET fallback chain in `src/modules/brain_extraction.sh` (no MNI template in the default path).
+
+### Phase 2: Unify Reference Space Logic (Architectural)
+Create a consistent reference space decision that flows through all pipeline stages.
+
+### Phase 3: Dynamic Registration Direction (Critical)
+Make registration direction respond to reference space selection.
+
+### Phase 4: Simplified Segmentation Flow (Enhancement)
+Eliminate need for complex segmentation transformations.
+
+## **Detailed Implementation Plan**
+
+### Step 1: Fix Brain Extraction (Template-Free) — ✅ DONE (PR #111)
+The as-built solution uses SynthStrip (contrast-agnostic, no template) as primary with an automatic ANTs(Otsu) → BET fallback and `robustfov` neck removal, rather than the Otsu-only sketch below. The original sketch is kept for reference:
+```bash
+# Replace perform_brain_extraction() in src/modules/utils.sh
+perform_brain_extraction() {
+  local input_file="$1"
+  local output_prefix="$2"
+  
+  # Template-free approach using intensity-based methods
+  # 1. N4 bias correction
+  # 2. Otsu thresholding  
+  # 3. Connected component analysis
+  # 4. Morphological operations
+  # 5. Mask application
+}
+```
+
+### Step 2: Unified Reference Space Management
+Create global variables to track reference space decision:
+```bash
+# Set in Step 2, used throughout pipeline
+export PIPELINE_REFERENCE_MODALITY="T1"  # or "FLAIR"
+export PIPELINE_REFERENCE_FILE="/path/to/reference/image"
+export PIPELINE_MOVING_FILE="/path/to/moving/image"
+```
+
+### Step 3: Dynamic Registration Logic
+```bash
+# In Step 4 registration
+if [ "$PIPELINE_REFERENCE_MODALITY" = "T1" ]; then
+    # FLAIR → T1 registration
+    register_to_reference "$t1_std" "$flair_std" "FLAIR" "$reg_prefix"
+    log_message "Registering FLAIR to T1 reference space"
+else
+    # T1 → FLAIR registration
+    register_to_reference "$flair_std" "$t1_std" "T1" "$reg_prefix"
+    log_message "Registering T1 to FLAIR reference space"
+fi
+```
+
+### Step 4: Reference-Aware Segmentation
+```bash
+# In Step 5 segmentation
+if [ "$PIPELINE_REFERENCE_MODALITY" = "T1" ]; then
+    # Direct segmentation on T1 reference
+    extract_brainstem_final "$t1_std"
+else
+    # Segmentation on T1, then transform to FLAIR reference
+    extract_brainstem_final "$t1_std"
+    transform_segmentation_to_reference_space
+fi
+```
+
+## **Pipeline Flow After Fixes**
+
+```mermaid
+graph TD
+    A[Step 2: Preprocessing] --> B[Reference Space Selection]
+    B --> C{Selected Modality}
+    C -->|T1| D[T1 = Reference, FLAIR = Moving]
+    C -->|FLAIR| E[FLAIR = Reference, T1 = Moving]
+    
+    D --> F[Step 3: Brain Extraction - Template Free]
+    E --> F
+    F --> G[Standardization to Common Grid]
+    
+    G --> H[Step 4: Dynamic Registration]
+    H --> I{Reference Type}
+    I -->|T1 Ref| J[Register FLAIR → T1]
+    I -->|FLAIR Ref| K[Register T1 → FLAIR]
+    
+    J --> L[Step 5: Reference-Aware Segmentation]
+    K --> L
+    L --> M[Analysis in Reference Space]
+    
+    style B fill:#e1f5fe
+    style F fill:#fff3e0
+    style H fill:#c8e6c9
+    style L fill:#f3e5f5
+```
+
+## **Critical Variables to Track**
+
+### Global Pipeline State (Set in Step 2)
+```bash
+export PIPELINE_REFERENCE_MODALITY="T1|FLAIR"      # Which modality is reference
+export PIPELINE_REFERENCE_IMAGE=""                  # Path to reference image  
+export PIPELINE_MOVING_IMAGE=""                     # Path to moving image
+export PIPELINE_REFERENCE_STD=""                    # Standardized reference
+export PIPELINE_MOVING_STD=""                       # Standardized moving
+export PIPELINE_REGISTERED_MOVING=""                # Registered moving image
+```
+
+### Registration Transform Files (Created in Step 4)
+```bash
+# Registration outputs depend on direction
+if [ "$PIPELINE_REFERENCE_MODALITY" = "T1" ]; then
+    # FLAIR→T1: Standard naming
+    TRANSFORM_PREFIX="${reg_dir}/flair_to_t1"
+else
+    # T1→FLAIR: Reversed naming  
+    TRANSFORM_PREFIX="${reg_dir}/t1_to_flair"
+fi
+```
+
+## **Benefits of Complete Fix**
+
+### 1. MNI Independence
+- No external template dependencies
+- Works with any population/protocol
+- Robust intensity-based brain extraction
+
+### 2. Consistent Reference Logic
+- Single decision point in Step 2
+- All subsequent steps respect this decision
+- Clear variable tracking throughout pipeline
+
+### 3. Optimal Registration
+- Always registers moving → reference
+- Maintains highest quality reference space
+- Reduces accumulated errors
+
+### 4. Simplified Analysis
+- Analysis always done in reference space
+- No complex space transformations needed
+- Clear interpretation of results
+
+## **Implementation Priority**
+
+1. **Phase 1 (Critical)**: Fix MNI dependency - enables pipeline to run
+2. **Phase 2 (Important)**: Unify reference space logic - improves consistency
+3. **Phase 3 (Essential)**: Dynamic registration - ensures correct spatial alignment
+4. **Phase 4 (Enhancement)**: Simplified segmentation - reduces complexity
+
+## **Testing Strategy**
+
+### Test Case 1: T1 as Reference
+- Verify FLAIR→T1 registration works correctly
+- Confirm segmentation quality in T1 space
+- Check analysis results consistency
+
+### Test Case 2: FLAIR as Reference  
+- Verify T1→FLAIR registration works correctly
+- Confirm segmentation transforms to FLAIR space
+- Check analysis maintains accuracy
+
+### Test Case 3: Template-Free Brain Extraction
+- Compare brain extraction quality vs. template-based
+- Verify mask quality across different image types
+- Test fallback to FSL BET if needed
+
+This comprehensive fix addresses both the immediate MNI dependency issue and the underlying architectural problems with reference space management throughout the pipeline.


### PR DESCRIPTION
Surgical, in-place documentation updates so the prose docs match the best-practice batch already merged on `main` (PRs #111–#119). No code changes — `.md` only.

## What's reflected
- **Brainstem subdivision:** Talairach removed → **FreeSurfer brainstem substructures** (Iglesias 2015 `segmentBS`/`brainstemSsLabels`: midbrain/pons/medulla/SCP), selected via `BRAINSTEM_SEGMENTATION_METHOD` (default `freesurfer`, fallback `atlas`). Harvard-Oxford is now described as the **gross brainstem extent only**, tightened to `maxprob-thr25`. (#119)
- **Brain extraction:** BET/ANTs → **SynthStrip primary** with automatic SynthStrip → ANTs(Otsu) → BET fallback, shared `robustfov` neck removal, modality-specific BET `-f`, posterior-fossa QC gate (`BRAIN_EXTRACTION_METHOD`). (#111)
- **Denoising:** Rician-only → **modality-aware dispatcher** (NLM for T1/T2/FLAIR, MP-PCA `dwidenoise` for DWI, SWI/TOF skipped) + full DWI path. (#118)
- **N4:** field strength now tunes the **b-spline mesh / spline distance (`-b`)**; gentler, lesion-aware FLAIR preset. (#115)
- **Registration:** **Mutual Information** for cross-modality SyN, `--winsorize-image-intensities`, label-aware `GenericLabel` interpolation. (#112)
- **Detection:** **CSF/partial-volume exclusion** via the FAST CSF PVE map; **single authoritative fallback SD multiplier** (`THRESHOLD_WM_SD_MULTIPLIER`) reconciled across bash + `gmm_threshold.py`. (#114)
- **New optional supervised WMH modules:** FSL BIANCA (`wmh_bianca.sh`), LST-AI + FreeSurfer SAMSEG (`wmh_lst_samseg.sh`), default-off. (#113, #116)

## Files
- `README.md`, `docs/README.md`, `docs/TECHNICAL_OVERVIEW.md`, `docs/README_tests.md` — surgical line/section fixes (preserved structure/voice).
- `docs/brainstem_freesurfer_segmentation_spec.md` — now **tracked**; added a `Status: IMPLEMENTED` banner (#119), with inline notes where the as-built defaults differ from the original draft (default `freesurfer`/`atlas`, no `fusion` mode; HO `maxprob-thr25`; FS↔HO agreement config).
- `docs/complete_pipeline_analysis_and_fix_plan.md` — now **tracked**; status banner + inline **✅ DONE** markers on the brain-extraction/MNI-dependency items resolved by #111; still-open items left as-is.

`git grep -niE 'talairach' -- '*.md'` returns only explicit removed/legacy notes (no stale claims) in the edited files.

## Scope note
The in-flight **multi-atlas / Bianciardi / CIT168 / AAL3** work is **not** documented here (not yet merged) — a separate finalization pass will add it. **`CLAUDE.md` is owned by another agent** and is intentionally untouched.

## Verification
- `bash -n` over all `*.sh`: clean
- `shellcheck --severity=error`: clean
- `tests/test_environment_unit.sh` (100/100), `test_pipeline_control_unit.sh` (98/98), `test_import_unit.sh` (29/29): all pass
- `bash src/pipeline.sh --help | grep -q "Usage:"`: pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)