### PR TITLE
Docs finalization: CLAUDE.md/headers/multi-atlas + 2024-2026 citation library + synthetic-data recipe

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,7 @@
 DICOM
 mri-brain-examples-ds004199-1.0.6/
 validation_runs/
+test_output/
 .DS_Store
 .git
 *.nii.gz

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -41,13 +41,23 @@ src/modules/             # 35+ modules, each sourced by pipeline.sh
   environment.sh         # logging, error codes, path utils, dependency checks
   require_env.sh         # lightweight include guard — source instead of environment.sh in modules
   import.sh              # DICOM → NIfTI via dcm2niix
-  preprocess.sh          # Rician denoising, N4 bias correction
-  brain_extraction.sh    # BET / ANTs brain extraction
+  preprocess.sh          # modality-aware denoising (T1/T2/FLAIR Rician NLM, DWI MP-PCA, SWI/TOF skip) + N4 bias correction (field-strength via -b spline distance; gentler, lesion-aware FLAIR N4)
+  dwi_preprocess.sh      # full DWI path: MP-PCA dwidenoise → optional Gibbs unring → bias correct (gated by PROCESS_DWI)
+  brain_extraction.sh    # SynthStrip primary (→ANTs→BET fallback) + robustfov FOV-normalization + posterior-fossa QC
   registration.sh        # multi-stage ANTs registration (~600 line register_to_reference())
-  segmentation.sh        # Harvard-Oxford gross extent + FreeSurfer substructures (dispatch)
-  multi_atlas.sh         # Bianciardi + CIT168 + AAL3 → subject-space per-region masks
+  segmentation.sh        # Harvard-Oxford gross extent (thr25) + FreeSurfer brainstem substructures; optional multi-atlas warp (Bianciardi/CIT168/AAL3)
+  brainstem_freesurfer.sh # FreeSurfer segmentBS substructures (Iglesias 2015): midbrain/pons/medulla/SCP in native space
+  multi_atlas.sh         # Bianciardi + CIT168 + AAL3 → subject-space per-region masks (SyN→MNI + GenericLabel)
+  brainstem_aanseg.sh    # EXPLORATORY: FreeSurfer AANSegment arousal-network nuclei (≤1mm only; off by default)
   analysis.sh            # hyperintensity detection, cluster analysis
   gmm_threshold.py       # standalone GMM thresholder (called by analysis.sh)
+  fp_filter.sh           # post-detection false-positive suppression (config-gated; complements CSF/PV exclusion)
+  wmh_bianca.sh          # optional supervised WMH: FSL BIANCA (needs training data); off by default
+  wmh_lst_samseg.sh      # optional WMH: LST-AI + FreeSurfer SAMSEG (pretrained, no training data); off by default
+  wmh_synthseg.sh        # optional WMH: contrast-agnostic WMH-SynthSeg (mri_WMHsynthseg); off by default
+  wmh_segcsvd.sh         # optional WMH: segcsvdWMH CNN (FLAIR-only); off by default
+  wmh_shiva.sh           # optional WMH: SHIVA-WMH small-lesion detector (high sensitivity); off by default
+  wmh_mars.sh            # optional WMH: MARS-WMH deep-learning tool (MIAC); off by default
   visualization.sh       # 3D rendering, HTML reports
   qa.sh                  # 20+ validation checks
 config/default_config.sh # all pipeline defaults (has include guard)
@@ -95,6 +105,18 @@ _MODULE_LOADED=1
 | `BRAINSTEM_SEGMENTATION_METHOD` | `freesurfer` \| `atlas`/`harvard_oxford` \| `multi_atlas`/`bianciardi` |
 | `USE_BIANCIARDI` / `USE_CIT168` / `USE_AAL3` | per-atlas enables for `multi_atlas` (AAL3 off by default) |
 | `ATLAS_DIR` | atlas root, default `${FSLDIR}/data/atlases` |
+
+## Brainstem segmentation method & optional modules
+
+**`BRAINSTEM_SEGMENTATION_METHOD`** (default `freesurfer`) selects the brainstem labeling backend:
+
+- `freesurfer` (default) — FreeSurfer `segmentBS`/`brainstemSsLabels` substructures (midbrain/pons/medulla/SCP) on the subject's own T1; gated by an FS↔HO agreement (Dice + leakage) check; falls back to the HO gross mask on disagreement or missing FreeSurfer/license.
+- `atlas` / `harvard_oxford` — Harvard-Oxford gross brainstem extent only (index 7, `maxprob-thr25`).
+- `multi_atlas` / `bianciardi` — additionally warps Bianciardi BrainstemNavigator / CIT168 / AAL3 into subject space (shared SyN→MNI + `GenericLabel`) for nucleus-level masks (`docs/multi_atlas_integration_spec.md`).
+
+**Atlas-on-disk prerequisite** — `atlas`/`multi_atlas`/`bianciardi` need the atlases pre-downloaded under `$FSLDIR/data/atlases` (`ATLAS_DIR`): `Bianciardi/`, `CIT168/`, `AAL3/`, `HarvardOxford/`. The startup `check_atlas_availability` step (`environment.sh`, called from `pipeline.sh`) reports presence/absence per atlas and warns if the selected method needs a missing one; absence is **non-fatal** — the pipeline degrades to the HO gross mask. Override layout via `ATLAS_{BIANCIARDI,CIT168,AAL3,HARVARDOXFORD}_REL`.
+
+**Optional WMH / seg modules (all default-OFF)** — supervised/DL add-ons, each intersected with the brainstem mask: `wmh_bianca.sh` (FSL BIANCA), `wmh_lst_samseg.sh` (LST-AI + SAMSEG), `wmh_synthseg.sh` (WMH-SynthSeg), `wmh_segcsvd.sh` (segcsvdWMH), `wmh_shiva.sh` (SHIVA-WMH), `wmh_mars.sh` (MARS-WMH); plus `brainstem_aanseg.sh` (EXPLORATORY AANSegment, ≤1 mm only) and the post-detection `fp_filter.sh`. None is validated in the brainstem — keep conservative pons QA / human-in-the-loop.
 
 ## Runtime notes
 

--- a/docs/README.md
+++ b/docs/README.md
@@ -28,6 +28,41 @@ For a minimal pure-python implemention with synthetic data generation, LLM repor
 - Updated Juelich pons segmentation: applied same interpolation fix, yielding anatomically reasonable voxel counts.
 - Integrated FLAIR enhancement: generated separate FLAIR intensity masks for segmentation quality analysis.
 
