### PR TITLE
Integration rework: wire FS/multi-atlas/CSF-PV/per-region-GMM + WMH modules into live analysis; retire Talairach analysis; gate DICOM mapping

### DIFF
--- a/config/default_config.sh
+++ b/config/default_config.sh
@@ -321,6 +321,18 @@ export REG_LABEL_INTERPOLATION="GenericLabel"
 export THRESHOLD_WM_SD_MULTIPLIER=1.2   # SD multiplier from local norm; used by GMM fallback + legacy path
 export MIN_HYPERINTENSITY_SIZE=3        # Minimum cluster size in voxels (FSL cluster --minextent)
 
+# Primary analysis engine selector (Step 6).  Controls which detector runs as
+# the PRIMARY hyperintensity analysis on a normal run:
+#   detect_hyperintensities  (DEFAULT) - the modern engine in analysis.sh that
+#       discovers the FreeSurfer brainstem substructures + multi-atlas nuclei
+#       under segmentation/detailed_brainstem (find_all_atlas_regions), performs
+#       CSF/partial-volume exclusion (#114) and per-region GMM thresholding.
+#   comprehensive - the legacy run_comprehensive_analysis path (NAWM SD-threshold
+#       over Talairach-style mask globs).  Retained as a guarded fallback only.
+# If the selected primary engine fails, the pipeline automatically falls back to
+# the OTHER engine so a run never aborts purely on engine choice.
+export ANALYSIS_PRIMARY_ENGINE="detect_hyperintensities"
+
 # ---------------------------------------------------------------------------
 # CSF / partial-volume exclusion (posterior-fossa false-positive reduction)
 # ---------------------------------------------------------------------------
@@ -778,6 +790,15 @@ export SUPPORTED_MODALITIES=("FLAIR" "SWI" "DWI" "TLE" "COR")
 
 # Batch processing parameters
 export  SUBJECT_LIST=""  # Path to subject list file for batch processing
+
+# ------------------------------------------------------------------------------
+# DICOM cluster-to-coordinate mapping stage (Step 6 tail)
+# ------------------------------------------------------------------------------
+# STOPGAP (default OFF): the cluster-to-DICOM coordinate mapping stage
+# (dicom_cluster_mapping.sh, invoked at the tail of Step 6 in pipeline.sh) is
+# known-broken and pending a separate rewrite. It is gated OFF by default so a
+# normal run skips it; set RUN_DICOM_MAPPING=true to opt back in once fixed.
+export RUN_DICOM_MAPPING=false
 
 # ------------------------------------------------------------------------------
 # DICOM File Pattern Configuration (used by import.sh and qa.sh)

--- a/src/modules/analysis.sh
+++ b/src/modules/analysis.sh
@@ -15,6 +15,62 @@
 # - Analysis QA integration
 #
 
+# Return 0 if two images occupy the SAME voxel space, 1 otherwise.
+# A matrix-dimension match alone is NOT sufficient: two volumes can share dims
+# yet differ in voxel size (pixdim) or world transform (sform/qform), which would
+# silently misalign a copied mask.  This compares dim1-3, pixdim1-3 AND the world
+# transform so the caller only skips resampling when the grids truly coincide.
+#
+# Conservative by design: when the world transform cannot be CONFIRMED equal
+# (sform missing/degenerate on either image, falling through to a degenerate
+# qform), this returns 1 (NOT same space) so the caller resamples via the header
+# transform — which is a safe no-op if the grids actually do match, but avoids a
+# silent misalignment if they don't.
+_analysis_same_space() {
+    local a="$1" b="$2"
+    [ -f "$a" ] && [ -f "$b" ] || return 1
+
+    local a_dims b_dims a_pix b_pix
+    a_dims=$(fslinfo "$a" | grep -E "^dim[123]" | awk '{print $2}' | tr '\n' 'x')
+    b_dims=$(fslinfo "$b" | grep -E "^dim[123]" | awk '{print $2}' | tr '\n' 'x')
+    [ "$a_dims" = "$b_dims" ] || return 1
+
+    a_pix=$(fslinfo "$a" | grep -E "^pixdim[123]" | awk '{printf "%.4f ", $2}')
+    b_pix=$(fslinfo "$b" | grep -E "^pixdim[123]" | awk '{printf "%.4f ", $2}')
+    [ "$a_pix" = "$b_pix" ] || return 1
+
+    # Compare the world transform (rounded). Prefer sform; fall back to qform.
+    # A matrix that is empty or all-zeros (sform_code/qform_code = 0) is treated
+    # as UNUSABLE — two unusable matrices must NOT be compared as "equal", since
+    # that would let genuinely different spaces slip through (the exact failure
+    # this helper exists to prevent).
+    local a_world b_world
+    a_world=$(_analysis_world_matrix "$a")
+    b_world=$(_analysis_world_matrix "$b")
+    if [ -z "$a_world" ] || [ -z "$b_world" ]; then
+        # Cannot confirm the world transform -> be conservative, force resample.
+        return 1
+    fi
+    [ "$a_world" = "$b_world" ] || return 1
+    return 0
+}
+
+# Echo a rounded, single-line world matrix (sform preferred, qform fallback) for
+# an image, or echo nothing when neither is usable (empty or all-zeros).
+_analysis_world_matrix() {
+    local img="$1" m
+    local xform
+    for xform in getsform getqform; do
+        m=$(fslorient "-${xform}" "$img" 2>/dev/null | awk '{for(i=1;i<=NF;i++) printf "%.3f ", $i}')
+        # Reject empty or all-zero (degenerate / code 0) matrices.
+        if [ -n "$m" ] && echo "$m" | grep -qE '[1-9]'; then
+            echo "$m"
+            return 0
+        fi
+    done
+    return 0
+}
+
 # Function to detect hyperintensities with improved false positive reduction
 detect_hyperintensities() {
     # Usage: detect_hyperintensities <FLAIR_input.nii.gz> <output_prefix> [<T1_input.nii.gz>]
@@ -205,6 +261,11 @@ detect_hyperintensities() {
     if [ ${#atlas_regions[@]} -gt 0 ]; then
         log_message "Found ${#atlas_regions[@]} atlas-based region masks for sophisticated per-region analysis"
         
+        # Reset any value left over from a previous subject (batch mode) so a
+        # stale export can't be mistaken for this subject's result if the GMM
+        # step exits without setting it.
+        export ATLAS_GMM_RESULT=""
+
         # Apply GMM-based analysis to each atlas region separately
         apply_per_region_gmm_analysis "$flair_brain" atlas_regions "$temp_dir" "$out_prefix"
         
@@ -228,8 +289,12 @@ detect_hyperintensities() {
             local final_mask="${out_prefix}_threshATLAS_GMM.nii.gz"
             local cleaned="${out_prefix}_cleanedATLAS_GMM.nii.gz"
             
-            # Use the combined atlas GMM result
-            if [ -n "$ATLAS_GMM_RESULT" ] && [ -f "$ATLAS_GMM_RESULT" ]; then
+            # Use the combined atlas GMM result. apply_per_region_gmm_analysis
+            # only exports ATLAS_GMM_RESULT when >=1 region succeeds; under
+            # `set -u` an unset reference would hard-abort the run (now reachable
+            # because detect_hyperintensities is the default primary engine), so
+            # default it to empty and let the [ -n ]/[ -f ] guard handle absence.
+            if [ -n "${ATLAS_GMM_RESULT:-}" ] && [ -f "${ATLAS_GMM_RESULT:-}" ]; then
                 cp "$ATLAS_GMM_RESULT" "$cleaned"
                 
                 # Apply minimum cluster size filtering
@@ -809,14 +874,17 @@ build_csf_exclusion_mask() {
     work_dir=$(mktemp -d)
 
     # CSF PVE map may be in a different space than the reference; resample if so.
+    # Use a full same-space check (dims + pixdim + sform), not dims alone, so we
+    # never skip resampling on a grid that merely shares matrix dimensions.
     local csf_resampled="$csf_prob"
-    local ref_dims csf_dims
-    ref_dims=$(fslinfo "$reference_image" | grep -E "^dim[123]" | awk '{print $2}' | tr '\n' 'x' | sed 's/x$//')
-    csf_dims=$(fslinfo "$csf_prob" | grep -E "^dim[123]" | awk '{print $2}' | tr '\n' 'x' | sed 's/x$//')
-    if [ "$ref_dims" != "$csf_dims" ]; then
+    if ! _analysis_same_space "$reference_image" "$csf_prob"; then
         csf_resampled="${work_dir}/csf_resampled.nii.gz"
         log_message "Resampling CSF PVE map to reference space..."
-        if ! flirt -in "$csf_prob" -ref "$reference_image" -out "$csf_resampled" -interp trilinear -dof 6; then
+        # -applyxfm -usesqform uses the stored sform/qform to map between the
+        # two grids (header-based resample), which is correct here because the
+        # CSF PVE map and the reference are already in the same physical space
+        # and only differ in sampling grid (no rigid registration needed).
+        if ! flirt -in "$csf_prob" -ref "$reference_image" -out "$csf_resampled" -applyxfm -usesqform -interp trilinear; then
             log_formatted "WARNING" "CSF PVE resampling failed; CSF subtraction will be skipped"
             rm -rf "$work_dir"
             return 1
@@ -1014,28 +1082,27 @@ apply_per_region_gmm_analysis() {
         local gmm_temp_dir="${region_work_dir}/gmm_analysis"
         mkdir -p "$gmm_temp_dir"
         
-        # Check if mask needs resampling to match FLAIR space
+        # Check if mask needs resampling to match FLAIR space.  Use the full
+        # same-space check (dims + pixdim + sform), not dims alone, and resample
+        # via the header transform (-applyxfm -usesqform) with nearestneighbour
+        # to preserve the discrete label mask.
         local region_resampled="${region_work_dir}/${region_base}_resampled.nii.gz"
-        local mask_dims=$(fslinfo "$region_mask" | grep -E "^dim[123]" | awk '{print $2}' | tr '\n' 'x' | sed 's/x$//')
-        local flair_dims=$(fslinfo "$flair_image" | grep -E "^dim[123]" | awk '{print $2}' | tr '\n' 'x' | sed 's/x$//')
-        
-        if [ "$mask_dims" = "$flair_dims" ]; then
+        if _analysis_same_space "$region_mask" "$flair_image"; then
             cp "$region_mask" "$region_resampled"
         else
             log_message "Resampling $region_base mask to FLAIR space..."
-            flirt -in "$region_mask" -ref "$flair_image" -out "$region_resampled" -interp nearestneighbour -dof 6
+            flirt -in "$region_mask" -ref "$flair_image" -out "$region_resampled" -applyxfm -usesqform -interp nearestneighbour
         fi
-        
+
         # CRITICAL: Pre-filter segmentation mask with brain mask BEFORE any analysis
         local region_brain_masked="${region_work_dir}/${region_base}_brain_masked.nii.gz"
         log_message "Pre-filtering $region_base with brain mask to exclude non-brain voxels..."
-        
-        # Resample brain mask to match region if needed
+
+        # Resample brain mask to match region if needed (same-space check + header resample)
         local brain_mask_resampled="$brain_mask"
-        local brain_dims=$(fslinfo "$brain_mask" | grep -E "^dim[123]" | awk '{print $2}' | tr '\n' 'x' | sed 's/x$//')
-        if [ "$brain_dims" != "$flair_dims" ]; then
+        if ! _analysis_same_space "$brain_mask" "$flair_image"; then
             brain_mask_resampled="${region_work_dir}/brain_mask_resampled.nii.gz"
-            flirt -in "$brain_mask" -ref "$flair_image" -out "$brain_mask_resampled" -interp nearestneighbour -dof 6
+            flirt -in "$brain_mask" -ref "$flair_image" -out "$brain_mask_resampled" -applyxfm -usesqform -interp nearestneighbour
         fi
         
         # Apply brain mask to region mask
@@ -1906,492 +1973,16 @@ transform_segmentation_to_original() {
     return 0
 }
 
-# Helper function to analyze a specific region and modality
-analyze_region_modality() {
-    local region="$1"
-    local region_mask="$2"
-    local image_file="$3"
-    local modality="$4"        # "FLAIR" or "T1"
-    local intensity_type="$5"  # "hyper" or "hypo"
-    local base_hyper_dir="$6"
-    
-    # Create modality-specific output directory
-    local region_output_dir="${base_hyper_dir}/${region}_${modality}"
-    mkdir -p "$region_output_dir"
-    
-    # Create masked image for this region
-    local region_image="${region_output_dir}/${region}_${modality}.nii.gz"
-    if ! fslmaths "$image_file" -mas "$region_mask" "$region_image"; then
-        log_formatted "WARNING" "Failed to create masked ${modality} for $region"
-        return 1
-    fi
-    
-    # Get region statistics for adaptive thresholding
-    local region_stats=$(fslstats "$region_image" -k "$region_mask" -M -S)
-    local region_mean=$(echo "$region_stats" | awk '{print $1}')
-    local region_std=$(echo "$region_stats" | awk '{print $2}')
-    
-    if [ "$region_mean" = "0.000000" ] || [ -z "$region_std" ]; then
-        log_message "Skipping ${modality} ${intensity_type}intensities in $region - no signal detected"
-        return 1
-    fi
-    
-    log_message "$region ${modality} statistics - Mean: $region_mean, StdDev: $region_std"
-    
-    # Apply modality-specific thresholding with different multipliers for T1 vs FLAIR
-    # Fallback literal must equal config THRESHOLD_WM_SD_MULTIPLIER (the single
-    # authoritative fallback) so the legacy path agrees with the GMM path.
-    local base_threshold_multiplier="${THRESHOLD_WM_SD_MULTIPLIER:-1.2}"
-    local threshold_multiplier
-    local threshold_val
-    local abnormality_mask="${region_output_dir}/${region}_${modality}_${intensity_type}intensities.nii.gz"
-    
-    # CRITICAL FIX: Use higher thresholds for T1 hypointensities than FLAIR hyperintensities
-    if [ "$modality" = "T1" ]; then
-        # T1 hypointensities need higher threshold (double the base threshold)
-        threshold_multiplier=$(echo "$base_threshold_multiplier * 2.0" | bc -l)
-        log_message "Using enhanced T1 threshold multiplier: $threshold_multiplier (2x base for hypointensities)"
-    else
-        # FLAIR hyperintensities use standard threshold
-        threshold_multiplier="$base_threshold_multiplier"
-        log_message "Using standard FLAIR threshold multiplier: $threshold_multiplier"
-    fi
-    
-    if [ "$intensity_type" = "hyper" ]; then
-        # FLAIR hyperintensities: mean + multiplier * std (above threshold)
-        threshold_val=$(echo "$region_mean + $threshold_multiplier * $region_std" | bc -l)
-        log_message "Using ${modality} hyperintensity threshold: $threshold_val for $region (multiplier: $threshold_multiplier)"
-        
-        # Create hyperintensity mask (above threshold)
-        if ! fslmaths "$region_image" -thr "$threshold_val" -bin "$abnormality_mask"; then
-            log_formatted "WARNING" "Failed to create ${modality} hyperintensity mask for $region"
-            return 1
-        fi
-    else
-        # T1 hypointensities: mean - multiplier * std (below threshold)
-        threshold_val=$(echo "$region_mean - $threshold_multiplier * $region_std" | bc -l)
-        log_message "Using ${modality} hypointensity threshold: $threshold_val for $region (multiplier: $threshold_multiplier)"
-        
-        # Create hypointensity mask (below threshold)
-        if ! fslmaths "$region_image" -uthr "$threshold_val" -bin "$abnormality_mask"; then
-            log_formatted "WARNING" "Failed to create ${modality} hypointensity mask for $region"
-            return 1
-        fi
-    fi
-    
-    # Apply minimum cluster size filtering
-    local min_size="${MIN_HYPERINTENSITY_SIZE:-4}"
-    local filtered_mask="${region_output_dir}/${region}_${modality}_${intensity_type}intensities_filtered.nii.gz"
-    
-    if cluster --in="$abnormality_mask" --thresh=0.5 \
-               --connectivity=26 --minextent="$min_size" \
-               --oindex="$filtered_mask" > /dev/null 2>&1; then
-        log_message "✓ Applied clustering filter (min size: $min_size voxels) to ${modality} $region"
-    else
-        log_message "Clustering failed for ${modality} $region, using unfiltered mask"
-        cp "$abnormality_mask" "$filtered_mask"
-    fi
-    
-    # Create intensity version
-    local abnormality_intensity="${region_output_dir}/${region}_${modality}_${intensity_type}intensities_intensity.nii.gz"
-    fslmaths "$region_image" -mas "$filtered_mask" "$abnormality_intensity"
-    
-    # Create RGB overlay for visualization
-    local overlay="${region_output_dir}/overlay.nii.gz"
-    log_message "Creating ${modality} RGB overlay for $region..."
-    
-    # Check dimensions match
-    local image_dims=$(fslinfo "$region_image" | grep -E "^dim[123]" | awk '{print $2}' | tr '\n' 'x' | sed 's/x$//')
-    local mask_dims=$(fslinfo "$filtered_mask" | grep -E "^dim[123]" | awk '{print $2}' | tr '\n' 'x' | sed 's/x$//')
-    
-    if [ "$image_dims" = "$mask_dims" ]; then
-        # Create RGB channels
-        local temp_dir=$(mktemp -d)
-        
-        # Red channel - background image
-        local max_val=$(fslstats "$region_image" -k "$region_mask" -R | awk '{print $2}')
-        if [ "$max_val" != "0.000000" ] && [ -n "$max_val" ]; then
-            fslmaths "$region_image" -div "$max_val" "${temp_dir}/r.nii.gz"
-        else
-            fslmaths "$region_image" -mul 0 "${temp_dir}/r.nii.gz"
-        fi
-        
-        # Green channel - abnormalities (hyperintensities green, hypointensities blue)
-        if [ "$intensity_type" = "hyper" ]; then
-            fslmaths "$filtered_mask" -mul 0.8 "${temp_dir}/g.nii.gz"
-            fslmaths "$filtered_mask" -mul 0 "${temp_dir}/b.nii.gz"
-        else
-            fslmaths "$filtered_mask" -mul 0 "${temp_dir}/g.nii.gz"
-            fslmaths "$filtered_mask" -mul 0.8 "${temp_dir}/b.nii.gz"
-        fi
-        
-        # Blue channel - mask outline (or hypointensities)
-        if [ "$intensity_type" = "hyper" ]; then
-            fslmaths "$region_mask" -edge -bin -mul 0.3 "${temp_dir}/b.nii.gz"
-        fi
-        
-        # Merge RGB channels
-        if fslmerge -t "$overlay" "${temp_dir}/r.nii.gz" "${temp_dir}/g.nii.gz" "${temp_dir}/b.nii.gz"; then
-            log_message "✓ Created ${modality} RGB overlay for $region"
-        else
-            log_formatted "WARNING" "Failed to create ${modality} RGB overlay for $region"
-            # Create fallback overlay
-            fslmaths "$region_image" -add "$filtered_mask" "$overlay"
-        fi
-        
-        rm -rf "$temp_dir"
-    else
-        log_formatted "WARNING" "Dimension mismatch for ${modality} $region overlay - creating fallback"
-        fslmaths "$region_image" -add "$filtered_mask" "$overlay"
-    fi
-    
-    # Quantify results
-    local abnormal_voxels=$(fslstats "$filtered_mask" -V | awk '{print $1}')
-    local abnormal_volume=$(fslstats "$filtered_mask" -V | awk '{print $2}')
-    local region_voxels=$(fslstats "$region_mask" -V | awk '{print $1}')
-    local region_volume=$(fslstats "$region_mask" -V | awk '{print $2}')
-    
-    local percentage="0"
-    if [ "$region_voxels" -gt 0 ]; then
-        percentage=$(echo "scale=2; $abnormal_voxels * 100 / $region_voxels" | bc)
-    fi
-    
-    log_message "✓ $region ${modality} ${intensity_type}intensities results:"
-    log_message "   Abnormal voxels: $abnormal_voxels ($abnormal_volume mm³)"
-    log_message "   Region coverage: ${percentage}%"
-    
-    # Create region summary
-    {
-        echo "Talairach Region ${modality} ${intensity_type^}intensity Analysis"
-        echo "=============================================="
-        echo "Region: $region"
-        echo "Modality: $modality"
-        echo "Analysis type: ${intensity_type}intensities"
-        echo "Date: $(date)"
-        echo ""
-        echo "Input files:"
-        echo "  Image: $(basename "$image_file")"
-        echo "  Mask: $(basename "$region_mask")"
-        echo ""
-        echo "Analysis parameters:"
-        echo "  Threshold multiplier: $threshold_multiplier"
-        echo "  Threshold value: $threshold_val"
-        echo "  Threshold direction: $([ "$intensity_type" = "hyper" ] && echo "above (>)" || echo "below (<)")"
-        echo "  Minimum cluster size: $min_size voxels"
-        echo ""
-        echo "Results:"
-        echo "  Region volume: $region_volume mm³ ($region_voxels voxels)"
-        echo "  Abnormal volume: $abnormal_volume mm³ ($abnormal_voxels voxels)"
-        echo "  Percentage affected: ${percentage}%"
-        echo ""
-        echo "Output files:"
-        echo "  Abnormality mask: $(basename "$filtered_mask")"
-        echo "  Abnormality intensity: $(basename "$abnormality_intensity")"
-        echo "  RGB overlay: $(basename "$overlay")"
-    } > "${region_output_dir}/${region}_${modality}_${intensity_type}intensity_report.txt"
-    
-    log_message "✓ Created ${modality} analysis report: ${region_output_dir}/${region}_${modality}_${intensity_type}intensity_report.txt"
-    
-    return 0
-}
-
-# Function to analyze intensity abnormalities in Talairach brainstem regions (both FLAIR and T1)
-analyze_talairach_hyperintensities() {
-    local flair_file="$1"
-    local analysis_dir="$2"
-    local output_basename="$3"
-    local t1_file="${4:-}"  # Optional T1 file
-    
-    log_formatted "INFO" "===== TALAIRACH INTENSITY ABNORMALITY ANALYSIS ====="
-    log_message "FLAIR input: $flair_file"
-    log_message "T1 input: ${t1_file:-none provided}"
-    log_message "Analysis directory: $analysis_dir"
-    log_message "Output basename: $output_basename"
-    
-    # Validate inputs
-    if [ ! -f "$flair_file" ]; then
-        log_formatted "ERROR" "FLAIR file not found: $flair_file"
-        return 1
-    fi
-    
-    if [ ! -d "$analysis_dir" ]; then
-        log_formatted "ERROR" "Analysis directory not found: $analysis_dir"
-        return 1
-    fi
-    
-    # Try to find T1 file if not provided
-    if [ -z "$t1_file" ] || [ ! -f "$t1_file" ]; then
-        log_message "Searching for T1 file..."
-        local t1_candidates=(
-            "${RESULTS_DIR}/standardized/"*"T1"*"_std.nii.gz"
-            "${RESULTS_DIR}/bias_corrected/"*"T1"*".nii.gz"
-            "${RESULTS_DIR}/preprocessing/"*"T1"*".nii.gz"
-        )
-        
-        for candidate in "${t1_candidates[@]}"; do
-            if [ -f "$candidate" ]; then
-                t1_file="$candidate"
-                log_message "Found T1 file: $t1_file"
-                break
-            fi
-        done
-        
-        if [ ! -f "$t1_file" ]; then
-            log_formatted "WARNING" "No T1 file found - will only analyze FLAIR hyperintensities"
-            t1_file=""
-        fi
-    fi
-    
-    # Create hyperintensities output directory
-    local hyper_dir="${RESULTS_DIR}/comprehensive_analysis/hyperintensities"
-    mkdir -p "$hyper_dir"
-    
-    # Find all Talairach region masks
-    local talairach_regions=(
-        "left_medulla"
-        "right_medulla"
-        "left_pons"
-        "right_pons"
-        "left_midbrain"
-        "right_midbrain"
-        "pons"  # combined pons
-    )
-    
-    log_message "Analyzing intensity abnormalities in Talairach brainstem regions..."
-    log_message "Will analyze: FLAIR (hyperintensities) and T1 (hypointensities)"
-    
-    # Process each Talairach region for both modalities
-    for region in "${talairach_regions[@]}"; do
-        # Look for region mask files
-        local region_mask=""
-        local region_files=(
-            "${analysis_dir}/${output_basename}_${region}_flair_space.nii.gz"
-            "${analysis_dir}/${output_basename}_${region}.nii.gz"
-        )
-        
-        for mask_file in "${region_files[@]}"; do
-            if [ -f "$mask_file" ]; then
-                region_mask="$mask_file"
-                break
-            fi
-        done
-        
-        if [ -z "$region_mask" ] || [ ! -f "$region_mask" ]; then
-            log_message "Skipping $region - mask not found"
-            continue
-        fi
-        
-        log_message "Processing intensity abnormalities in $region..."
-        log_message "Using mask: $(basename "$region_mask")"
-        
-        # Process FLAIR hyperintensities
-        analyze_region_modality "$region" "$region_mask" "$flair_file" "FLAIR" "hyper" "$hyper_dir"
-        
-        # Process T1 hypointensities if T1 available
-        if [ -n "$t1_file" ] && [ -f "$t1_file" ]; then
-            analyze_region_modality "$region" "$region_mask" "$t1_file" "T1" "hypo" "$hyper_dir"
-        fi
-    done
-    
-    # Create combined summary across all Talairach regions
-    log_message "Creating combined Talairach intensity abnormality summary..."
-    
-    local combined_report="${hyper_dir}/talairach_intensity_abnormality_summary.txt"
-    {
-        echo "Talairach Brainstem Intensity Abnormality Analysis Summary"
-        echo "========================================================="
-        echo "Date: $(date)"
-        echo "FLAIR input: $(basename "$flair_file")"
-        if [ -n "$t1_file" ] && [ -f "$t1_file" ]; then
-            echo "T1 input: $(basename "$t1_file")"
-        else
-            echo "T1 input: Not available"
-        fi
-        echo ""
-        echo "FLAIR HYPERINTENSITIES (lesions appear bright)"
-        echo "=============================================="
-        echo "Region | Volume (mm³) | Hyperintensities (mm³) | % Affected"
-        echo "-------|--------------|-------------------------|----------"
-        
-        for region in "${talairach_regions[@]}"; do
-            local flair_report="${hyper_dir}/${region}_FLAIR/${region}_FLAIR_hyperintensity_report.txt"
-            if [ -f "$flair_report" ]; then
-                local region_vol=$(grep "Region volume:" "$flair_report" | awk '{print $3}')
-                local abnormal_vol=$(grep "Abnormal volume:" "$flair_report" | awk '{print $3}')
-                local percentage=$(grep "Percentage affected:" "$flair_report" | awk '{print $3}')
-                printf "%-6s | %12s | %23s | %8s\n" "$region" "$region_vol" "$abnormal_vol" "$percentage"
-            else
-                printf "%-6s | %12s | %23s | %8s\n" "$region" "N/A" "N/A" "N/A"
-            fi
-        done
-        
-        if [ -n "$t1_file" ] && [ -f "$t1_file" ]; then
-            echo ""
-            echo "T1 HYPOINTENSITIES (lesions appear dark)"
-            echo "========================================"
-            echo "Region | Volume (mm³) | Hypointensities (mm³) | % Affected"
-            echo "-------|--------------|------------------------|----------"
-            
-            for region in "${talairach_regions[@]}"; do
-                local t1_report="${hyper_dir}/${region}_T1/${region}_T1_hypointensity_report.txt"
-                if [ -f "$t1_report" ]; then
-                    local region_vol=$(grep "Region volume:" "$t1_report" | awk '{print $3}')
-                    local abnormal_vol=$(grep "Abnormal volume:" "$t1_report" | awk '{print $3}')
-                    local percentage=$(grep "Percentage affected:" "$t1_report" | awk '{print $3}')
-                    printf "%-6s | %12s | %22s | %8s\n" "$region" "$region_vol" "$abnormal_vol" "$percentage"
-                else
-                    printf "%-6s | %12s | %22s | %8s\n" "$region" "N/A" "N/A" "N/A"
-                fi
-            done
-        fi
-        
-        echo ""
-        echo "Analysis Parameters:"
-        echo "  Threshold multiplier: ${THRESHOLD_WM_SD_MULTIPLIER:-1.2}"
-        echo "  Minimum cluster size: ${MIN_HYPERINTENSITY_SIZE:-4} voxels"
-        echo "  FLAIR thresholding: mean + multiplier × std (above threshold)"
-        echo "  T1 thresholding: mean - multiplier × std (below threshold)"
-        
-    } > "$combined_report"
-    
-    log_formatted "SUCCESS" "Talairach hyperintensity analysis complete"
-    log_message "Combined summary: $combined_report"
-    log_message "Individual reports in: $hyper_dir"
-    
-    return 0
-}
-
-# Function to run comprehensive analysis (wrapper for analyze_talairach_hyperintensities)
-run_comprehensive_analysis() {
-    local orig_t1="$1"
-    local orig_flair="$2"
-    local t1_std="$3"
-    local flair_std="$4"
-    local segmentation_dir="$5"
-    local comprehensive_dir="$6"
-    
-    log_formatted "INFO" "===== RUNNING COMPREHENSIVE ANALYSIS ====="
-    log_message "Original T1: $orig_t1"
-    log_message "Original FLAIR: $orig_flair"
-    log_message "Standardized T1: $t1_std"
-    log_message "Standardized FLAIR: $flair_std"
-    log_message "Segmentation directory: $segmentation_dir"
-    log_message "Output directory: $comprehensive_dir"
-    
-    # Validate inputs
-    if [ ! -f "$orig_flair" ]; then
-        log_formatted "ERROR" "Original FLAIR file not found: $orig_flair"
-        return 1
-    fi
-    
-    if [ ! -d "$segmentation_dir" ]; then
-        log_formatted "ERROR" "Segmentation directory not found: $segmentation_dir"
-        return 1
-    fi
-    
-    # Create comprehensive analysis output directory
-    mkdir -p "$comprehensive_dir"
-    
-    # Find Talairach analysis directory with masks
-    local analysis_dir=""
-    local output_basename=""
-    
-    # Look for Talairach masks in multiple possible locations
-    local possible_dirs=(
-        "${comprehensive_dir}/original_space"
-        "${segmentation_dir}/detailed_brainstem"
-        "${segmentation_dir}/../comprehensive_analysis/original_space"
-    )
-    
-    # Create the original_space directory if it doesn't exist
-    mkdir -p "${comprehensive_dir}/original_space"
-    
-    for dir in "${possible_dirs[@]}"; do
-        if [ -d "$dir" ]; then
-            # Look for Talairach region files to determine the correct basename
-            local sample_files=($(find "$dir" -name "*_left_medulla*.nii.gz" -o -name "*_left_pons*.nii.gz" 2>/dev/null | head -2))
-            
-            if [ ${#sample_files[@]} -gt 0 ]; then
-                analysis_dir="$dir"
-                # Extract basename from first file (remove region suffix)
-                local sample_file=$(basename "${sample_files[0]}" .nii.gz)
-                output_basename=$(echo "$sample_file" | sed -E 's/_(left|right)_(medulla|pons|midbrain).*$//')
-                log_message "Found Talairach masks in: $analysis_dir"
-                log_message "Using output basename: $output_basename"
-                break
-            fi
-        fi
-    done
-    
-    # If no existing Talairach masks found, use original_space and derive basename from input
-    if [ -z "$analysis_dir" ]; then
-        analysis_dir="${comprehensive_dir}/original_space"
-        # Derive basename from FLAIR file (common approach)
-        local flair_basename=$(basename "$orig_flair" .nii.gz)
-        # Remove common suffixes to get clean basename
-        output_basename=$(echo "$flair_basename" | sed -E 's/_(brain|std|n4|FLAIR|flair).*$//' | sed -E 's/_[0-9]+$//')
-        
-        log_message "No existing Talairach masks found"
-        log_message "Will use analysis directory: $analysis_dir"
-        log_message "Will use output basename: $output_basename"
-        
-        # Check if we have any segmentation data to work with
-        local seg_files=($(find "$segmentation_dir" -name "*.nii.gz" 2>/dev/null))
-        if [ ${#seg_files[@]} -eq 0 ]; then
-            log_formatted "ERROR" "No segmentation files found in $segmentation_dir"
-            return 1
-        fi
-        
-        log_message "Found ${#seg_files[@]} segmentation files to analyze"
-    fi
-    
-    # Determine which FLAIR and T1 files to use for analysis
-    # For hyperintensity detection, original space is often preferred for native resolution
-    local analysis_flair="$orig_flair"
-    local analysis_t1="$orig_t1"
-    
-    # Check if we should use standardized versions based on mask location
-    if [[ "$analysis_dir" == *"standardized"* ]] || [[ "$analysis_dir" == *"std"* ]]; then
-        log_message "Analysis directory suggests standardized space, using standardized images"
-        analysis_flair="$flair_std"
-        analysis_t1="$t1_std"
-    fi
-    
-    log_message "Using FLAIR for analysis: $analysis_flair"
-    log_message "Using T1 for analysis: $analysis_t1"
-    
-    # Call the main Talairach hyperintensity analysis function
-    log_message "Running Talairach hyperintensity analysis..."
-    if analyze_talairach_hyperintensities "$analysis_flair" "$analysis_dir" "$output_basename" "$analysis_t1"; then
-        log_formatted "SUCCESS" "Comprehensive analysis completed successfully"
-        
-        # Create summary of results
-        local summary_file="${comprehensive_dir}/comprehensive_analysis_summary.txt"
-        {
-            echo "Comprehensive Analysis Summary"
-            echo "============================="
-            echo "Date: $(date)"
-            echo "Analysis directory: $analysis_dir"
-            echo "Output basename: $output_basename"
-            echo "FLAIR input: $(basename "$analysis_flair")"
-            echo "T1 input: $(basename "$analysis_t1")"
-            echo ""
-            echo "Analysis completed successfully."
-            echo "Results available in: ${comprehensive_dir}/hyperintensities/"
-            echo "Detailed reports in individual region subdirectories."
-        } > "$summary_file"
-        
-        # Create comprehensive FLAIR visualizations for all segmentations
-        log_message "Creating comprehensive FLAIR segmentation visualizations..."
-        create_comprehensive_flair_visualizations "$analysis_flair" "$analysis_dir" "${comprehensive_dir}/visualizations" "comprehensive_flair"
-        
-        log_message "Summary report created: $summary_file"
-        return 0
-    else
-        log_formatted "ERROR" "Talairach hyperintensity analysis failed"
-        return 1
-    fi
-}
+# DEPRECATED / REMOVED: Talairach intensity-abnormality analysis layer.
+#
+# analyze_region_modality(), analyze_talairach_hyperintensities() and the
+# analysis.sh wrapper run_comprehensive_analysis() (Talairach NAWM SD-threshold
+# over *_left_medulla*/*_pons* mask globs) were retired here. The live analysis
+# path now uses detect_hyperintensities() (FreeSurfer/multi-atlas
+# detailed_brainstem regions via find_all_atlas_regions + CSF/PV exclusion +
+# per-region GMM) as the PRIMARY engine, with run_comprehensive_analysis()
+# (enhanced_registration_validation.sh) as the guarded legacy fallback. No live
+# Talairach analysis capability remains.
 
 # Function to create comprehensive 3D visualization script using both fsleyes and freeview
 create_3d_visualization_script() {
@@ -2602,7 +2193,7 @@ fi
     # Look for brainstem segmentation masks
     log_message "Searching for segmentation overlays in $output_dir"
     
-    # Brainstem region masks (Talairach atlas)
+    # Brainstem region masks (FreeSurfer / multi-atlas substructures)
     local regions=("left_medulla" "right_medulla" "left_pons" "right_pons" "left_midbrain" "right_midbrain" "pons")
     for region in "${regions[@]}"; do
         # Look for region masks in various formats
@@ -2811,310 +2402,13 @@ EOF
     return 0
 }
 
-# Function to create comprehensive FLAIR segmentation visualizations
-create_comprehensive_flair_visualizations() {
-    local flair_file="$1"
-    local segmentation_dir="$2"
-    local output_dir="${3:-${segmentation_dir}/visualizations}"
-    local analysis_name="${4:-flair_comprehensive}"
-    
-    log_formatted "INFO" "===== COMPREHENSIVE FLAIR SEGMENTATION VISUALIZATION ====="
-    log_message "FLAIR input: $flair_file"
-    log_message "Segmentation directory: $segmentation_dir"
-    log_message "Output directory: $output_dir"
-    
-    # Validate inputs
-    if [ ! -f "$flair_file" ]; then
-        log_formatted "ERROR" "FLAIR file not found: $flair_file"
-        return 1
-    fi
-    
-    if [ ! -d "$segmentation_dir" ]; then
-        log_formatted "ERROR" "Segmentation directory not found: $segmentation_dir"
-        return 1
-    fi
-    
-    # Create output directory
-    mkdir -p "$output_dir"
-    
-    # Find all FLAIR-related segmentation files
-    log_message "Searching for FLAIR segmentation files..."
-    local flair_masks=()
-    local flair_intensities=()
-    
-    # Look for various types of FLAIR segmentation files
-    local search_patterns=(
-        "*flair*space*.nii.gz"
-        "*FLAIR*.nii.gz"
-        "*hyperintensit*.nii.gz"
-        "*_flair_*.nii.gz"
-        "*talairach*flair*.nii.gz"
-        "*medulla*.nii.gz"
-        "*pons*.nii.gz"
-        "*midbrain*.nii.gz"
-        "*left_medulla*.nii.gz"
-        "*right_medulla*.nii.gz"
-        "*left_pons*.nii.gz"
-        "*right_pons*.nii.gz"
-        "*left_midbrain*.nii.gz"
-        "*right_midbrain*.nii.gz"
-        "*brainstem*.nii.gz"
-        "*talairach*.nii.gz"
-    )
-    
-    for pattern in "${search_patterns[@]}"; do
-        while IFS= read -r -d '' file; do
-            if [[ "$file" == *"_intensity"* ]] || [[ "$file" == *"_clustered"* ]]; then
-                flair_intensities+=("$file")
-            else
-                flair_masks+=("$file")
-            fi
-        done < <(find "$segmentation_dir" -name "$pattern" -type f -print0 2>/dev/null)
-    done
-    
-    # Also search in comprehensive analysis and Talairach-specific directories
-    local additional_dirs=(
-        "${segmentation_dir}/../comprehensive_analysis"
-        "${segmentation_dir}/../segmentation/detailed_brainstem"
-        "${segmentation_dir}/detailed_brainstem"
-        "${segmentation_dir}/../talairach"
-        "${segmentation_dir}/talairach"
-        "${RESULTS_DIR}/comprehensive_analysis/original_space"
-        "${RESULTS_DIR}/segmentation/detailed_brainstem"
-        "${RESULTS_DIR}/talairach"
-    )
-    
-    for comp_dir in "${additional_dirs[@]}"; do
-        if [ -d "$comp_dir" ]; then
-            log_message "Searching Talairach directory: $comp_dir"
-            for pattern in "${search_patterns[@]}"; do
-                while IFS= read -r -d '' file; do
-                    if [[ "$file" == *"_intensity"* ]] || [[ "$file" == *"_clustered"* ]]; then
-                        flair_intensities+=("$file")
-                    else
-                        flair_masks+=("$file")
-                    fi
-                done < <(find "$comp_dir" -name "$pattern" -type f -print0 2>/dev/null)
-            done
-        fi
-    done
-    
-    # Remove duplicates and sort
-    if [ ${#flair_masks[@]} -gt 0 ]; then
-        readarray -t flair_masks < <(printf '%s\n' "${flair_masks[@]}" | sort -u)
-    fi
-    if [ ${#flair_intensities[@]} -gt 0 ]; then
-        readarray -t flair_intensities < <(printf '%s\n' "${flair_intensities[@]}" | sort -u)
-    fi
-    
-    log_message "Found ${#flair_masks[@]} FLAIR mask files"
-    log_message "Found ${#flair_intensities[@]} FLAIR intensity files"
-    
-    if [ ${#flair_masks[@]} -eq 0 ] && [ ${#flair_intensities[@]} -eq 0 ]; then
-        log_formatted "WARNING" "No FLAIR segmentation files found"
-        return 1
-    fi
-    
-    # Create comprehensive visualization script
-    local viz_script="${output_dir}/${analysis_name}_all_segmentations.sh"
-    cat > "$viz_script" << 'EOF'
-#!/usr/bin/env bash
-#
-# Comprehensive FLAIR Segmentation Visualization
-# Generated automatically for all FLAIR-related segmentations
-#
-
-echo "Starting comprehensive FLAIR segmentation visualization..."
-echo "This will show all FLAIR segmentations and analysis results"
-echo ""
-
-# Check available visualization tools
-FSLEYES_AVAILABLE=false
-FREEVIEW_AVAILABLE=false
-
-if command -v fsleyes &> /dev/null; then
-    FSLEYES_AVAILABLE=true
-fi
-
-if command -v freeview &> /dev/null; then
-    FREEVIEW_AVAILABLE=true
-fi
-
-if [ "$FSLEYES_AVAILABLE" = false ] && [ "$FREEVIEW_AVAILABLE" = false ]; then
-    echo "ERROR: No visualization tools found (fsleyes or freeview)"
-    exit 1
-fi
-
-echo "Available tools:"
-[ "$FSLEYES_AVAILABLE" = true ] && echo "  - FSLeyes (FSL)"
-[ "$FREEVIEW_AVAILABLE" = true ] && echo "  - FreeView (FreeSurfer)"
-echo ""
-
-# Choose visualization tool
-if [ "$FSLEYES_AVAILABLE" = true ]; then
-    echo "Using FSLeyes for comprehensive overlay visualization..."
-    VISUALIZATION_CMD="fsleyes"
-elif [ "$FREEVIEW_AVAILABLE" = true ]; then
-    echo "Using FreeView for visualization..."
-    VISUALIZATION_CMD="freeview -v"
-fi
-
-EOF
-
-    # Add FLAIR background
-    echo "# Add FLAIR background image" >> "$viz_script"
-    echo "VISUALIZATION_CMD=\"\$VISUALIZATION_CMD '$flair_file'\"" >> "$viz_script"
-    echo "echo \"Background: $(basename "$flair_file")\"" >> "$viz_script"
-    echo "" >> "$viz_script"
-    
-    # Add each mask file with appropriate colormap
-    local overlay_count=0
-    for mask in "${flair_masks[@]}"; do
-        if [ -f "$mask" ]; then
-            local basename_mask=$(basename "$mask" .nii.gz)
-            local colormap="random"
-            local alpha="50"
-            
-            # Choose appropriate colormap based on file type (enhanced for Talairach)
-            if [[ "$basename_mask" == *"hyperintens"* ]]; then
-                colormap="hot"
-                alpha="70"
-            elif [[ "$basename_mask" == *"hypointens"* ]]; then
-                colormap="cool"
-                alpha="70"
-            elif [[ "$basename_mask" == *"left_medulla"* ]]; then
-                colormap="red"
-                alpha="65"
-            elif [[ "$basename_mask" == *"right_medulla"* ]]; then
-                colormap="red-yellow"
-                alpha="65"
-            elif [[ "$basename_mask" == *"medulla"* ]]; then
-                colormap="red"
-                alpha="60"
-            elif [[ "$basename_mask" == *"left_pons"* ]]; then
-                colormap="blue"
-                alpha="65"
-            elif [[ "$basename_mask" == *"right_pons"* ]]; then
-                colormap="blue-lightblue"
-                alpha="65"
-            elif [[ "$basename_mask" == *"pons"* ]]; then
-                colormap="blue"
-                alpha="60"
-            elif [[ "$basename_mask" == *"left_midbrain"* ]]; then
-                colormap="green"
-                alpha="65"
-            elif [[ "$basename_mask" == *"right_midbrain"* ]]; then
-                colormap="green-blue"
-                alpha="65"
-            elif [[ "$basename_mask" == *"midbrain"* ]]; then
-                colormap="green"
-                alpha="60"
-            elif [[ "$basename_mask" == *"brainstem"* ]]; then
-                colormap="subcortical"
-                alpha="55"
-            elif [[ "$basename_mask" == *"talairach"* ]]; then
-                colormap="random"
-                alpha="50"
-            fi
-            
-            cat >> "$viz_script" << EOF
-# Add $(basename "$mask")
-if [ -f "$mask" ]; then
-    if [ "\$FSLEYES_AVAILABLE" = true ]; then
-        VISUALIZATION_CMD="\$VISUALIZATION_CMD '$mask' -cm $colormap -a $alpha"
-    else
-        VISUALIZATION_CMD="\$VISUALIZATION_CMD '$mask':colormap=$colormap:opacity=0.$alpha"
-    fi
-    echo "Added overlay: $(basename "$mask") (${colormap})"
-fi
-
-EOF
-            ((overlay_count++))
-        fi
-    done
-    
-    # Add intensity files
-    for intensity in "${flair_intensities[@]}"; do
-        if [ -f "$intensity" ]; then
-            cat >> "$viz_script" << EOF
-# Add $(basename "$intensity")
-if [ -f "$intensity" ]; then
-    if [ "\$FSLEYES_AVAILABLE" = true ]; then
-        VISUALIZATION_CMD="\$VISUALIZATION_CMD '$intensity' -cm hot -a 80"
-    else
-        VISUALIZATION_CMD="\$VISUALIZATION_CMD '$intensity':colormap=heat:opacity=0.8"
-    fi
-    echo "Added intensity overlay: $(basename "$intensity")"
-fi
-
-EOF
-            ((overlay_count++))
-        fi
-    done
-    
-    # Complete the script
-    cat >> "$viz_script" << 'EOF'
-# Launch visualization
-echo ""
-echo "Launching visualization with $overlay_count overlays..."
-echo "Command: $VISUALIZATION_CMD"
-echo ""
-echo "Visualization Controls:"
-if [ "$FSLEYES_AVAILABLE" = true ]; then
-    echo "  FSLeyes:"
-    echo "    - Mouse: Navigate through slices"
-    echo "    - Right-click overlays: Adjust properties"
-    echo "    - Checkboxes: Toggle overlay visibility"
-    echo "    - 3D button: Switch to volume rendering"
-else
-    echo "  FreeView:"
-    echo "    - Mouse: Rotate, pan, zoom"
-    echo "    - View menu: Change display options"
-    echo "    - Right-click: Context menu"
-fi
-echo ""
-
-# Execute visualization
-eval "$VISUALIZATION_CMD"
-EOF
-
-    chmod +x "$viz_script"
-    
-    # Create summary report
-    local summary="${output_dir}/${analysis_name}_visualization_summary.txt"
-    {
-        echo "Comprehensive FLAIR Segmentation Visualization Summary"
-        echo "====================================================="
-        echo "Generated: $(date)"
-        echo "FLAIR input: $(basename "$flair_file")"
-        echo "Segmentation directory: $segmentation_dir"
-        echo ""
-        echo "Files included in visualization:"
-        echo "--------------------------------"
-        echo "Total overlays: $overlay_count"
-        echo ""
-        echo "Mask files (${#flair_masks[@]}):"
-        for mask in "${flair_masks[@]}"; do
-            echo "  - $(basename "$mask")"
-        done
-        echo ""
-        echo "Intensity files (${#flair_intensities[@]}):"
-        for intensity in "${flair_intensities[@]}"; do
-            echo "  - $(basename "$intensity")"
-        done
-        echo ""
-        echo "To view: ./${analysis_name}_all_segmentations.sh"
-    } > "$summary"
-    
-    log_formatted "SUCCESS" "Comprehensive FLAIR visualization created"
-    log_message "Visualization script: $viz_script"
-    log_message "Summary report: $summary"
-    log_message "Total overlays: $overlay_count"
-    
-    return 0
-}
+# REMOVED: create_comprehensive_flair_visualizations() — an orphaned visualization
+# helper whose only caller was the retired Talairach run_comprehensive_analysis()
+# wrapper. It carried *talairach* mask globs; deleted with the Talairach layer.
 
 # Export functions
+export -f _analysis_same_space
+export -f _analysis_world_matrix
 export -f detect_hyperintensities
 export -f create_supratentorial_mask
 export -f find_all_atlas_regions
@@ -3134,9 +2428,6 @@ export -f create_multi_threshold_comparison
 export -f create_3d_rendering
 export -f create_intensity_profiles
 export -f transform_segmentation_to_original
-export -f analyze_talairach_hyperintensities
-export -f run_comprehensive_analysis
 export -f create_3d_visualization_script
-export -f create_comprehensive_flair_visualizations
 
 log_message "Analysis module loaded with enhanced regional adaptive thresholding"

--- a/src/modules/dicom_cluster_mapping.sh
+++ b/src/modules/dicom_cluster_mapping.sh
@@ -283,9 +283,15 @@ match_clusters_to_dicom_files() {
                 local image_position=$(dcmdump "$dicom_file" 2>/dev/null | grep "ImagePositionPatient" | head -1 | sed 's/.*\[\(.*\)\].*/\1/' || echo "")
                 
                 if [ -n "$slice_location" ] || [ -n "$image_position" ]; then
-                    local pos_x=$(echo "$image_position" | cut -d'\\' -f1 || echo "0")
-                    local pos_y=$(echo "$image_position" | cut -d'\\' -f2 || echo "0")
-                    local pos_z=$(echo "$image_position" | cut -d'\\' -f3 || echo "$slice_location")
+                    # DICOM ImagePositionPatient is backslash-separated (e.g.
+                    # "-12.3\45.6\-78.9"). `cut -d'\\'` is INVALID — cut requires a
+                    # single-character delimiter and '\\' expands to two chars, so
+                    # cut errors and every coordinate silently became "0". Use awk,
+                    # whose -F field separator accepts the backslash regex '\\'.
+                    local pos_x pos_y pos_z
+                    pos_x=$(echo "$image_position" | awk -F'\\\\' '{print $1}'); pos_x="${pos_x:-0}"
+                    pos_y=$(echo "$image_position" | awk -F'\\\\' '{print $2}'); pos_y="${pos_y:-0}"
+                    pos_z=$(echo "$image_position" | awk -F'\\\\' '{print $3}'); pos_z="${pos_z:-$slice_location}"
                     
                     echo "$(basename "$dicom_file") $slice_location $pos_x $pos_y $pos_z" >> "$dicom_slices"
                 fi

--- a/src/modules/enhanced_registration_validation.sh
+++ b/src/modules/enhanced_registration_validation.sh
@@ -45,35 +45,9 @@ ensure_safe_fslmaths() {
     return 0
 }
 
-# Function to ensure analysis module is available
-ensure_analysis_module() {
-    if ! declare -f analyze_talairach_hyperintensities >/dev/null 2>&1; then
-        log_formatted "WARNING" "analyze_talairach_hyperintensities function not available, attempting to source analysis.sh"
-        
-        # Try to find and source analysis.sh
-        local analysis_paths=(
-            "$(dirname "${BASH_SOURCE[0]}")/analysis.sh"
-            "${SCRIPT_DIR}/modules/analysis.sh"
-            "./src/modules/analysis.sh"
-            "../src/modules/analysis.sh"
-        )
-        
-        for analysis_path in "${analysis_paths[@]}"; do
-            if [ -f "$analysis_path" ]; then
-                log_message "Found analysis.sh at: $analysis_path"
-                source "$analysis_path"
-                if declare -f analyze_talairach_hyperintensities >/dev/null 2>&1; then
-                    log_formatted "SUCCESS" "analyze_talairach_hyperintensities function loaded successfully"
-                    return 0
-                fi
-            fi
-        done
-        
-        log_formatted "WARNING" "Could not load analyze_talairach_hyperintensities function"
-        return 1
-    fi
-    return 0
-}
+# NOTE: ensure_analysis_module() was removed alongside the retired Talairach
+# analysis layer (it existed only to lazily source analyze_talairach_hyperintensities,
+# which no longer exists). analysis.sh is sourced by pipeline.sh before this module.
 
 # Emergency path validation function
 emergency_validate_paths() {
@@ -591,7 +565,7 @@ analyze_hyperintensities_in_all_masks() {
     local t1_file="$2"           # T1 image in standard space
     local segmentation_dir="$3"  # Directory containing segmentation masks
     local output_dir="$4"        # Output directory
-    local threshold="${5:-${THRESHOLD_WM_SD_MULTIPLIER:-1.5}}"  # Use config threshold or default to 1.25 SD above mean
+    local threshold="${5:-${THRESHOLD_WM_SD_MULTIPLIER:-1.2}}"  # Use config threshold; falls back to the authoritative 1.2 SD multiplier
     
     log_formatted "INFO" "===== ANALYZING HYPERINTENSITIES IN ALL SEGMENTATION MASKS ====="
     log_message "FLAIR: $flair_file"
@@ -643,7 +617,7 @@ analyze_hyperintensities_in_all_masks() {
         log_formatted "WARNING" "No pons mask found with standardized naming (*pons_mask_orig.nii.gz or *pons_mask_flair_space.nii.gz) in $segmentation_dir"
     fi
     
-    # Talairach detailed brainstem subdivisions - STANDARDIZED NAMING ONLY
+    # FreeSurfer / multi-atlas brainstem subdivisions - STANDARDIZED NAMING ONLY
     local detailed_regions=("left_medulla" "right_medulla" "left_pons" "right_pons" "left_midbrain" "right_midbrain")
     
     for region in "${detailed_regions[@]}"; do
@@ -666,16 +640,8 @@ analyze_hyperintensities_in_all_masks() {
         fi
     done
     
-    # Talairach atlas - STANDARDIZED NAMING ONLY
-    local talairach_mask=$(find "$segmentation_dir" -name "*talairach_mask_orig.nii.gz" | head -1)
-    if [ -f "$talairach_mask" ]; then
-        log_message "Found Talairach atlas mask: $talairach_mask"
-        mask_files+=("$talairach_mask")
-        mask_names+=("talairach")
-    else
-        log_formatted "WARNING" "No Talairach atlas mask found with standardized naming (*talairach_mask_orig.nii.gz) in $segmentation_dir"
-    fi
-    
+    # (Talairach atlas mask discovery retired — no live Talairach analysis remains.)
+
     # Gold standard - STANDARDIZED NAMING ONLY
     local gold_mask=$(find "$segmentation_dir" -name "*gold_mask_orig.nii.gz" | head -1)
     if [ -f "$gold_mask" ]; then
@@ -1746,39 +1712,16 @@ run_comprehensive_analysis() {
     log_message "Step 5: Analyzing hyperintensities in all masks using standardized FLAIR..."
     analyze_hyperintensities_in_all_masks "$flair_std" "$t1_std" "$orig_space_dir" "${output_dir}/hyperintensities"
     
-    # 6. Analyze hyperintensities in Talairach brainstem regions
-    log_message "Step 6: Analyzing hyperintensities in Talairach brainstem regions..."
-    
-    # Ensure analysis module is loaded and check if the analyze_talairach_hyperintensities function is available
-    if ensure_analysis_module && declare -f analyze_talairach_hyperintensities >/dev/null 2>&1; then
-        # Check if Talairach analysis files exist
-        if [ -d "${RESULTS_DIR}/comprehensive_analysis/original_space" ]; then
-            # Find the appropriate output basename for Talairach files
-            local talairach_basename=""
-            for basename_candidate in $(find "${RESULTS_DIR}/comprehensive_analysis/original_space" -name "*_left_medulla_flair_space.nii.gz" | head -1 | xargs basename 2>/dev/null | sed 's/_left_medulla_flair_space.nii.gz//' 2>/dev/null || echo ""); do
-                if [ -n "$basename_candidate" ]; then
-                    talairach_basename="$basename_candidate"
-                    break
-                fi
-            done
-            
-            if [ -n "$talairach_basename" ]; then
-                log_message "Found Talairach segmentation with basename: $talairach_basename"
-                analyze_talairach_hyperintensities "$flair_std" "${RESULTS_DIR}/comprehensive_analysis/original_space" "$talairach_basename" "$t1_std"
-            else
-                log_message "No Talairach segmentation files found - skipping Talairach hyperintensity analysis"
-            fi
-        else
-            log_message "No original space directory found - skipping Talairach hyperintensity analysis"
-        fi
-    else
-        log_message "Talairach hyperintensity analysis function not available - ensure analysis module is loaded"
-    fi
-    
+    # 6. (Retired) Talairach brainstem hyperintensity hunt.
+    # The dedicated Talairach analysis layer (analyze_talairach_hyperintensities)
+    # has been removed; the modern detect_hyperintensities() engine in
+    # analysis.sh now covers brainstem substructures (FreeSurfer / multi-atlas
+    # detailed_brainstem) with CSF/PV exclusion + per-region GMM as the live path.
+
     # 7. Create combined visualization
     log_message "Step 7: Creating combined visualization..."
     # This is done inside analyze_hyperintensities_in_all_masks
-    
+
     log_formatted "SUCCESS" "Comprehensive validation and analysis complete"
     log_message "Results available in: $output_dir"
     
@@ -1918,6 +1861,5 @@ verify_pipeline_step_outputs() {
 # Export verification function
 export -f verify_pipeline_step_outputs
 export -f emergency_validate_paths
-export -f ensure_analysis_module
 
 log_message "Enhanced registration validation module loaded with coordinate space validation"

--- a/src/pipeline.sh
+++ b/src/pipeline.sh
@@ -130,6 +130,21 @@ fi
 
 #source src/modules/extract_dicom_metadata.py
 
+# Locate the binary hyperintensity mask produced by run_comprehensive_analysis
+# (legacy/fallback engine).  Prefers harvard_brainstem, then pons, then any.
+# Echoes the path (empty if none found).
+_find_comprehensive_hyperintensity_mask() {
+  local comprehensive_dir="$1"
+  local m="${comprehensive_dir}/hyperintensities/harvard_brainstem/hyperintensities_bin.nii.gz"
+  if [ ! -f "$m" ]; then
+    m="${comprehensive_dir}/hyperintensities/pons/hyperintensities_bin.nii.gz"
+  fi
+  if [ ! -f "$m" ]; then
+    m=$(find "${comprehensive_dir}/hyperintensities" -name "hyperintensities_bin.nii.gz" 2>/dev/null | head -1)
+  fi
+  [ -n "$m" ] && [ -f "$m" ] && echo "$m"
+}
+
 # Load configuration file
 load_config() {
   local config_file="$1"
@@ -1093,58 +1108,164 @@ run_pipeline() {
     
     log_message "Using registered FLAIR: $flair_registered"
     
-    # Run comprehensive analysis instead of just dorsal pons hyperintensity detection
-    # This analyzes ALL segmentation masks and validates registration
+    # Hyperintensity analysis (Step 6 core).
+    #
+    # PRIMARY (default, ANALYSIS_PRIMARY_ENGINE=detect_hyperintensities):
+    #   detect_hyperintensities() (analysis.sh) discovers the FreeSurfer
+    #   brainstem substructures + multi-atlas nuclei under
+    #   segmentation/detailed_brainstem (find_all_atlas_regions), applies the
+    #   CSF/partial-volume exclusion (#114) and the per-region GMM thresholding
+    #   engine.  This is what a normal run uses.
+    # FALLBACK (ANALYSIS_PRIMARY_ENGINE=comprehensive, or automatic when the
+    #   primary engine fails): run_comprehensive_analysis() (the legacy NAWM
+    #   SD-threshold path) — kept for backward compatibility and as a safety net.
     local comprehensive_dir=$(create_module_dir "comprehensive_analysis")
-    
-    log_formatted "INFO" "===== RUNNING COMPREHENSIVE ANALYSIS ====="
-    log_message "This will analyze hyperintensities in ALL segmentation masks"
-    log_message "and validate registration quality across spaces"
-    
-    # Pass all relevant images and directories to the comprehensive analysis
-    run_comprehensive_analysis \
-      "$orig_t1" \
-      "$orig_flair" \
-      "$t1_std" \
-      "$flair_std" \
-      "$RESULTS_DIR/segmentation" \
-      "$comprehensive_dir"
-    
-    # For backward compatibility, create a link to the traditional hyperintensity mask
     local hyperintensities_dir=$(create_module_dir "hyperintensities")
-    # Look for hyperintensity mask — harvard_brainstem preferred, then pons, then any
-    local hyperintensity_mask="${comprehensive_dir}/hyperintensities/harvard_brainstem/hyperintensities_bin.nii.gz"
-    if [ ! -f "$hyperintensity_mask" ]; then
-      hyperintensity_mask="${comprehensive_dir}/hyperintensities/pons/hyperintensities_bin.nii.gz"
-    fi
-    if [ ! -f "$hyperintensity_mask" ]; then
-      hyperintensity_mask=$(find "${comprehensive_dir}/hyperintensities" -name "hyperintensities_bin.nii.gz" 2>/dev/null | head -1)
-    fi
-    
-    if [ -f "$hyperintensity_mask" ]; then
-      local seg_basename=$(basename "$seg_mask" .nii.gz | sed 's/_brainstem$//')
-      local legacy_mask="${hyperintensities_dir}/${seg_basename}_brainstem_thresh${THRESHOLD_WM_SD_MULTIPLIER:-1.25}_bin.nii.gz"
-      ln -sf "$hyperintensity_mask" "$legacy_mask"
-      log_message "Created link to comprehensive analysis result: $legacy_mask"
-    else
-      log_formatted "WARNING" "Comprehensive analysis didn't produce expected hyperintensity mask"
-      log_message "Falling back to traditional hyperintensity detection using brainstem mask..."
+    local seg_basename=$(basename "$seg_mask" .nii.gz | sed 's/_brainstem$//')
+    local hyperintensity_mask=""
 
-      local seg_basename=$(basename "$seg_mask" .nii.gz | sed 's/_brainstem$//')
+    local primary_engine="${ANALYSIS_PRIMARY_ENGINE:-detect_hyperintensities}"
+    log_formatted "INFO" "===== STEP 6: HYPERINTENSITY ANALYSIS (primary engine: ${primary_engine}) ====="
+
+    if [ "$primary_engine" = "detect_hyperintensities" ]; then
+      # --- PRIMARY: modern per-region GMM + CSF/PV engine -------------------
+      log_message "Running detect_hyperintensities (FS/multi-atlas detailed_brainstem + CSF/PV + per-region GMM)..."
       local hyperintensities_prefix="${hyperintensities_dir}/${seg_basename}_brainstem"
-      detect_hyperintensities "$orig_flair" "$hyperintensities_prefix" "$orig_t1"
-      hyperintensity_mask="${hyperintensities_prefix}_thresh${THRESHOLD_WM_SD_MULTIPLIER:-1.25}_bin.nii.gz"
-      analyze_hyperintensity_clusters "$hyperintensity_mask" "$seg_orig" "$orig_t1" "${hyperintensities_dir}/clusters" 5
+      if detect_hyperintensities "$orig_flair" "$hyperintensities_prefix" "$orig_t1"; then
+        # detect_hyperintensities emits the binary mask as *_threshATLAS_GMM_bin.nii.gz
+        hyperintensity_mask="${hyperintensities_prefix}_threshATLAS_GMM_bin.nii.gz"
+        if [ ! -f "$hyperintensity_mask" ]; then
+          # tolerate any thresh*_bin produced by a config-driven fallback inside the engine
+          hyperintensity_mask=$(find "$hyperintensities_dir" -name "${seg_basename}_brainstem_thresh*_bin.nii.gz" 2>/dev/null | head -1)
+        fi
+        if [ -n "$hyperintensity_mask" ] && [ -f "$hyperintensity_mask" ]; then
+          log_formatted "SUCCESS" "Primary analysis (detect_hyperintensities) produced: $hyperintensity_mask"
+          analyze_hyperintensity_clusters "$hyperintensity_mask" "$seg_orig" "$orig_t1" "${hyperintensities_dir}/clusters" 5 || \
+            log_formatted "WARNING" "Cluster analysis reported a non-fatal failure"
+        else
+          log_formatted "WARNING" "detect_hyperintensities returned success but no mask found; falling back to comprehensive analysis"
+        fi
+      else
+        log_formatted "WARNING" "detect_hyperintensities failed; falling back to comprehensive analysis"
+      fi
+
+      # Automatic fallback to the legacy engine if the primary produced nothing.
+      if [ -z "$hyperintensity_mask" ] || [ ! -f "$hyperintensity_mask" ]; then
+        log_formatted "INFO" "===== FALLBACK: COMPREHENSIVE ANALYSIS ====="
+        run_comprehensive_analysis \
+          "$orig_t1" "$orig_flair" "$t1_std" "$flair_std" \
+          "$RESULTS_DIR/segmentation" "$comprehensive_dir" || \
+          log_formatted "WARNING" "Comprehensive (fallback) analysis reported a non-fatal failure"
+        hyperintensity_mask=$(_find_comprehensive_hyperintensity_mask "$comprehensive_dir" || true)
+        if [ -n "$hyperintensity_mask" ] && [ -f "$hyperintensity_mask" ]; then
+          local legacy_mask="${hyperintensities_dir}/${seg_basename}_brainstem_threshATLAS_GMM_bin.nii.gz"
+          ln -sf "$hyperintensity_mask" "$legacy_mask"
+          log_message "Linked comprehensive fallback result: $legacy_mask"
+        fi
+      fi
+    else
+      # --- PRIMARY: legacy comprehensive analysis (config opt-in) -----------
+      log_formatted "INFO" "===== RUNNING COMPREHENSIVE ANALYSIS (legacy primary) ====="
+      log_message "This analyzes hyperintensities in ALL segmentation masks and validates registration"
+      run_comprehensive_analysis \
+        "$orig_t1" "$orig_flair" "$t1_std" "$flair_std" \
+        "$RESULTS_DIR/segmentation" "$comprehensive_dir" || \
+        log_formatted "WARNING" "Comprehensive analysis reported a non-fatal failure"
+      hyperintensity_mask=$(_find_comprehensive_hyperintensity_mask "$comprehensive_dir" || true)
+
+      if [ -n "$hyperintensity_mask" ] && [ -f "$hyperintensity_mask" ]; then
+        local legacy_mask="${hyperintensities_dir}/${seg_basename}_brainstem_threshATLAS_GMM_bin.nii.gz"
+        ln -sf "$hyperintensity_mask" "$legacy_mask"
+        log_message "Created link to comprehensive analysis result: $legacy_mask"
+      else
+        log_formatted "WARNING" "Comprehensive analysis produced no mask; falling back to detect_hyperintensities"
+        local hyperintensities_prefix="${hyperintensities_dir}/${seg_basename}_brainstem"
+        if detect_hyperintensities "$orig_flair" "$hyperintensities_prefix" "$orig_t1"; then
+          hyperintensity_mask="${hyperintensities_prefix}_threshATLAS_GMM_bin.nii.gz"
+          [ -f "$hyperintensity_mask" ] || hyperintensity_mask=$(find "$hyperintensities_dir" -name "${seg_basename}_brainstem_thresh*_bin.nii.gz" 2>/dev/null | head -1)
+          if [ -n "$hyperintensity_mask" ] && [ -f "$hyperintensity_mask" ]; then
+            analyze_hyperintensity_clusters "$hyperintensity_mask" "$seg_orig" "$orig_t1" "${hyperintensities_dir}/clusters" 5 || \
+              log_formatted "WARNING" "Cluster analysis reported a non-fatal failure"
+          fi
+        fi
+      fi
     fi
-    
-    # NEW: DICOM Cluster Mapping Integration
+
+    # --- Optional WMH / nuclei modules (each self-gated; default OFF) -------
+    # Every run_* below no-ops unless its *_ENABLED flag is "true", so default
+    # behaviour is unchanged. Outputs land under analysis/wmh/<tool>.
+    local wmh_out_dir="${RESULTS_DIR}/analysis/wmh"
+    mkdir -p "$wmh_out_dir"
+    if declare -f run_bianca_wmh >/dev/null 2>&1; then
+      run_bianca_wmh "$flair_std" "${wmh_out_dir}/bianca" "$t1_std" "" || \
+        log_formatted "WARNING" "run_bianca_wmh reported a non-fatal failure"
+    fi
+    if declare -f run_supervised_wmh_lst_samseg >/dev/null 2>&1; then
+      run_supervised_wmh_lst_samseg "$orig_flair" "$orig_t1" "${wmh_out_dir}/lst_samseg" || \
+        log_formatted "WARNING" "run_supervised_wmh_lst_samseg reported a non-fatal failure"
+    fi
+    if declare -f run_wmh_synthseg >/dev/null 2>&1; then
+      run_wmh_synthseg "$orig_flair" "${wmh_out_dir}/synthseg" || \
+        log_formatted "WARNING" "run_wmh_synthseg reported a non-fatal failure"
+    fi
+    if declare -f run_segcsvd_wmh >/dev/null 2>&1; then
+      run_segcsvd_wmh "$orig_flair" "$orig_t1" "${wmh_out_dir}/segcsvd" || \
+        log_formatted "WARNING" "run_segcsvd_wmh reported a non-fatal failure"
+    fi
+    if declare -f run_shiva_wmh >/dev/null 2>&1; then
+      run_shiva_wmh "$orig_flair" "$orig_t1" "${wmh_out_dir}/shiva" || \
+        log_formatted "WARNING" "run_shiva_wmh reported a non-fatal failure"
+    fi
+    if declare -f run_mars_wmh >/dev/null 2>&1; then
+      run_mars_wmh "$orig_flair" "$orig_t1" "${wmh_out_dir}/mars" || \
+        log_formatted "WARNING" "run_mars_wmh reported a non-fatal failure"
+    fi
+    if declare -f run_aanseg >/dev/null 2>&1; then
+      run_aanseg "$orig_t1" "$SUBJECT_ID" "$seg_mask" "${RESULTS_DIR}/analysis/aanseg" || \
+        log_formatted "WARNING" "run_aanseg reported a non-fatal failure"
+    fi
+
+    # --- Post-detection false-positive filter (self-gated; default OFF) -----
+    # Operates on the detected lesion mask. No-op (pass-through) unless
+    # FP_FILTER_ENABLED=true, so default behaviour is unchanged.
+    if declare -f run_fp_filter >/dev/null 2>&1 && [ -n "$hyperintensity_mask" ] && [ -f "$hyperintensity_mask" ]; then
+      # CSF probability map written by detect_hyperintensities (FSL FAST PVE 0).
+      # `|| true` keeps a transient find failure from aborting under set -e.
+      local fp_csf_prob=""
+      fp_csf_prob=$(find "$hyperintensities_dir" -name "*_csf_prob.nii.gz" 2>/dev/null | head -1 || true)
+      # Whole-brain mask for the brain-edge erosion stage. Prefer the brain mask
+      # detect_hyperintensities emitted (already in the lesion mask's space);
+      # fall back to the brain-extraction mask. NOT the brainstem segmentation
+      # ($seg_orig) — eroding that would delete legitimate brainstem-edge lesions.
+      local fp_brain_mask=""
+      fp_brain_mask=$(find "$hyperintensities_dir" -name "*_brain_mask.nii.gz" 2>/dev/null | head -1 || true)
+      if [ -z "$fp_brain_mask" ]; then
+        fp_brain_mask=$(find "${RESULTS_DIR}/brain_extraction" -iname "*BrainExtractionMask.nii.gz" 2>/dev/null | head -1 || true)
+      fi
+      local fp_filtered="${hyperintensity_mask%.nii.gz}_fpfiltered.nii.gz"
+      if run_fp_filter "$hyperintensity_mask" "$fp_filtered" "$fp_brain_mask" "$fp_csf_prob"; then
+        if [ "${FP_FILTER_ENABLED:-false}" = "true" ] && [ -f "$fp_filtered" ]; then
+          log_message "FP filter applied; using filtered lesion mask: $fp_filtered"
+          hyperintensity_mask="$fp_filtered"
+        fi
+      else
+        log_formatted "WARNING" "run_fp_filter reported a non-fatal failure"
+      fi
+    fi
+
+    # DICOM Cluster Mapping Integration (STOPGAP: gated OFF by default).
+    # The cluster-to-DICOM coordinate mapping stage is known-broken and pending a
+    # separate rewrite, so it is skipped unless RUN_DICOM_MAPPING=true.
+    if [ "${RUN_DICOM_MAPPING:-false}" != "true" ]; then
+      log_formatted "INFO" "Skipping DICOM cluster mapping (RUN_DICOM_MAPPING != true; stage pending rewrite)"
+    else
     log_formatted "INFO" "===== MAPPING CLUSTERS TO DICOM SPACE ====="
     log_message "Performing cluster-to-DICOM coordinate mapping for medical viewer compatibility"
-    
+
     # Create DICOM mapping directory
     local dicom_mapping_dir="${RESULTS_DIR}/dicom_cluster_mapping"
     mkdir -p "$dicom_mapping_dir"
-    
+
     # Find cluster analysis results — check comprehensive analysis first, then legacy
     local cluster_analysis_dir="${comprehensive_dir}/hyperintensities/harvard_brainstem/cluster_analysis"
     if [ ! -d "$cluster_analysis_dir" ]; then
@@ -1189,7 +1310,8 @@ run_pipeline() {
       log_formatted "WARNING" "Cluster analysis directory not found - skipping DICOM mapping"
       log_message "Expected cluster analysis at: $cluster_analysis_dir"
     fi
-    
+    fi  # end RUN_DICOM_MAPPING gate
+
     # Validate hyperintensity detection using the known output path
     if [ ! -f "$hyperintensity_mask" ]; then
       log_error "Hyperintensity mask missing: $hyperintensity_mask" $ERR_VALIDATION
@@ -1268,14 +1390,25 @@ run_pipeline() {
     local pons_mask=""
     local flair_file=""
     
-    # Look for hyperintensity mask in comprehensive analysis results first
-    if [ -d "${RESULTS_DIR}/comprehensive_analysis/hyperintensities" ]; then
-      hyperintensity_mask=$(find "${RESULTS_DIR}/comprehensive_analysis/hyperintensities" -name "*hyperintensities_bin.nii.gz" | head -1)
+    # Prefer the final lesion mask from the primary engine (detect_hyperintensities):
+    # the FP-filtered variant first, then the canonical ATLAS_GMM binary mask. Only
+    # then fall back to the comprehensive engine's mask and finally to any *_bin
+    # (the generic glob can otherwise pick an intermediate like a region/brain mask).
+    if [ -d "${RESULTS_DIR}/hyperintensities" ]; then
+      hyperintensity_mask=$(find "${RESULTS_DIR}/hyperintensities" -name "*_threshATLAS_GMM_bin_fpfiltered.nii.gz" 2>/dev/null | head -1)
+      if [ -z "$hyperintensity_mask" ]; then
+        hyperintensity_mask=$(find "${RESULTS_DIR}/hyperintensities" -name "*_threshATLAS_GMM_bin.nii.gz" 2>/dev/null | head -1)
+      fi
     fi
-    
-    # Fallback to traditional hyperintensities directory
+
+    # Comprehensive (legacy/fallback) engine result.
+    if [ -z "$hyperintensity_mask" ] && [ -d "${RESULTS_DIR}/comprehensive_analysis/hyperintensities" ]; then
+      hyperintensity_mask=$(find "${RESULTS_DIR}/comprehensive_analysis/hyperintensities" -name "*hyperintensities_bin.nii.gz" 2>/dev/null | head -1)
+    fi
+
+    # Last-resort generic fallback.
     if [ -z "$hyperintensity_mask" ] && [ -d "${RESULTS_DIR}/hyperintensities" ]; then
-      hyperintensity_mask=$(find "${RESULTS_DIR}/hyperintensities" -name "*_bin.nii.gz" | head -1)
+      hyperintensity_mask=$(find "${RESULTS_DIR}/hyperintensities" -name "*_bin.nii.gz" 2>/dev/null | head -1)
     fi
     
     # Find pons mask


### PR DESCRIPTION
## What & why

Previously `pipeline.sh` ran `run_comprehensive_analysis` (in
`enhanced_registration_validation.sh`, sourced LAST so it shadowed the
`analysis.sh` copy) as the PRIMARY Step-6 analysis, with `detect_hyperintensities`
only as a fallback. That primary path searched `$RESULTS_DIR/segmentation` for
**Talairach-style** mask names and had **0 references to `detailed_brainstem`**.
Result: the FreeSurfer brainstem substructures, multi-atlas nuclei, CSF/PV
exclusion (#114), and per-region GMM never ran in normal execution; the 9 optional
WMH `run_*` modules were sourced but never dispatched; and the Talairach analysis
layer was dead-but-live.

This PR re-routes the live path, dispatches the optional modules, retires the dead
Talairach layer, folds in analysis-layer review fixes, and adds a stopgap for the
broken DICOM mapping stage. **One PR.** Core analysis behaviour changes, so a
config-gated fallback is preserved and the default stays predictable.

## Traces (as requested)

### (a) With FS/multi-atlas masks present, the live path now reads `detailed_brainstem` and runs CSF/PV + per-region GMM
- New `ANALYSIS_PRIMARY_ENGINE` (default `detect_hyperintensities`) selects the
  PRIMARY engine in `pipeline.sh` Step 6.
- `detect_hyperintensities` (analysis.sh) -> `find_all_atlas_regions` searches
  `${RESULTS_DIR}/segmentation/detailed_brainstem` (where `brainstem_freesurfer.sh`
  and `multi_atlas.sh` write parcels) -> `apply_per_region_gmm_analysis` ->
  per-region CSF/PV exclusion (`build_csf_exclusion_mask` / `apply_csf_pv_exclusion`)
  + per-region GMM (`gmm_threshold.py`). Output binary mask:
  `<prefix>_threshATLAS_GMM_bin.nii.gz`.
- `run_comprehensive_analysis` (the legacy NAWM/SD-threshold engine, Talairach
  globs) is retained as a **guarded fallback**: auto-invoked when the primary
  yields no mask, or used as primary when `ANALYSIS_PRIMARY_ENGINE=comprehensive`
  (which then falls back to `detect_hyperintensities`). A run never aborts purely
  on engine choice.

### (b) Enabling a `WMH_*_ENABLED` flag now actually invokes the module
The analysis stage dispatches each module (each self-gated; all default OFF, so
default behaviour is unchanged):
`WMH_BIANCA_ENABLED`->`run_bianca_wmh`,
`WMH_LSTAI_ENABLED`/`WMH_SAMSEG_ENABLED`->`run_supervised_wmh_lst_samseg`,
`WMH_SYNTHSEG_ENABLED`->`run_wmh_synthseg`,
`WMH_SEGCSVD_ENABLED`->`run_segcsvd_wmh`,
`WMH_SHIVA_ENABLED`->`run_shiva_wmh`,
`WMH_MARS_ENABLED`->`run_mars_wmh`,
`BRAINSTEM_AANSEG_ENABLED`->`run_aanseg`,
`FP_FILTER_ENABLED`->`run_fp_filter` (post-detection, on the lesion mask).
Arg order follows each module header's documented hook.

### (c) No live Talairach analysis remains
Removed `analyze_talairach_hyperintensities()`, `analyze_region_modality()`, the
shadowed `analysis.sh` `run_comprehensive_analysis()` wrapper, the orphaned
`create_comprehensive_flair_visualizations()` (carried talairach globs),
`ensure_analysis_module()`, the evrv "Step 6" Talairach hunt, and the talairach
atlas mask glob. `git grep -n talairach -- src/` shows only comments / a
deprecated stub (`extract_brainstem_talairach`) / legit FreeSurfer "talairach
transform" references — no live capability.

### (d) DICOM stage is gated off
`RUN_DICOM_MAPPING=false` added; the cluster-to-DICOM stage in `pipeline.sh` is
skipped unless set true (pending a separate rewrite). Also fixed the
`cut -d'\\'` bad-delimiter bug (`cut` requires a single-char delimiter; `'\\'`
is two chars) -> `awk -F'\\\\'`, so `ImagePositionPatient` x/y/z parse correctly.

## Analysis-layer review fixes
- CSF->FLAIR and region/brain-mask resamples: `flirt -applyxfm -usesqform`
  (header transform) instead of `-dof 6`.
- New `_analysis_same_space()` compares dim + pixdim + sform/qform (not dims
  alone) and is conservative: when the world transform can't be confirmed it
  forces a safe header resample, preventing silent mask misalignment.
- evrv fallback SD multiplier `1.5` -> `1.2` (+ corrected comment).

## Robustness (from code-review)
- Default `ATLAS_GMM_RESULT` under `set -u` and reset it per subject, so the
  now-default engine can't hard-abort when no region succeeds.
- Pass the whole-brain mask (not the brainstem seg) to `run_fp_filter`'s
  brain-edge erosion stage; guard command substitutions against `set -e`.
- Advanced-visualization mask lookup now prefers the canonical final lesion mask
  over an arbitrary `*_bin` intermediate.

## Verification
- `git ls-files '*.sh' | xargs -I{} bash -n {}` — clean
- `shellcheck --severity=error` on all changed files — clean
- `test_environment_unit` (100), `test_pipeline_control_unit` (98),
  `test_import_unit` (29), `test_multi_atlas_unit` (22) — all 100%
- `uv run pytest tests/ -v` — 27 passed
- `pipeline.sh --help` smoke — OK

🤖 Generated with [Claude Code](https://claude.com/claude-code)