+## Multi-Atlas Labeling & Optional Modules
+
+Beyond the default FreeSurfer/Harvard-Oxford path, the pipeline now ships several **opt-in** segmentation and lesion-detection back-ends:
+
+- **Multi-atlas brainstem labeling** (`BRAINSTEM_SEGMENTATION_METHOD=multi_atlas`/`bianciardi`, `multi_atlas.sh`) — warps the **Bianciardi BrainstemNavigator v1.0** (nucleus-level), **CIT168** subcortical, and (off-by-default) **AAL3** atlases into subject T1 space via one shared SyN→MNI registration plus label-aware `GenericLabel` interpolation, producing per-region masks the existing per-region GMM detection consumes directly. See [docs/multi_atlas_integration_spec.md](multi_atlas_integration_spec.md).
+- **Atlas-availability check** — a startup `check_atlas_availability` step reports which atlases are present under `$FSLDIR/data/atlases` and warns if the selected method needs a missing one; absence is **non-fatal** (the pipeline degrades to the Harvard-Oxford gross mask).
+- **Optional supervised / deep-learning WMH modules (all default-OFF)**, each intersected with the brainstem mask: FSL **BIANCA** (`wmh_bianca.sh`), **LST-AI + FreeSurfer SAMSEG** (`wmh_lst_samseg.sh`), **WMH-SynthSeg** (`wmh_synthseg.sh`), **segcsvdWMH** (`wmh_segcsvd.sh`), **SHIVA-WMH** (`wmh_shiva.sh`), and **MARS-WMH** (`wmh_mars.sh`).
+- **AANSegment** (`brainstem_aanseg.sh`) — **exploratory** FreeSurfer arousal-network nuclei segmentation (≤1 mm input only; large-lesion-sensitive; off by default).
+- **Post-detection false-positive filter** (`fp_filter.sh`) — config-gated FP suppression that operates *after* detection, complementing the CSF/partial-volume exclusion that runs *before* thresholding.
+
+> ⚠️ **None of these is validated in the brainstem/pons.** All published WMH/lesion SOTA is supratentorial; the posterior fossa is repeatedly "under-evaluated", and Ryu et al. 2025 find DL segmentation "relatively poor" in the brainstem. Treat every optional module as exploratory, keep conservative pons QA with a human in the loop, and locally validate any tool before relying on it.
+
+## Recent advances & roadmap (2024–2026)
+
+This section situates BrainStem X against the 2024–2026 literature and records the methods we have wired in (or are evaluating) and the honest caveats. Items marked **[preprint]** / **[provisional]** are not peer-reviewed or have no released code, and are cited with that caveat.
+
+**Brain extraction.** SynthStrip (Hoopes et al., NeuroImage 2022;260:119474) is the contrast-agnostic primary, falling back to ANTs and BET (Smith, Hum Brain Mapp 2002;17(3):143-155); HD-BET (Isensee et al., Hum Brain Mapp 2019;40(17):4952-4964) is a possible alternative.
+
+**Denoising / bias correction.** N4ITK (Tustison et al., IEEE TMI 2010;29(6):1310-1320) for bias; adaptive Rician NLM (Manjón et al., JMRI 2010;31(1):192-203) for structural; MP-PCA `dwidenoise` (Veraart et al., NeuroImage 2016;142:394-406) and Gibbs unringing (Kellner et al., MRM 2016;76(5):1574-1581) for DWI; Patch2Self2 (Fadnavis et al., CVPR 2024) and DeepN4 (Kanakaraj et al., Neuroinformatics 2024;22:193-205, T1-only) are candidate upgrades. FLAIR N4 is deliberately gentle because bias correction can absorb diffuse lesion contrast under high lesion load (Valdés Hernández et al., 2016, PMC4846712).
+
+**Registration.** SyN (Avants et al., Med Image Anal 2008;12(1):26-41), benchmarked against the classic nonlinear-registration evaluation (Klein et al., NeuroImage 2009;46(3):786-802). Learned registration is maturing: SynthMorph (Hoffmann et al., Imaging Neuroscience 2024;2:1-33), uniGradICON (Tian et al., MICCAI 2024), and the LUMIR/Learn2Reg 2024 benchmark **[preprint, arXiv:2505.24160]**.
+
+**Segmentation / atlases.** FreeSurfer brainstem substructures (Iglesias et al., NeuroImage 2015;113:184-195; Fischl, NeuroImage 2012;62(2):774-781) and Harvard-Oxford (Desikan et al., NeuroImage 2006;31(3):968-980) are the defaults; the multi-atlas path adds Bianciardi (Bianciardi et al., Brain Connect 2015;5(10):597-607; Toolkit v1.0 **[conference abstract]** Hannanu et al., ISMRM 2025 #0950), CIT168 (Pauli, Nili & Tyszka, Sci Data 2018;5:180063), and AAL3 (Rolls et al., NeuroImage 2020;206:116189). Talairach has been **removed** (single 1988 post-mortem brain; the MNI↔Talairach disparity, Lancaster et al. 2007, PMC2856713, is worst exactly inferiorly/posteriorly — i.e. in the brainstem). Contrast-agnostic learned segmentation is on the radar: SynthSeg (Billot et al., Med Image Anal 2023;86:102789), SynthSR (Iglesias et al., Sci Adv 2023;9(5):eadd3607); brainstem-specific DL includes AANSegment (Olchanyi et al., Hum Brain Mapp 2025;46(14):e70357) and MARS/dl-brainstem (Gesierich et al., Hum Brain Mapp 2025;46(3):e70141). Tissue priors via FSL FAST (Zhang et al., IEEE TMI 2001;20(1):45-57) or Atropos (Avants et al., Neuroinformatics 2011;9(4):381-400).
+
+**WMH / lesion detection.** Optional back-ends: BIANCA (Griffanti et al., NeuroImage 2016;141:191-205), LST-AI (Wiltgen et al., NeuroImage: Clinical 2024;42:103611), SAMSEG lesions (Cerri et al., NeuroImage 2021;225:117471), segcsvdWMH (Gibson et al., Hum Brain Mapp 2024;45(18):e70104), SHIVA-WMH (Tran et al., Hum Brain Mapp 2024;45(1):e26548), MARS-WMH (Gesierich et al., Cereb Circ Cogn Behav 2025;9:100393), and WMH-SynthSeg (Laso et al., IEEE ISBI 2024; arXiv:2312.05119). Further context: DeepWMH (Liu et al., Science Bulletin 2024;69(7):872-875), normative/generative anomaly detection (Bercea et al., Nat Commun 2025;16:1624), the WMH methods review (Rahmani et al., Brain Imaging Behav 2024;18:1310-1322), and benchmarks (Wu et al., J Imaging Inform Med 2026; DELCODE, Front Psychiatry 2023;13:1010273; Martersteck et al., Alzheimer's & Dementia 2025; WMH Segmentation Challenge, Kuijf et al., IEEE TMI 2019;38(11):2556-2568).
+
+**Infratentorial false positives (CSF pulsation).** The dominant brainstem FP source. Review of CSF-flow artifacts (Pai et al., Insights into Imaging 2025;16:288); the peri-CSF pseudolesion class (Bawil et al., BioMed Eng OnLine 2026;25:69); acquisition-side fix C-FLAIR (Graf et al., Radiology 2025;317(2)); joint ventricle×WMH modelling (SegAE, Atlason et al., PLOS ONE 2022;17(8):e0274212); the small-lesion-removal caveat (Molchanova et al., 2024, **[preprint, arXiv:2507.12092]**); and the brainstem reality check (Ryu et al., Sci Rep 2025;15:13214).
+
+**Standards.** McDonald 2024 (Montalban et al., Lancet Neurol 2025;24(10):850-865), MAGNIMS-CMSC-NAIMS 2024 (Barkhof et al., Lancet Neurol 2025;24(10):866-879), and STRIVE-2 (Duering et al., Lancet Neurol 2023;22(7):602-618).
+
+**Roadmap caveats (read these).**
+1. **No method is validated in the brainstem/pons.** Every cited WMH/segmentation tool was evaluated supratentorially; the posterior fossa is repeatedly "under-evaluated" and Ryu 2025 finds DL "relatively poor" there. Any adopted tool needs local brainstem validation; we keep conservative pons QA / human-in-the-loop.
+2. **3D-FLAIR acquisition is the single biggest lever** for infratentorial specificity — a high-quality isotropic 3D-FLAIR helps more than any post-processing step we could add.
+3. **Per-region GMM thresholding in the brainstem is a genuine published gap** (no 2024–2026 precedent we could find). That is simultaneously this project's novelty *and* a lack-of-external-validation caveat: the approach is unproven against an established brainstem reference.
+
 ## Features
 
 ### Acquisition-Specific Processing and Registration
@@ -133,7 +168,7 @@ For a minimal pure-python implemention with synthetic data generation, LLM repor
 - **Connectivity weighting** for refined detection using 3D morphological operations (fslmaths)
 - **Multi-threshold hyperintensity detection** with configurable standard deviation multipliers and minimum cluster size filtering
 - **Cross-modality validation** analyzes both FLAIR hyperintensities and T1 hypointensities with statistical correlation
-- **Optional supervised WMH modules** (default-off): FSL BIANCA (`wmh_bianca.sh`) and LST-AI + FreeSurfer SAMSEG (`wmh_lst_samseg.sh`), each intersecting results with the brainstem mask
+- **Optional supervised / DL WMH modules** (all default-off), each intersecting results with the brainstem mask: FSL BIANCA (`wmh_bianca.sh`), LST-AI + FreeSurfer SAMSEG (`wmh_lst_samseg.sh`), WMH-SynthSeg (`wmh_synthseg.sh`), segcsvdWMH (`wmh_segcsvd.sh`), SHIVA-WMH (`wmh_shiva.sh`), MARS-WMH (`wmh_mars.sh`); plus a post-detection false-positive filter (`fp_filter.sh`)
 
 #### Advanced Visualization & QA (visualization.sh, qa.sh)
 - **Interactive 3D rendering** creates volume renderings of hyperintensity clusters with customizable opacity and color mapping
@@ -216,8 +251,10 @@ The analysis module implements **region-based hyperintensity detection**:
    - Minimum cluster size filtering (configurable via `MIN_HYPERINTENSITY_SIZE`)
    - Morphological closing operations to eliminate noise
 
-5. **Optional Supervised WMH Modules** (default-off)
-   - FSL BIANCA (`wmh_bianca.sh`) and LST-AI + FreeSurfer SAMSEG (`wmh_lst_samseg.sh`), each intersecting results with the brainstem mask
+5. **Optional Supervised / DL WMH Modules** (all default-off)
+   - Each intersects results with the brainstem mask: FSL BIANCA (`wmh_bianca.sh`), LST-AI + FreeSurfer SAMSEG (`wmh_lst_samseg.sh`), WMH-SynthSeg (`wmh_synthseg.sh`), segcsvdWMH (`wmh_segcsvd.sh`), SHIVA-WMH (`wmh_shiva.sh`), MARS-WMH (`wmh_mars.sh`)
+   - A post-detection false-positive filter (`fp_filter.sh`) can be applied afterward (config-gated)
+   - **None is validated in the brainstem** — keep conservative pons QA / human-in-the-loop
 
 #### QA Module (qa.sh)
 The QA module performs **20+ comprehensive validation checks**:
@@ -345,7 +382,7 @@ The pipeline implements a sophisticated 8-stage processing workflow with intelli
 - **CSF / partial-volume exclusion** using the FSL FAST CSF PVE map before thresholding
 - **Multi-threshold detection** configurable SD multipliers with minimum cluster size filtering
 - **Cross-modality validation** analyzes hyperintensity patterns across T1/T2/FLAIR with statistical correlation
-- **Optional supervised WMH** FSL BIANCA and LST-AI + FreeSurfer SAMSEG modules (default-off), intersected with the brainstem mask
+- **Optional supervised / DL WMH** BIANCA, LST-AI + SAMSEG, WMH-SynthSeg, segcsvdWMH, SHIVA-WMH, MARS-WMH modules (all default-off), intersected with the brainstem mask; optional `fp_filter.sh` post-detection FP suppression
 - **Native-to-standard space mapping** enables analysis in both subject native and standardized coordinates
 - **DICOM cluster backtrace** creates coordinate lookup tables for medical imaging viewer navigation
 

--- a/docs/TECHNICAL_OVERVIEW.md
+++ b/docs/TECHNICAL_OVERVIEW.md
@@ -27,6 +27,88 @@ Brainstem regions can present clinically with very subtle variations below the c
 - Updated Juelich pons segmentation: applied same interpolation fix, yielding anatomically reasonable voxel counts
 - Integrated FLAIR enhancement: generated separate FLAIR intensity masks for segmentation quality analysis
 
+## Multi-Atlas Labeling, Optional Modules & Atlas Availability
+
+The default segmentation path is FreeSurfer substructures with a Harvard-Oxford gross-extent fallback. Several **opt-in** back-ends extend it:
+
+- **Multi-atlas brainstem labeling** (`multi_atlas.sh`, enabled via `BRAINSTEM_SEGMENTATION_METHOD=multi_atlas`/`bianciardi`) — warps the **Bianciardi BrainstemNavigator v1.0**, **CIT168**, and (off-by-default) **AAL3** atlases into subject T1 space through one shared SyN→MNI registration with label-aware `GenericLabel` interpolation. Bianciardi's *overlapping* probabilistic maps are combined by a streaming winner-take-all argmax into an int16 dseg **plus** an overlay set for the 12 reticular-formation nuclei that argmax would zero out. Per-region masks land where `analysis.sh:find_all_atlas_regions` discovers them, so per-region GMM detection consumes them unchanged. Full detail: [multi_atlas_integration_spec.md](multi_atlas_integration_spec.md).
+- **Atlas-availability check** (`check_atlas_availability` in `environment.sh`, invoked at startup) — reports presence/absence of each atlas under `$FSLDIR/data/atlases` (`ATLAS_DIR`) and warns if the selected method needs a missing one. Absence is **non-fatal**: the pipeline degrades to the Harvard-Oxford gross mask. Layout is overridable via `ATLAS_{BIANCIARDI,CIT168,AAL3,HARVARDOXFORD}_REL`.
+- **Optional supervised / deep-learning WMH modules (all default-OFF)**, each intersected with the brainstem mask: FSL **BIANCA** (`wmh_bianca.sh`), **LST-AI + FreeSurfer SAMSEG** (`wmh_lst_samseg.sh`), **WMH-SynthSeg** (`wmh_synthseg.sh`), **segcsvdWMH** (`wmh_segcsvd.sh`), **SHIVA-WMH** (`wmh_shiva.sh`), **MARS-WMH** (`wmh_mars.sh`).
+- **AANSegment** (`brainstem_aanseg.sh`) — **exploratory** FreeSurfer arousal-network nuclei segmentation; ≤1 mm input only, large-lesion-sensitive, off by default.
+- **Post-detection false-positive filter** (`fp_filter.sh`) — config-gated FP suppression operating *after* detection, complementing the CSF/partial-volume exclusion that runs *before* thresholding.
+
+> ⚠️ **None of these is validated in the brainstem/pons.** Published WMH/lesion SOTA is supratentorial; the posterior fossa is repeatedly "under-evaluated", and Ryu et al. 2025 report DL is "relatively poor" there. Treat optional modules as exploratory, keep conservative pons QA with a human in the loop, and locally validate before relying on any tool.
+
+## Recent Advances & Roadmap (2024–2026)
+
+This section situates BrainStem X against the 2024–2026 literature. Items marked **[preprint]** / **[provisional]** are not peer-reviewed or have no released code and are cited with that caveat.
+
+### Brain extraction
+- **SynthStrip** — Hoopes et al., NeuroImage 2022;260:119474 (contrast-agnostic primary)
+- **BET** — Smith, Hum Brain Mapp 2002;17(3):143-155 (fallback)
+- **HD-BET** — Isensee et al., Hum Brain Mapp 2019;40(17):4952-4964 (candidate alternative)
+
+### Denoising / bias correction
+- **N4ITK** — Tustison et al., IEEE TMI 2010;29(6):1310-1320
+- **Adaptive Rician NLM** — Manjón et al., JMRI 2010;31(1):192-203
+- **MP-PCA `dwidenoise`** — Veraart et al., NeuroImage 2016;142:394-406
+- **Gibbs unringing** — Kellner et al., MRM 2016;76(5):1574-1581
+- **Patch2Self2** (dMRI) — Fadnavis et al., CVPR 2024 (candidate)
+- **DeepN4** (T1-only N4 approximation, context) — Kanakaraj et al., Neuroinformatics 2024;22:193-205
+- **FLAIR bias-correction harm under lesion load** — Valdés Hernández et al., 2016 (PMC4846712) — motivates the gentle FLAIR N4 preset
+
+### Registration
+- **SyN** — Avants et al., Med Image Anal 2008;12(1):26-41
+- **Nonlinear-registration evaluation** — Klein et al., NeuroImage 2009;46(3):786-802
+- **SynthMorph** (joint) — Hoffmann et al., Imaging Neuroscience 2024;2:1-33
+- **uniGradICON** — Tian et al., MICCAI 2024
+- **LUMIR/Learn2Reg 2024** — **[preprint, arXiv:2505.24160]**
+
+### Segmentation / atlases
+- **FreeSurfer brainstem substructures** — Iglesias et al., NeuroImage 2015;113:184-195
+- **FreeSurfer** — Fischl, NeuroImage 2012;62(2):774-781
+- **Harvard-Oxford** — Desikan et al., NeuroImage 2006;31(3):968-980 (Makris et al. 2006)
+- **Bianciardi BrainstemNavigator** — Bianciardi et al., Brain Connect 2015;5(10):597-607; Toolkit v1.0 **[conference abstract]** Hannanu et al., ISMRM 2025 #0950
+- **CIT168** — Pauli, Nili & Tyszka, Sci Data 2018;5:180063
+- **AAL3** — Rolls et al., NeuroImage 2020;206:116189
+- **AANSegment** — Olchanyi et al., Hum Brain Mapp 2025;46(14):e70357 (≤1 mm only; CC BY-NC-ND; large-lesion-sensitive)
+- **MARS / dl-brainstem** — Gesierich et al., Hum Brain Mapp 2025;46(3):e70141
+- **Talairach (legacy; removed)** — Lancaster et al. 2007 (PMC2856713); MNI↔Talairach disparity is worst inferiorly/posteriorly, i.e. in the brainstem
+- **FSL FAST** — Zhang et al., IEEE TMI 2001;20(1):45-57; **Atropos** — Avants et al., Neuroinformatics 2011;9(4):381-400
+- **SynthSeg** — Billot et al., Med Image Anal 2023;86:102789; **SynthSR** — Iglesias et al., Sci Adv 2023;9(5):eadd3607
+
+### WMH / lesion detection
+- **BIANCA** — Griffanti et al., NeuroImage 2016;141:191-205
+- **LST-AI** — Wiltgen et al., NeuroImage: Clinical 2024;42:103611
+- **SAMSEG lesion** — Cerri et al., NeuroImage 2021;225:117471
+- **segcsvdWMH** — Gibson et al., Hum Brain Mapp 2024;45(18):e70104
+- **SHIVA-WMH** — Tran et al., Hum Brain Mapp 2024;45(1):e26548
+- **MARS-WMH** — Gesierich et al., Cereb Circ Cogn Behav 2025;9:100393
+- **WMH-SynthSeg** — Laso et al., IEEE ISBI 2024 (arXiv:2312.05119)
+- **DeepWMH** — Liu et al., Science Bulletin 2024;69(7):872-875
+- **Normative/generative anomaly detection** — Bercea et al., Nat Commun 2025;16:1624
+- **WMH methods review** — Rahmani et al., Brain Imaging Behav 2024;18:1310-1322
+- **FLAMeS** — Dereskewicz et al., J Neuroimaging 2025 (**[preprint, medRxiv 2025.05.19.25327707]**)
+- Benchmarks — Wu et al., J Imaging Inform Med 2026; DELCODE (Front Psychiatry 2023;13:1010273); Martersteck et al., Alzheimer's & Dementia 2025; WMH Segmentation Challenge (Kuijf et al., IEEE TMI 2019;38(11):2556-2568)
+
+### Infratentorial false positives (CSF pulsation) — the dominant brainstem FP source
+- **CSF flow artifacts review** — Pai et al., Insights into Imaging 2025;16:288
+- **Peri-CSF pseudolesion class** — Bawil et al., BioMed Eng OnLine 2026;25:69
+- **C-FLAIR (acquisition fix)** — Graf et al., Radiology 2025;317(2)
+- **SegAE / joint ventricle-WMH** — Atlason et al., PLOS ONE 2022;17(8):e0274212
+- **Small-lesion-removal caveat** — Molchanova et al., 2024 (**[preprint, arXiv:2507.12092]**)
+- **DL poor in brainstem (reality check)** — Ryu et al., Sci Rep 2025;15:13214
+
+### Standards
+- **McDonald 2024** — Montalban et al., Lancet Neurol 2025;24(10):850-865
+- **MAGNIMS-CMSC-NAIMS 2024** — Barkhof et al., Lancet Neurol 2025;24(10):866-879
+- **STRIVE-2** — Duering et al., Lancet Neurol 2023;22(7):602-618
+
+### Roadmap caveats (read these)
+1. **No method is validated in the brainstem/pons.** Every cited WMH/segmentation tool was evaluated supratentorially; the posterior fossa is repeatedly "under-evaluated" and Ryu 2025 finds DL "relatively poor" there. Any adopted tool needs local brainstem validation; the pipeline keeps conservative pons QA / human-in-the-loop.
+2. **3D-FLAIR acquisition is the single biggest lever** for infratentorial specificity — bigger than any post-processing step.
+3. **Per-region GMM thresholding in the brainstem is a genuine published gap** (no 2024–2026 precedent identified). This is both the project's novelty *and* a lack-of-external-validation caveat: the approach is unproven against an established brainstem reference.
+
 ## Complete Feature Set
 
 ### Acquisition-Specific Processing and Registration
@@ -148,7 +230,7 @@ Brainstem regions can present clinically with very subtle variations below the c
 - **Connectivity weighting** for refined detection using 3D morphological operations
 - **Multi-threshold hyperintensity detection** with configurable standard deviation multipliers and minimum cluster size filtering
 - **Cross-modality validation** analyzes both FLAIR hyperintensities and T1 hypointensities with statistical correlation
-- **Optional supervised WMH modules** (default-off): FSL BIANCA (`wmh_bianca.sh`) and LST-AI + FreeSurfer SAMSEG (`wmh_lst_samseg.sh`), each intersecting results with the brainstem mask
+- **Optional supervised / DL WMH modules** (all default-off), each intersecting results with the brainstem mask: FSL BIANCA (`wmh_bianca.sh`), LST-AI + FreeSurfer SAMSEG (`wmh_lst_samseg.sh`), WMH-SynthSeg (`wmh_synthseg.sh`), segcsvdWMH (`wmh_segcsvd.sh`), SHIVA-WMH (`wmh_shiva.sh`), MARS-WMH (`wmh_mars.sh`); plus a post-detection false-positive filter (`fp_filter.sh`)
 
 ### Advanced Visualization & QA (visualization.sh, qa.sh)
 
@@ -241,7 +323,7 @@ Brainstem regions can present clinically with very subtle variations below the c
 - **CSF / partial-volume exclusion** using the FSL FAST CSF PVE map before thresholding
 - **Multi-threshold detection** configurable SD multipliers (1.5-3.0) with minimum cluster size filtering
 - **Cross-modality validation** analyzes hyperintensity patterns across T1/T2/FLAIR with statistical correlation
-- **Optional supervised WMH** FSL BIANCA and LST-AI + FreeSurfer SAMSEG modules (default-off), intersected with the brainstem mask
+- **Optional supervised / DL WMH** BIANCA, LST-AI + SAMSEG, WMH-SynthSeg, segcsvdWMH, SHIVA-WMH, MARS-WMH modules (all default-off), intersected with the brainstem mask; optional `fp_filter.sh` post-detection FP suppression
 - **Native-to-standard space mapping** enables analysis in both subject native and standardized coordinates
 - **DICOM cluster backtrace** creates coordinate lookup tables for medical imaging viewer navigation
 
@@ -372,8 +454,10 @@ The analysis module implements **region-based hyperintensity detection**:
    - Minimum cluster size filtering (configurable, default 27 voxels)
    - Morphological closing operations to eliminate noise
 
-5. **Optional Supervised WMH Modules** (default-off)
-   - FSL BIANCA (`wmh_bianca.sh`) and LST-AI + FreeSurfer SAMSEG (`wmh_lst_samseg.sh`), each intersecting results with the brainstem mask
+5. **Optional Supervised / DL WMH Modules** (all default-off)
+   - Each intersects results with the brainstem mask: FSL BIANCA (`wmh_bianca.sh`), LST-AI + FreeSurfer SAMSEG (`wmh_lst_samseg.sh`), WMH-SynthSeg (`wmh_synthseg.sh`), segcsvdWMH (`wmh_segcsvd.sh`), SHIVA-WMH (`wmh_shiva.sh`), MARS-WMH (`wmh_mars.sh`)
+   - A post-detection false-positive filter (`fp_filter.sh`) can be applied afterward (config-gated)
+   - **None is validated in the brainstem** — keep conservative pons QA / human-in-the-loop
 
 ## Quality Assurance Details
 

--- a/docs/multi_atlas_integration_spec.md
+++ b/docs/multi_atlas_integration_spec.md
@@ -196,4 +196,45 @@ cases are unchanged; an unknown value still falls back to the HO gross mask.
 | `BIANCIARDI_MNI_SUBDIRS` | `2a…/2b…` | Bianciardi MNI source subdirs |
 | `REG_LABEL_INTERPOLATION` | `GenericLabel` | Label-aware warp interpolation |
 | `BRAINSTEM_SEGMENTATION_METHOD` | `freesurfer` | `multi_atlas`/`bianciardi` to enable |
-```
+
+## References
+
+Method-specific references for the atlases and the labeling approach used here.
+
+**Atlases**
+- **Bianciardi BrainstemNavigator** — Bianciardi M, et al. *Toward an in vivo
+  neuroimaging template of human brainstem nuclei of the ascending arousal,
+  autonomic, and motor systems.* Brain Connect 2015;5(10):597-607. Toolkit v1.0
+  release: Hannanu FF, et al., ISMRM 2025 #0950 (NITRC) — *conference abstract;
+  treat as provisional.*
+- **CIT168** — Pauli WM, Nili AN, Tyszka JM. *A high-resolution probabilistic
+  in vivo atlas of human subcortical brain nuclei.* Sci Data 2018;5:180063.
+- **AAL3** — Rolls ET, et al. *Automated anatomical labelling atlas 3.*
+  NeuroImage 2020;206:116189.
+- **Harvard-Oxford (gross extent baseline)** — Desikan RS, et al. NeuroImage
+  2006;31(3):968-980 (Makris N, et al. 2006).
+
+**Registration / label warping**
+- **SyN** (the MNI→subject transform reused per atlas) — Avants BB, et al.
+  *Symmetric diffeomorphic image registration with cross-correlation.* Med Image
+  Anal 2008;12(1):26-41.
+
+**Exploratory nucleus segmentation (not wired into multi-atlas split)**
+- **AANSegment** (arousal-network nuclei; `brainstem_aanseg.sh`) — Olchanyi MD,
+  et al. *Automated MRI segmentation of brainstem nuclei critical to
+  consciousness.* Hum Brain Mapp 2025;46(14):e70357. *Caveat: ≤1 mm input only;
+  CC BY-NC-ND; large-lesion-sensitive — exploratory.*
+
+### Why argmax + an overlay set (not a single dseg)
+
+A winner-take-all *argmax* collapses Bianciardi's *overlapping* probabilistic
+prob maps into a single integer dseg, which is the natural representation for the
+downstream per-region `safe_fslmaths -thr/-uthr` split. The trade-off is that a
+single-label dseg cannot encode overlap, so the 12 overlapping reticular-formation
+nuclei lose all voxels to neighbours; the hybrid build keeps those as an
+individually-warped **overlay set** rather than dropping them (see *CRITICAL
+CORRECTION* above). This argmax/maximum-probability rule for combining
+overlapping probabilistic atlases is the standard label-fusion choice; the
+multi-atlas-warp-then-combine rationale follows the general nonlinear-registration
+and label-propagation literature (Avants 2008, above; Klein A, et al. *Evaluation
+of 14 nonlinear deformation algorithms…* NeuroImage 2009;46(3):786-802).

--- a/docs/synthetic_test_data.md
+++ b/docs/synthetic_test_data.md
@@ -1,0 +1,161 @@
+# Synthetic Test Data for Brainstem Hyperintensity Detection
+
+Status: design spec / recipe. This document describes how to build a synthetic
+brainstem-lesion test set and a perturbation/mutation regression suite for
+BrainStem X. The goal is a *controllable ground truth*: lesions whose location,
+size, and contrast we set, so that every step of the pipeline's decision-making
+(CSF/PV exclusion → per-region GMM thresholding → cluster filtering → DICOM
+backtrace) can be validated against a known answer rather than a black-box label.
+
+> **Why this matters / project novelty.** A dedicated *brainstem small-lesion
+> simulator* is, as far as we can find, **unclaimed** in the 2024–2026
+> literature — all published synthetic-lesion work is supratentorial (WMH in the
+> periventricular/deep white matter, MS lesions, stroke). Combined with the
+> per-region brainstem GMM thresholding (itself a published gap), this synthetic
+> test set is both a validation tool and a contribution in its own right. It is
+> also a lack-of-precedent caveat: there is no external brainstem benchmark to
+> compare against, so the recipe must build its own ground truth.
+
+Items marked **[preprint]** / **[no released code]** are flagged as such; cite
+them with that caveat or omit.
+
+## Two generation tracks
+
+### Track A — label-conditioned (insert known labels, then render)
+
+Start from a label map (a healthy subject's segmentation or an atlas label
+volume), insert one or more **known hyperintensity labels** at chosen brainstem
+coordinates (e.g. dorsal pons, midbrain tegmentum), then *render* a realistic
+FLAIR from the augmented label map and warp it into subject space.
+
+1. **Insert labels.** Add lesion labels to the brainstem region of a clean label
+   map (FreeSurfer aseg / SynthSeg output, or an atlas dseg). Lesion shape/size
+   is parameterised (small punctate → confluent) so the test set spans the
+   regime the pipeline targets.
+2. **Render FLAIR from labels.** Use a label-conditioned generator:
+   - **brainSPADE3D** — Fernandez/Pinaya et al., *Generating Synthetic Brain MR
+     Images with Labels for Lesion Segmentation*, Med Image Anal 2024 (SASHIMI
+     2023; arXiv:2311.04552). A 3D semantic-diffusion model that synthesises
+     brain MR (incl. lesions) from a label map — the canonical "labels →
+     image" route.
+   - **SynthSeg / WMH-SynthSeg** — Billot et al., Med Image Anal
+     2023;86:102789; Laso et al., IEEE ISBI 2024 (arXiv:2312.05119). The
+     domain-randomised SynthSeg *generative model* renders contrast-agnostic
+     images from label maps; WMH-SynthSeg adds a WMH label class. Useful as a
+     fast, license-clean renderer when full diffusion synthesis is overkill.
+   - **Med-DDPM** — Dorjsembe et al., *Conditional Diffusion Models for
+     Semantic 3D Brain MRI Synthesis*, IEEE JBHI 2024;28(7):4084-4093 (mask →
+     volume conditional DDPM, an alternative renderer).
+   - **SynthSR** — Iglesias et al., Sci Adv 2023;9(5):eadd3607 (super-resolution
+     / contrast normalisation to make rendered volumes pipeline-realistic).
+3. **Warp through ANTs.** Push the rendered FLAIR (and its lesion ground-truth
+   mask) through the same SyN transforms the pipeline uses, so the synthetic
+   data lives in exactly the spaces the pipeline expects and the ground-truth
+   mask backtraces the way real detections do.
+
+### Track B — blend small synthetic lesions into clean 3D-FLAIR
+
+Start from a clean, high-quality 3D-FLAIR and **blend** small synthetic lesions
+directly into the brainstem, keeping the surrounding anatomy real.
+
+- **Soft Poisson Blending** of small synthetic lesions — Basaran et al., MICCAI
+  SASHIMI 2022 (arXiv:2208.02135). Gradient-domain (Poisson) blending inserts a
+  lesion patch with seamless intensity transitions — ideal for *small* brainstem
+  lesions where hard pasting produces obvious edges. This is the primary Track B
+  method.
+- **CarveMix** — Zhang et al., MICCAI 2021 / NeuroImage 2023. Lesion-aware
+  cut-and-mix augmentation; copy a carved lesion region (with soft boundaries)
+  between volumes. Good for cheaply expanding the lesion-position/shape space.
+- **Self-supervised lesion generation** — Huo et al., 2024 (arXiv:2406.14826)
+  **[preprint]**. Self-supervised synthesis of lesions for training/augmentation.
+- **LesionGAN** (small-lesion exemplar) — Momeni et al., Front Neurosci 2021.
+  GAN-based small-lesion synthesis; an exemplar of the small-lesion regime.
+- **SynthStroke** — Chalcroft et al., JMLBI 2025 (arXiv:2404.01946). Synthetic
+  stroke-lesion generation; relevant as a related infarct/lesion synthesiser
+  (still supratentorial — adapt with care).
+
+Track B keeps real CSF pulsation, partial-volume, and acquisition texture around
+the lesion, which Track A's fully-rendered images do not — so the two tracks are
+complementary (B = realistic surround, controlled lesion; A = fully controlled
+anatomy + lesion).
+
+## Mutation / perturbation regression suite (TorchIO + MONAI)
+
+Beyond inserting lesions, we mutate *clean* and *lesioned* inputs to test the
+pipeline's robustness and, crucially, its **false-positive behaviour** under the
+artifacts that plague the posterior fossa. Implemented with **TorchIO** and
+**MONAI** transforms:
+
+- **TorchIO** — Pérez-García et al., Comput Methods Programs Biomed
+  2021;208:106236.
+- **MONAI** — Cardoso et al., 2022 (arXiv:2211.02701).
+
+Key perturbations and what they probe:
+
+| Transform | Models | Tests |
+|---|---|---|
+| `RandomGhosting` | CSF-pulsation / flow ghosting | the dominant brainstem FP source — does CSF/PV exclusion + FP filter hold up? |
+| `RandomMotion` | head motion | cluster stability under blur/duplication |
+| `RandomBiasField` | residual B1 inhomogeneity | does FLAIR N4 / z-scoring stay lesion-faithful? |
+| `RandomGibbs` (Gibbs ringing) | truncation ringing near sharp CSF/tissue edges | edge artifacts mistaken for lesions |
+| `RandomNoise` / `RandomBlur` (resolution) | SNR / thick-slice clinical data | sensitivity at low SNR and 2D thick-slice |
+
+The regression test asserts that (a) inserted lesions are still detected after
+perturbation (sensitivity), and (b) **no new clusters** appear from
+ghosting/ringing alone on lesion-free inputs (specificity / FP control). The
+`RandomGhosting`-as-CSF-pulsation case directly exercises the dominant
+infratentorial failure mode.
+
+## Physics-faithful artifacts (optional, higher fidelity)
+
+For artifacts that augmentation transforms only approximate, simulate from spin
+physics / acquisition:
+
+- **KomaMRI.jl** — Castillo-Passi et al., MRM 2023;90(1):329-342. A GPU Bloch
+  simulator: generate physically-faithful MRI (incl. flow/motion/off-resonance
+  artifacts) from a digital phantom + pulse sequence.
+- **BigBrain-MR** — Sainz Martinez et al., NeuroImage 2023 (DOI
+  10.1016/j.neuroimage.2023.120074). High-resolution multi-contrast digital
+  phantom derived from BigBrain — a realistic substrate to drive KomaMRI.
+- **BrainWeb** — Cocosco/Collins/Evans, McGill (1997–2006). The classic digital
+  brain phantom with controllable noise/inhomogeneity; a cheap baseline.
+
+These let CSF-pulsation, Gibbs ringing, and motion be simulated from the
+acquisition rather than pasted on, which matters for the brainstem where the
+4th-ventricle/basal-cistern CSF flow drives most false positives.
+
+## Metamorphic testing (non-medical reference)
+
+- **SegRMT** — Mzoughi et al., 2025 (arXiv:2504.02335) **[preprint;
+  non-medical]**. Metamorphic testing of segmentation models: define
+  metamorphic relations (e.g. "a contrast-preserving transform should not change
+  the segmentation") and assert them. A useful *pattern* to adopt for the
+  perturbation suite above, even though the paper's domain is not medical.
+
+## Out of scope / flagged (do not rely on these here)
+
+Cited only to record that they were considered; preprint / unreleased /
+unverified — **omit or flag explicitly**:
+
+- MSRepaint (arXiv:2510.02063) **[preprint]**
+- THOMASINA **[preprint]**
+- SuperSynth **[wiki-only, no paper]**
+- Brain-SAM **[preprint]**
+- wmh_seg (arXiv:2402.12701) **[preprint]**
+- cVAE-normative **[bioRxiv]**
+- EJR-2025 CSF-flow ROI score **[publisher 403, unverified]**
+- TUMSyn **[no paired labels]**
+
+## Summary
+
+- **Track A** (brainSPADE3D / SynthSeg / WMH-SynthSeg / Med-DDPM, + SynthSR,
+  warped through ANTs) gives fully-controlled anatomy with inserted labels.
+- **Track B** (Soft Poisson Blending, CarveMix) inserts small synthetic lesions
+  into real clean 3D-FLAIR, preserving realistic surround.
+- A **TorchIO + MONAI** mutation suite (`RandomGhosting`=CSF-pulsation,
+  `RandomMotion`/`RandomBiasField`/`RandomGibbs`/noise) is the regression
+  harness; **KomaMRI.jl + BigBrain-MR / BrainWeb** add physics-faithful
+  artifacts where higher fidelity is needed; **SegRMT** supplies the metamorphic
+  testing pattern.
+- The **brainstem small-lesion simulator is unclaimed** in current literature =
+  project novelty *and* a no-external-benchmark caveat.

--- a/src/modules/analysis.sh
+++ b/src/modules/analysis.sh
@@ -3,8 +3,14 @@
 # analysis.sh - Analysis functions for the brain MRI processing pipeline
 #
 # This module contains:
-# - Hyperintensity detection
-# - Cluster analysis
+# - Region-based hyperintensity detection over the FreeSurfer brainstem
+#   substructures (falls back to the HO gross mask when absent)
+# - CSF / partial-volume exclusion (subtracts an FSL FAST CSF-PVE-derived mask;
+#   posterior-fossa CSF is the dominant false-positive source) before thresholding
+# - Per-region GMM thresholding (delegated to gmm_threshold.py; adaptive 2-3
+#   components) with a single authoritative fallback SD multiplier
+#   (THRESHOLD_WM_SD_MULTIPLIER) when GMM is skipped
+# - Cluster analysis (3D connectivity + minimum-size filtering)
 # - Volume quantification
 # - Analysis QA integration
 #

--- a/src/modules/brain_extraction.sh
+++ b/src/modules/brain_extraction.sh
@@ -4,7 +4,11 @@
 #
 # This module contains:
 # - Multi-axial integration
-# - Brain extraction
+# - Brain extraction: SynthStrip primary (FreeSurfer mri_synthstrip,
+#   contrast-agnostic; Hoopes 2022) with an automatic SynthStrip -> ANTs(Otsu)
+#   -> BET (Smith 2002) fallback chain, a shared robustfov FOV/neck-removal
+#   pre-step, modality-specific BET -f, and a posterior-fossa coverage QC gate
+#   (selected via BRAIN_EXTRACTION_METHOD)
 # - Dimension standardization
 # - Cropping with padding
 # - Parallel processing for all of the above

--- a/src/modules/preprocess.sh
+++ b/src/modules/preprocess.sh
@@ -3,9 +3,15 @@
 # preprocess.sh - True preprocessing functions for the brain MRI processing pipeline
 #
 # This module contains:
-# - Rician NLM denoising
-# - N4 bias field correction
-# - Parameter optimization
+# - Orientation standardization (RAS/LPS) with header-heuristic fallback
+# - Modality-aware denoising: T1/T2/FLAIR -> adaptive Rician NLM (ANTs
+#   DenoiseImage; Manjon 2010), DWI -> MP-PCA (dwidenoise; Veraart 2016, via
+#   dwi_preprocess.sh), SWI/TOF -> skipped
+# - N4 bias-field correction (Tustison 2010) where field strength tunes the
+#   b-spline mesh / spline distance (-b); FLAIR uses a gentler, lesion-aware
+#   preset so diffuse lesion contrast is not absorbed into the bias field
+#   (Valdes Hernandez 2016)
+# - Metadata-driven parameter optimization
 #
 # This is now focused only on true preprocessing steps, with brain extraction
 # and standardization moved to the brain_extraction.sh module for better modularity.

--- a/src/modules/registration.sh
+++ b/src/modules/registration.sh
@@ -5,6 +5,11 @@
 # This module contains a fully ANTs-based approach for:
 # - T2-SPACE-FLAIR to T1MPRAGE registration with white matter guided alignment
 # - Multi-modality registration (T2, DWI, SWI) to T1
+# - Multi-stage Rigid -> Affine -> SyN (Avants 2008) with a modality-aware
+#   metric: Mutual Information for cross-modality pairs (FLAIR<->T1),
+#   cross-correlation for same-modality, with --winsorize-image-intensities
+# - Label-aware warping (GenericLabel interpolation) when applying transforms
+#   to atlases / masks, to avoid label blurring
 # - Registration visualization and quality assessment
 # - Complete methodological consistency with ANTs throughout the pipeline
 #


### PR DESCRIPTION
Surgical **docs + comments + .gitignore only** pass to align the prose docs and module headers with the fully-merged code, and to inject the vetted 2024–2026 citation library. **No code-logic changes** (every `.sh` diff is comment-only).

## What changed

**1. `CLAUDE.md`**
- Fixed the stale `preprocess.sh` / `brain_extraction.sh` / `segmentation.sh` one-liners.
- Added the new modules to the module table: `dwi_preprocess.sh`, `brainstem_freesurfer.sh`, `multi_atlas.sh`, `brainstem_aanseg.sh`, `fp_filter.sh`, and the six `wmh_*` modules.
- Documented `BRAINSTEM_SEGMENTATION_METHOD` values (`freesurfer` default / `atlas` / `multi_atlas`/`bianciardi`), the atlas-on-disk prerequisite (`$FSLDIR/data/atlases`), the `check_atlas_availability` startup step, and the optional default-OFF WMH/seg modules.

**2. Module header comments (comment blocks only)**
- `brain_extraction.sh` — SynthStrip primary → ANTs → BET fallback + robustfov + posterior-fossa QC.
- `preprocess.sh` — modality-aware denoise (T1/T2/FLAIR Rician NLM, DWI MP-PCA, SWI/TOF skip) + lesion-aware FLAIR N4.
- `registration.sh` — MI cross-modality SyN + winsorize + label-aware GenericLabel.
- `analysis.sh` — CSF/PV exclusion + per-region GMM.

**3. `docs/README.md` + `docs/TECHNICAL_OVERVIEW.md`**
- Added multi-atlas warp (Bianciardi/CIT168/AAL3 via SyN→MNI + GenericLabel), the optional supervised/DL WMH modules (BIANCA, LST-AI/SAMSEG, WMH-SynthSeg, segcsvdWMH, SHIVA-WMH, MARS-WMH), AANSegment (exploratory), the FP-filter, and the atlas-availability check.
- New "Recent advances & roadmap (2024–2026)" section with the cited methods and the three caveats: (a) no method is validated in the brainstem/pons; (b) 3D-FLAIR acquisition is the single biggest lever; (c) per-region GMM thresholding in the brainstem is a published gap. Preprints/provisional items flagged.

**4. `docs/multi_atlas_integration_spec.md`**
- Added method-specific references (Bianciardi/CIT168/AAL3/AANSegment + the argmax/overlap-set rationale). Also fixed a pre-existing dangling code fence.

**5. NEW `docs/synthetic_test_data.md`**
- Track A (label-conditioned: insert labels → render FLAIR via brainSPADE3D / SynthSeg / WMH-SynthSeg / Med-DDPM → warp through ANTs) and Track B (Soft Poisson Blending / CarveMix of small synthetic lesions into clean 3D-FLAIR); the TorchIO + MONAI mutation suite (RandomGhosting=CSF-pulsation, RandomMotion/BiasField/Gibbs); KomaMRI.jl + BigBrain-MR / BrainWeb for physics-faithful artifacts; SegRMT metamorphic pattern. Notes the brainstem small-lesion simulator is unclaimed = project novelty. All cited; out-of-scope preprints flagged.

**6. `.gitignore`** — added `test_output/` (`.DS_Store` was already present).

## Verification
- `git ls-files '*.sh' | xargs -I{} bash -n {}` — clean.
- `git ls-files '*.sh' | xargs shellcheck --severity=error` — no error-level findings.
- `tests/test_environment_unit.sh` (100/0), `tests/test_pipeline_control_unit.sh` (98/0), `tests/test_import_unit.sh` (29/0) — all pass.
- `bash src/pipeline.sh --help | grep -q "Usage:"` — passes.
- Markdown: code-fence balance even in all four touched/new docs; relative links resolve.

🤖 Generated with [Claude Code](https://claude.com/claude-code)