### PR TITLE
Contrast-matched cascaded registration: T1→FLAIR→DWI/T2/SWI with composed transforms

### DIFF
--- a/config/default_config.sh
+++ b/config/default_config.sh
@@ -307,6 +307,55 @@ export REG_WINSORIZE_UPPER=0.995        # Upper winsorize quantile
 # (anti-aliased, preserves discrete values); continuous intensity images keep Linear.
 export REG_LABEL_INTERPOLATION="GenericLabel"
 
+# ===========================================================================
+# CONTRAST-MATCHED CASCADED REGISTRATION  (src/modules/registration.sh)
+# ===========================================================================
+# Default behaviour registers every modality DIRECTLY to T1 via cross-modality
+# Mutual Information.  That is fine for FLAIR<->T1, but a T2-weighted series
+# (3D-FLAIR, T2, the DWI trace, SWI) registers far better to a SAME-CONTRAST 3D
+# structural anchor than to T1.  In particular a DERIVED DWI trace (T2-weighted,
+# no raw 4D) fits a 0.9 mm 3D-FLAIR much better than a 2D 5 mm T1.
+#
+# When CONTRAST_MATCHED_REGISTRATION=true the pipeline builds a cascade:
+#
+#       T1  (master, -> MNI/atlas via the existing T1->MNI path)
+#        ^
+#        |  FLAIR -> T1   (cross-modality MI; the existing main registration)
+#        |
+#   {T2, DWI, SWI} -> FLAIR   (same-contrast anchor; their nearest 3D structural)
+#
+# Each T2-weighted modality is registered to the FLAIR anchor, and its transforms
+# are COMPOSED with the FLAIR->T1 transforms so the modality reaches T1 (and
+# onward to MNI/atlas) in a SINGLE antsApplyTransforms application — avoiding the
+# double interpolation of warping twice.  Both the composed FORWARD transform
+# list and its INVERSE are persisted (the inverse is needed by the downstream
+# DICOM cluster->source mapping).
+#
+# DEFAULT OFF preserves byte-identical current behaviour.  RECOMMENDED ON when a
+# good 3D FLAIR plus one or more T2-weighted series (T2/DWI/SWI) are present.
+export CONTRAST_MATCHED_REGISTRATION=false
+
+# Per-family contrast anchor map.  Each entry is "MODALITY:ANCHOR" where ANCHOR is
+# the modality whose registered space the MODALITY is matched to.  T2-weighted
+# family {T2,FLAIR,DWI,SWI} anchors on FLAIR; FLAIR anchors on T1; T1 anchors on
+# the MNI master.  Resolved by resolve_contrast_anchor() in registration.sh.
+export CONTRAST_ANCHOR_MAP=("T2:FLAIR" "DWI:FLAIR" "SWI:FLAIR" "FLAIR:T1" "T1:MNI")
+
+# Metric for the same-contrast modality->FLAIR step.  MI is always safe; CC only
+# if the pair is genuinely same-contrast (e.g. a true T2 vs 3D-FLAIR).  Left at MI
+# by default because a DWI trace / SWI are only approximately T2-like.
+export CONTRAST_MATCHED_METRIC="MI"
+
+# Interpolation used when resampling a contrast-matched INTENSITY image into T1
+# space via the composed transform.  Linear for continuous intensities; label/mask
+# warps must use GenericLabel (apply_transformation handles that separately).
+export CONTRAST_MATCHED_INTENSITY_INTERP="Linear"
+
+# Subdirectory (under ${RESULTS_DIR}/registered) holding the contrast-matched
+# outputs: per-modality registration to FLAIR, the composed-to-T1 resample, the
+# persisted composed forward/inverse transform lists, and a transform manifest.
+export CONTRAST_MATCHED_SUBDIR="contrast_matched"
+
 # ANTs specific parameters - if not set, ANTs will use defaults
 # export METRIC_SAMPLING_STRATEGY="NONE"  # Options: NONE (use all voxels), REGULAR, RANDOM
 # export METRIC_SAMPLING_PERCENTAGE=1.0   # Percentage of voxels to sample (when not NONE)

--- a/src/modules/registration.sh
+++ b/src/modules/registration.sh
@@ -1363,6 +1363,306 @@ register_all_modalities() {
     return 0
 }
 
+# =============================================================================
+# CONTRAST-MATCHED CASCADED REGISTRATION
+# -----------------------------------------------------------------------------
+# Cascade:  T1 (master, ->MNI)  <-  FLAIR  <-  {T2, DWI, SWI}
+# A T2-weighted modality is registered to its same-contrast FLAIR anchor, then
+# its transforms are COMPOSED with the existing FLAIR->T1 transforms so the
+# modality reaches T1 space in a SINGLE antsApplyTransforms application.  Both
+# the composed forward and inverse transform lists are persisted.
+#
+# These functions are NO-OPs unless CONTRAST_MATCHED_REGISTRATION=true is wired
+# in by the caller (pipeline.sh); they never run on the default flag-off path.
+# =============================================================================
+
+# Resolve the contrast anchor modality for a given modality from CONTRAST_ANCHOR_MAP.
+# Echoes the anchor modality (e.g. DWI -> FLAIR, FLAIR -> T1, T1 -> MNI).
+# Falls back to T1 when the modality is not listed in the map.
+resolve_contrast_anchor() {
+    local modality="$1"
+    local entry
+    for entry in "${CONTRAST_ANCHOR_MAP[@]}"; do
+        if [ "${entry%%:*}" = "$modality" ]; then
+            echo "${entry##*:}"
+            return 0
+        fi
+    done
+    # Unlisted modality: default to the T1 master.
+    echo "T1"
+    return 0
+}
+
+# Build the ordered antsApplyTransforms -t argument list for a SyN transform set.
+# Usage: _collect_syn_transform_args <out_array_name> <prefix> <direction>
+#   prefix    : registration output prefix (expects ${prefix}0GenericAffine.mat,
+#               ${prefix}1Warp.nii.gz, ${prefix}1InverseWarp.nii.gz)
+#   direction : "forward" (moving->fixed) or "inverse" (fixed->moving)
+#
+# ANTs applies -t entries RIGHT-TO-LEFT (last listed is applied first).
+#   forward (moving->fixed): -t Warp -t Affine        (affine first, then warp)
+#   inverse (fixed->moving): -t [Affine,1] -t InverseWarp (inverse warp first,
+#                            then inverted affine)
+# Returns 1 if the required transforms are missing.
+_collect_syn_transform_args() {
+    local -n _out_args="$1"
+    local prefix="$2"
+    local direction="$3"
+
+    local affine="${prefix}0GenericAffine.mat"
+    local warp="${prefix}1Warp.nii.gz"
+    local inverse_warp="${prefix}1InverseWarp.nii.gz"
+
+    if [ ! -f "$affine" ]; then
+        log_formatted "ERROR" "Composing transforms: affine not found: $affine"
+        return 1
+    fi
+
+    if [ "$direction" = "forward" ]; then
+        # moving -> fixed: warp listed first, affine second (affine applied first).
+        if [ -f "$warp" ]; then
+            _out_args+=("-t" "$warp")
+        fi
+        _out_args+=("-t" "$affine")
+    else
+        # fixed -> moving: inverted affine listed first, inverse warp second
+        # (inverse warp applied first).
+        _out_args+=("-t" "[${affine},1]")
+        if [ -f "$inverse_warp" ]; then
+            _out_args+=("-t" "$inverse_warp")
+        fi
+    fi
+    return 0
+}
+
+# Register a T2-weighted modality to its FLAIR anchor and compose the resulting
+# transforms with the existing FLAIR->T1 transforms so the modality is resampled
+# into T1 space in a SINGLE antsApplyTransforms application.
+#
+# Usage:
+#   register_contrast_matched_modality \
+#       <modality_image> <modality_name> \
+#       <flair_anchor_image> <flair_to_t1_prefix> \
+#       <t1_reference_image> <output_dir>
+#
+#   flair_to_t1_prefix : prefix of the EXISTING FLAIR->T1 registration outputs
+#                        (FLAIR moving, T1 fixed) — i.e. ${reg_dir}/<flair>_to_<t1>.
+#   t1_reference_image : the T1 (or pipeline reference) grid to resample onto.
+#
+# Persists, under <output_dir>:
+#   <mod>_to_flair*                         modality->FLAIR registration outputs
+#   <mod>_to_t1_composedWarped.nii.gz       modality resampled into T1 space
+#   <mod>_to_t1_forward_transforms.txt      composed forward -t list (mod->T1)
+#   <mod>_to_t1_inverse_transforms.txt      composed inverse -t list (T1->mod)
+#   <mod>_transform_manifest.txt            human-readable provenance manifest
+register_contrast_matched_modality() {
+    local modality_image="$1"
+    local modality_name="$2"
+    local flair_anchor="$3"
+    local flair_to_t1_prefix="$4"
+    local t1_reference="$5"
+    local output_dir="$6"
+
+    log_message "=== Contrast-matched registration: ${modality_name} -> FLAIR -> T1 ==="
+    log_message "Modality image:      $modality_image"
+    log_message "FLAIR anchor:        $flair_anchor"
+    log_message "FLAIR->T1 prefix:    $flair_to_t1_prefix"
+    log_message "T1 reference:        $t1_reference"
+    log_message "Output dir:          $output_dir"
+
+    # Input validation.
+    if [ ! -f "$modality_image" ]; then
+        log_formatted "ERROR" "Contrast-matched: modality image not found: $modality_image"
+        return "${ERR_DATA_MISSING:-1}"
+    fi
+    if [ ! -f "$flair_anchor" ]; then
+        log_formatted "ERROR" "Contrast-matched: FLAIR anchor not found: $flair_anchor"
+        return "${ERR_DATA_MISSING:-1}"
+    fi
+    if [ ! -f "$t1_reference" ]; then
+        log_formatted "ERROR" "Contrast-matched: T1 reference not found: $t1_reference"
+        return "${ERR_DATA_MISSING:-1}"
+    fi
+
+    local flair_to_t1_affine="${flair_to_t1_prefix}0GenericAffine.mat"
+    if [ ! -f "$flair_to_t1_affine" ]; then
+        log_formatted "ERROR" "Contrast-matched: FLAIR->T1 transforms missing (need ${flair_to_t1_affine}); cannot compose"
+        return "${ERR_REGISTRATION:-1}"
+    fi
+
+    mkdir -p "$output_dir"
+
+    local ants_bin="${ANTS_BIN:-${ANTS_PATH}/bin}"
+
+    # --- Step 1: register the modality to the FLAIR anchor (same-contrast). -----
+    # Reuse register_to_reference (multi-stage rigid->affine->SyN).  The metric is
+    # chosen inside perform_multistage_registration: same modality name => CC,
+    # otherwise MI.  For the DWI-trace/SWI cases we keep MI by passing the FLAIR
+    # modality name unchanged so the modality differs from the anchor (=> MI),
+    # which is the safe choice configured via CONTRAST_MATCHED_METRIC=MI.
+    local mod_to_flair_prefix="${output_dir}/$(basename "$modality_image" .nii.gz)_to_flair"
+    local mod_to_flair_warped="${mod_to_flair_prefix}Warped.nii.gz"
+
+    if [ -f "$mod_to_flair_warped" ] && [ -s "$mod_to_flair_warped" ]; then
+        log_message "Found existing ${modality_name}->FLAIR registration: $mod_to_flair_warped (skipping)"
+    else
+        log_message "Registering ${modality_name} to FLAIR anchor (same-contrast)..."
+        # Capture status without tripping `set -e` if a caller invokes this
+        # function outside an if/|| context.
+        local reg_status=0
+        register_to_reference "$flair_anchor" "$modality_image" "$modality_name" "$mod_to_flair_prefix" || reg_status=$?
+        if [ "$reg_status" -ne 0 ] || [ ! -f "$mod_to_flair_warped" ]; then
+            log_formatted "ERROR" "${modality_name}->FLAIR registration failed (status $reg_status)"
+            return "${ERR_REGISTRATION:-1}"
+        fi
+    fi
+
+    # --- Step 2: build the COMPOSED forward transform list (modality -> T1). ----
+    # Chain order, applied right-to-left by ANTs:
+    #   modality --(mod->FLAIR)--> FLAIR --(FLAIR->T1)--> T1
+    # so list the FLAIR->T1 stage FIRST, then the mod->FLAIR stage:
+    #   -t FLAIR2T1_warp -t FLAIR2T1_affine -t mod2FLAIR_warp -t mod2FLAIR_affine
+    local forward_args=()
+    if ! _collect_syn_transform_args forward_args "$flair_to_t1_prefix" "forward"; then
+        log_formatted "ERROR" "Could not assemble FLAIR->T1 forward transforms"
+        return "${ERR_REGISTRATION:-1}"
+    fi
+    if ! _collect_syn_transform_args forward_args "$mod_to_flair_prefix" "forward"; then
+        log_formatted "ERROR" "Could not assemble ${modality_name}->FLAIR forward transforms"
+        return "${ERR_REGISTRATION:-1}"
+    fi
+
+    # --- Step 3: build the COMPOSED inverse transform list (T1 -> modality). ----
+    # Reverse the cascade: undo FLAIR->T1 first, then undo mod->FLAIR.  Applied
+    # right-to-left this maps T1 grid points back to the modality:
+    #   -t [mod2FLAIR_affine,1] -t mod2FLAIR_inverseWarp -t [FLAIR2T1_affine,1] -t FLAIR2T1_inverseWarp
+    local inverse_args=()
+    if ! _collect_syn_transform_args inverse_args "$mod_to_flair_prefix" "inverse"; then
+        log_formatted "ERROR" "Could not assemble ${modality_name}->FLAIR inverse transforms"
+        return "${ERR_REGISTRATION:-1}"
+    fi
+    if ! _collect_syn_transform_args inverse_args "$flair_to_t1_prefix" "inverse"; then
+        log_formatted "ERROR" "Could not assemble FLAIR->T1 inverse transforms"
+        return "${ERR_REGISTRATION:-1}"
+    fi
+
+    # --- Step 4: persist the composed transform lists + a provenance manifest. --
+    local forward_list_file="${output_dir}/$(basename "$modality_image" .nii.gz)_to_t1_forward_transforms.txt"
+    local inverse_list_file="${output_dir}/$(basename "$modality_image" .nii.gz)_to_t1_inverse_transforms.txt"
+    local manifest_file="${output_dir}/$(basename "$modality_image" .nii.gz)_transform_manifest.txt"
+
+    printf '%s\n' "${forward_args[@]}" > "$forward_list_file"
+    printf '%s\n' "${inverse_args[@]}" > "$inverse_list_file"
+    {
+        echo "Contrast-matched cascade transform manifest"
+        echo "==========================================="
+        echo "Generated: $(date)"
+        echo "Modality:           $modality_name"
+        echo "Modality image:     $modality_image"
+        echo "FLAIR anchor:       $flair_anchor"
+        echo "T1 reference grid:  $t1_reference"
+        echo ""
+        echo "Cascade: ${modality_name} -> FLAIR -> T1"
+        echo ""
+        echo "FORWARD (${modality_name} -> T1) antsApplyTransforms args:"
+        echo "  ${forward_args[*]}"
+        echo ""
+        echo "INVERSE (T1 -> ${modality_name}) antsApplyTransforms args:"
+        echo "  ${inverse_args[*]}"
+    } > "$manifest_file"
+    log_message "Persisted composed forward transforms: $forward_list_file"
+    log_message "Persisted composed inverse transforms: $inverse_list_file"
+    log_message "Persisted transform manifest:          $manifest_file"
+
+    # --- Step 5: resample the modality into T1 space in ONE application. --------
+    # Intensity image => continuous interpolation (avoids the double interpolation
+    # of warping mod->FLAIR then FLAIR->T1 separately).
+    local composed_warped="${output_dir}/$(basename "$modality_image" .nii.gz)_to_t1_composedWarped.nii.gz"
+    local interp="${CONTRAST_MATCHED_INTENSITY_INTERP:-Linear}"
+
+    local apply_status=0
+    execute_ants_command "contrast_matched_${modality_name}_to_t1" \
+        "Composed ${modality_name}->FLAIR->T1 resample (single application)" \
+        "${ants_bin}/antsApplyTransforms" \
+        -d 3 \
+        -i "$modality_image" \
+        -r "$t1_reference" \
+        -o "$composed_warped" \
+        "${forward_args[@]}" \
+        -n "$interp" || apply_status=$?
+
+    if [ "$apply_status" -ne 0 ] || [ ! -f "$composed_warped" ]; then
+        log_formatted "ERROR" "Composed ${modality_name}->T1 resample failed (status $apply_status)"
+        return "${ERR_REGISTRATION:-1}"
+    fi
+
+    log_formatted "SUCCESS" "✅ Contrast-matched ${modality_name} resampled into T1 space: $composed_warped"
+    return 0
+}
+
+# Orchestrate contrast-matched registration for all present T2-weighted modalities.
+#
+# Usage:
+#   register_contrast_matched_cascade \
+#       <t1_reference> <flair_anchor> <flair_to_t1_prefix> \
+#       <output_dir> <modality_spec> [<modality_spec> ...]
+#
+#   modality_spec : "NAME=path" (e.g. "DWI=/path/dwi_std.nii.gz").  Only specs
+#                   whose path exists AND whose resolved anchor is FLAIR are
+#                   processed; everything else is skipped (logged, non-fatal).
+#
+# Returns 0 if every present T2-weighted modality registered successfully (or if
+# none were present); non-zero if any attempted modality failed.
+register_contrast_matched_cascade() {
+    local t1_reference="$1"
+    local flair_anchor="$2"
+    local flair_to_t1_prefix="$3"
+    local output_dir="$4"
+    shift 4
+    local specs=("$@")
+
+    log_message "=== Contrast-matched cascade: registering T2-weighted modalities to FLAIR -> T1 ==="
+
+    if [ ${#specs[@]} -eq 0 ]; then
+        log_message "No T2-weighted modality specs supplied; nothing to do"
+        return 0
+    fi
+
+    mkdir -p "$output_dir"
+
+    local overall_status=0
+    local processed=0
+    local spec name path anchor
+    for spec in "${specs[@]}"; do
+        name="${spec%%=*}"
+        path="${spec#*=}"
+
+        if [ -z "$path" ] || [ ! -f "$path" ]; then
+            log_message "Skipping ${name}: image not present ($path)"
+            continue
+        fi
+
+        anchor="$(resolve_contrast_anchor "$name")"
+        if [ "$anchor" != "FLAIR" ]; then
+            log_message "Skipping ${name}: anchor is '${anchor}', not FLAIR (handled by the standard T1 path)"
+            continue
+        fi
+
+        processed=$((processed + 1))
+        if register_contrast_matched_modality \
+                "$path" "$name" "$flair_anchor" "$flair_to_t1_prefix" \
+                "$t1_reference" "$output_dir"; then
+            log_formatted "SUCCESS" "Contrast-matched ${name} complete"
+        else
+            log_formatted "WARNING" "Contrast-matched ${name} failed (continuing with remaining modalities)"
+            overall_status=1
+        fi
+    done
+
+    log_message "Contrast-matched cascade processed ${processed} T2-weighted modality(ies)"
+    return $overall_status
+}
+
 # Export functions
 export -f perform_multistage_registration
 export -f register_to_reference
@@ -1371,6 +1671,9 @@ export -f validate_registration
 export -f apply_transformation
 export -f register_multiple_to_reference
 export -f register_all_modalities
+export -f resolve_contrast_anchor
+export -f register_contrast_matched_modality
+export -f register_contrast_matched_cascade
 
 # Helper function to prepare white matter segmentation
 prepare_wm_segmentation() {

--- a/src/pipeline.sh
+++ b/src/pipeline.sh
@@ -822,7 +822,66 @@ run_pipeline() {
       return $ERR_VALIDATION
     fi
     log_formatted "SUCCESS" "Step validated: Registration"
-    
+
+    # ───────────────────────────────────────────────────────────────────────
+    # CONTRAST-MATCHED CASCADED REGISTRATION  (default OFF; no-op when disabled)
+    # ───────────────────────────────────────────────────────────────────────
+    # Register each present T2-weighted modality (T2, DWI, SWI) to the FLAIR
+    # anchor (same-contrast), then COMPOSE with the existing FLAIR->T1 transforms
+    # so the modality reaches T1 space in a single antsApplyTransforms call.
+    # Persists composed forward + inverse transform lists for downstream use
+    # (incl. the future DICOM cluster->source mapping).  This block runs only
+    # when CONTRAST_MATCHED_REGISTRATION=true, leaving the default path unchanged.
+    if [ "${CONTRAST_MATCHED_REGISTRATION:-false}" = "true" ]; then
+      log_formatted "INFO" "===== CONTRAST-MATCHED CASCADED REGISTRATION ====="
+      # The cascade treats T1 as the master.  It composes onto the existing
+      # FLAIR->T1 forward transforms, which only exist when T1 is the reference
+      # (moving=FLAIR, fixed=T1).  When FLAIR is the reference the transforms run
+      # the other way; skip cleanly rather than compose in the wrong direction.
+      if [ "$PIPELINE_REFERENCE_MODALITY" != "T1" ]; then
+        log_formatted "WARNING" "Contrast-matched cascade requires T1 as reference (PIPELINE_REFERENCE_MODALITY=$PIPELINE_REFERENCE_MODALITY) - skipping"
+      else
+        # The main registration above produced FLAIR(moving)->T1(fixed) transforms
+        # under this prefix; recover it from the standardized filenames.
+        local flair_to_t1_prefix="${reg_dir}/$(basename "$flair_std" .nii.gz)_to_$(basename "$t1_std" .nii.gz)"
+        if [ ! -f "${flair_to_t1_prefix}0GenericAffine.mat" ]; then
+          log_formatted "WARNING" "FLAIR->T1 transforms not found at ${flair_to_t1_prefix} - skipping contrast-matched cascade"
+        else
+          local cm_dir="${reg_dir}/${CONTRAST_MATCHED_SUBDIR:-contrast_matched}"
+          mkdir -p "$cm_dir"
+
+          # Locate present T2-weighted secondary modalities (T2/DWI/SWI).  These
+          # are not standardized like T1/FLAIR, so search the standard output dirs
+          # (brain_extraction -> bias_corrected -> extracted), excluding masks.
+          local cm_specs=()
+          local cm_mod cm_found cm_search_dir
+          for cm_mod in T2 DWI SWI; do
+            # Exclude the T2-SPACE-FLAIR (already the anchor) via the FLAIR filter below.
+            cm_found=""
+            for cm_search_dir in "${RESULTS_DIR}/brain_extraction" "${RESULTS_DIR}/bias_corrected" "${EXTRACT_DIR}"; do
+              [ -d "$cm_search_dir" ] || continue
+              cm_found=$(find "$cm_search_dir" -iname "*${cm_mod}*.nii.gz" ! -iname "*FLAIR*" ! -iname "*Mask*" ! -iname "*_mean.nii.gz" 2>/dev/null | head -1)
+              [ -n "$cm_found" ] && break
+            done
+            if [ -n "$cm_found" ]; then
+              log_message "Contrast-matched: found ${cm_mod} candidate: $cm_found"
+              cm_specs+=("${cm_mod}=${cm_found}")
+            else
+              log_message "Contrast-matched: no ${cm_mod} present (skipping)"
+            fi
+          done
+
+          if [ ${#cm_specs[@]} -eq 0 ]; then
+            log_message "No T2-weighted secondary modalities present; contrast-matched cascade has nothing to do"
+          else
+            register_contrast_matched_cascade \
+              "$t1_std" "$flair_std" "$flair_to_t1_prefix" "$cm_dir" "${cm_specs[@]}" \
+              || log_formatted "WARNING" "Contrast-matched cascade reported issues (non-fatal)"
+          fi
+        fi
+      fi
+    fi
+
     # Launch enhanced visual QA for registration (non-blocking) with better error handling
     log_message "DEBUG: About to call enhanced_launch_visual_qa from pipeline.sh"
     if declare -f enhanced_launch_visual_qa >/dev/null 2>&1; then

--- a/tests/test_contrast_matched_registration_unit.sh
+++ b/tests/test_contrast_matched_registration_unit.sh
@@ -1,0 +1,210 @@
+#!/usr/bin/env bash
+#
+# test_contrast_matched_registration_unit.sh
+#   Unit tests for the contrast-matched cascaded registration helpers in
+#   src/modules/registration.sh.
+#
+# Tests:
+#   - resolve_contrast_anchor maps each family to the correct anchor
+#   - _collect_syn_transform_args builds the correct ANTs -t order/direction
+#     (forward = moving->fixed: warp then affine; inverse = fixed->moving:
+#      [affine,1] then InverseWarp) — the warp-direction bug class
+#   - register_contrast_matched_modality composes mod->FLAIR with FLAIR->T1 in
+#     the correct cascade order and persists forward + inverse transform lists
+#   - register_contrast_matched_cascade skips non-FLAIR-anchored / absent specs
+#   - module sources cleanly + double-source is a no-op (include guard)
+#
+
+set -u
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+source "$SCRIPT_DIR/test_helpers.sh"
+
+init_test_suite "Contrast-matched cascaded registration Unit Tests"
+setup_test_environment
+
+# Source environment then the module under test.
+load_environment_module
+# The module exercises failure paths; disable errexit like the sibling suites.
+set +e
+source "$PROJECT_ROOT/src/modules/registration.sh" 2>/dev/null || true
+# Load the config block so CONTRAST_ANCHOR_MAP etc. are defined.
+source "$PROJECT_ROOT/config/default_config.sh" 2>/dev/null || true
+
+# ══════════════════════════════════════════════════════════════════════════════
+# 1. Module load + function definitions
+# ══════════════════════════════════════════════════════════════════════════════
+begin_test_group "1. Functions defined + guard"
+
+assert_function_exists "resolve_contrast_anchor"             "resolve_contrast_anchor defined"
+assert_function_exists "_collect_syn_transform_args"         "_collect_syn_transform_args defined"
+assert_function_exists "register_contrast_matched_modality"  "register_contrast_matched_modality defined"
+assert_function_exists "register_contrast_matched_cascade"   "register_contrast_matched_cascade defined"
+
+# ══════════════════════════════════════════════════════════════════════════════
+# 2. resolve_contrast_anchor — per-family anchor map
+# ══════════════════════════════════════════════════════════════════════════════
+begin_test_group "2. resolve_contrast_anchor"
+
+assert_equals "FLAIR" "$(resolve_contrast_anchor DWI)"  "DWI anchors on FLAIR"
+assert_equals "FLAIR" "$(resolve_contrast_anchor T2)"   "T2 anchors on FLAIR"
+assert_equals "FLAIR" "$(resolve_contrast_anchor SWI)"  "SWI anchors on FLAIR"
+assert_equals "T1"    "$(resolve_contrast_anchor FLAIR)" "FLAIR anchors on T1"
+assert_equals "MNI"   "$(resolve_contrast_anchor T1)"   "T1 anchors on MNI master"
+assert_equals "T1"    "$(resolve_contrast_anchor BOGUS)" "unlisted modality defaults to T1"
+
+# ══════════════════════════════════════════════════════════════════════════════
+# 3. _collect_syn_transform_args — ORDER + DIRECTION (warp-direction bug class)
+# ══════════════════════════════════════════════════════════════════════════════
+begin_test_group "3. _collect_syn_transform_args order/direction"
+
+pfx="$TEMP_TEST_DIR/reg/mod_to_flair"
+mkdir -p "$TEMP_TEST_DIR/reg"
+: > "${pfx}0GenericAffine.mat"
+: > "${pfx}1Warp.nii.gz"
+: > "${pfx}1InverseWarp.nii.gz"
+
+# Forward (moving->fixed): warp FIRST, affine SECOND (affine applied first).
+fwd=()
+_collect_syn_transform_args fwd "$pfx" "forward"
+rc=$?
+assert_equals "0" "$rc" "forward collect returns 0"
+assert_equals "-t ${pfx}1Warp.nii.gz -t ${pfx}0GenericAffine.mat" "${fwd[*]}" \
+    "forward order: warp then affine"
+
+# Inverse (fixed->moving): inverted affine FIRST, InverseWarp SECOND.
+inv=()
+_collect_syn_transform_args inv "$pfx" "inverse"
+rc=$?
+assert_equals "0" "$rc" "inverse collect returns 0"
+assert_equals "-t [${pfx}0GenericAffine.mat,1] -t ${pfx}1InverseWarp.nii.gz" "${inv[*]}" \
+    "inverse order: inverted affine then inverse warp"
+
+# Missing affine => failure.
+miss=()
+_collect_syn_transform_args miss "$TEMP_TEST_DIR/reg/nope" "forward"
+assert_equals "1" "$?" "missing affine => non-zero"
+
+# Affine-only (no warp) forward => affine only.
+pfx2="$TEMP_TEST_DIR/reg/affineonly"
+: > "${pfx2}0GenericAffine.mat"
+aff=()
+_collect_syn_transform_args aff "$pfx2" "forward"
+assert_equals "-t ${pfx2}0GenericAffine.mat" "${aff[*]}" "affine-only forward => affine only"
+
+# ══════════════════════════════════════════════════════════════════════════════
+# 4. register_contrast_matched_modality — composition order + persistence
+# ══════════════════════════════════════════════════════════════════════════════
+begin_test_group "4. register_contrast_matched_modality composes + persists"
+
+cm_root="$TEMP_TEST_DIR/cm"
+mkdir -p "$cm_root/reg" "$cm_root/out"
+
+# Inputs (empty files are enough; ANTs is mocked).
+dwi="$cm_root/DWI_trace_std.nii.gz";   : > "$dwi"
+flair="$cm_root/FLAIR_std.nii.gz";     : > "$flair"
+t1="$cm_root/T1_std.nii.gz";           : > "$t1"
+
+# Existing FLAIR->T1 transforms (forward = FLAIR moving -> T1 fixed).
+f2t1="$cm_root/reg/flair_to_t1"
+: > "${f2t1}0GenericAffine.mat"
+: > "${f2t1}1Warp.nii.gz"
+: > "${f2t1}1InverseWarp.nii.gz"
+
+# Mock register_to_reference: emit the mod->FLAIR transform set + Warped output.
+register_to_reference() {
+    local out_prefix="$4"
+    : > "${out_prefix}0GenericAffine.mat"
+    : > "${out_prefix}1Warp.nii.gz"
+    : > "${out_prefix}1InverseWarp.nii.gz"
+    : > "${out_prefix}Warped.nii.gz"
+    return 0
+}
+
+# Mock execute_ants_command: capture the antsApplyTransforms args and "produce"
+# the output file named after -o.
+CM_CAPTURED_ARGS=""
+execute_ants_command() {
+    shift 2                      # drop log_prefix + description
+    CM_CAPTURED_ARGS="$*"
+    # Find the -o output and create it so the success check passes.
+    local prev="" a
+    for a in "$@"; do
+        [ "$prev" = "-o" ] && : > "$a"
+        prev="$a"
+    done
+    return 0
+}
+
+register_contrast_matched_modality "$dwi" "DWI" "$flair" "$f2t1" "$t1" "$cm_root/out"
+assert_equals "0" "$?" "register_contrast_matched_modality returns 0"
+
+m2f="$cm_root/out/$(basename "$dwi" .nii.gz)_to_flair"
+expected_fwd="-t ${f2t1}1Warp.nii.gz -t ${f2t1}0GenericAffine.mat -t ${m2f}1Warp.nii.gz -t ${m2f}0GenericAffine.mat"
+
+assert_contains "$CM_CAPTURED_ARGS" "$expected_fwd" \
+    "composed forward applies FLAIR->T1 stage before mod->FLAIR stage (right-to-left = mod->FLAIR first)"
+assert_contains "$CM_CAPTURED_ARGS" "-i $dwi" "antsApplyTransforms input is the DWI"
+assert_contains "$CM_CAPTURED_ARGS" "-r $t1"  "antsApplyTransforms reference is the T1 grid"
+
+# Persisted forward list file content matches the composed forward args.
+fwd_file="$cm_root/out/$(basename "$dwi" .nii.gz)_to_t1_forward_transforms.txt"
+inv_file="$cm_root/out/$(basename "$dwi" .nii.gz)_to_t1_inverse_transforms.txt"
+manifest="$cm_root/out/$(basename "$dwi" .nii.gz)_transform_manifest.txt"
+assert_file_exists "$fwd_file"  "forward transform list persisted"
+assert_file_exists "$inv_file"  "inverse transform list persisted"
+assert_file_exists "$manifest"  "transform manifest persisted"
+assert_file_exists "$cm_root/out/$(basename "$dwi" .nii.gz)_to_t1_composedWarped.nii.gz" \
+    "composed-to-T1 resample produced"
+
+# Forward file is the args one-per-line; flatten and compare.
+fwd_flat="$(tr '\n' ' ' < "$fwd_file" | sed 's/ *$//')"
+assert_equals "$expected_fwd" "$fwd_flat" "persisted forward list == composed forward args"
+
+# Inverse cascade: undo FLAIR->T1 first (T1->FLAIR), then undo mod->FLAIR
+# (FLAIR->DWI).  As an ANTs -t list, applied right-to-left:
+#   [mod_affine,1] modInvWarp [flair_affine,1] flairInvWarp
+expected_inv="-t [${m2f}0GenericAffine.mat,1] -t ${m2f}1InverseWarp.nii.gz -t [${f2t1}0GenericAffine.mat,1] -t ${f2t1}1InverseWarp.nii.gz"
+inv_flat="$(tr '\n' ' ' < "$inv_file" | sed 's/ *$//')"
+assert_equals "$expected_inv" "$inv_flat" "persisted inverse list reverses the cascade"
+
+# Missing FLAIR->T1 transforms => clean failure (no compose).
+register_contrast_matched_modality "$dwi" "DWI" "$flair" "$cm_root/reg/missing" "$t1" "$cm_root/out2"
+assert_not_equals "0" "$?" "missing FLAIR->T1 transforms => non-zero"
+
+# ══════════════════════════════════════════════════════════════════════════════
+# 5. register_contrast_matched_cascade — selection / skipping
+# ══════════════════════════════════════════════════════════════════════════════
+begin_test_group "5. register_contrast_matched_cascade selection"
+
+# The group-4 mocks for register_to_reference + execute_ants_command are still
+# active, so the REAL cascade -> real register_contrast_matched_modality runs and
+# each successfully-processed modality leaves a *_to_t1_composedWarped.nii.gz.
+# Counting those files tells us exactly which modalities were attempted, without
+# shadowing register_contrast_matched_modality (which SC2218 would flag).
+_count_composed() { find "$1" -name '*_to_t1_composedWarped.nii.gz' 2>/dev/null | wc -l | tr -d ' '; }
+
+casc_out="$TEMP_TEST_DIR/casc"
+mkdir -p "$casc_out"
+present_dwi="$casc_out/DWI.nii.gz"; : > "$present_dwi"
+present_swi="$casc_out/SWI.nii.gz"; : > "$present_swi"
+
+# DWI present (anchor FLAIR), SWI present (anchor FLAIR), T2 ABSENT (skip),
+# T1 spec present but anchor != FLAIR (skip).
+present_t1="$casc_out/T1.nii.gz"; : > "$present_t1"
+register_contrast_matched_cascade "$t1" "$flair" "$f2t1" "$casc_out" \
+    "DWI=$present_dwi" "SWI=$present_swi" "T2=$casc_out/absent_T2.nii.gz" "T1=$present_t1"
+assert_equals "0" "$?" "cascade returns 0 when all attempted succeed"
+assert_equals "2" "$(_count_composed "$casc_out")" \
+    "cascade registers only the 2 present FLAIR-anchored modalities (DWI, SWI)"
+
+# Empty spec list => nothing registered, returns 0.
+empty_out="$TEMP_TEST_DIR/casc_empty"
+mkdir -p "$empty_out"
+register_contrast_matched_cascade "$t1" "$flair" "$f2t1" "$empty_out"
+assert_equals "0" "$?" "cascade with no specs returns 0"
+assert_equals "0" "$(_count_composed "$empty_out")" "cascade with no specs registers nothing"
+
+# ── Summary ───────────────────────────────────────────────────────────────────
+cleanup_test_environment
+print_test_summary


### PR DESCRIPTION
## Cascade design

Default behaviour registers every modality DIRECTLY to T1 via cross-modality Mutual Information. That is fine for FLAIR↔T1, but a T2-weighted series (3D-FLAIR, T2, the DWI trace, SWI) registers far better to a SAME-CONTRAST 3D structural anchor than to T1. Verified on a real dataset: a DERIVED DWI trace (T2-weighted, no raw 4D) fits the 0.9 mm 3D-FLAIR much better than a 2D 5 mm T1.

When `CONTRAST_MATCHED_REGISTRATION=true` the pipeline builds:

```
      T1  (master, → MNI/atlas via the existing T1→MNI path)
       ^
       |  FLAIR → T1   (cross-modality MI; the existing main registration, reused)
       |
  {T2, DWI, SWI} → FLAIR   (same-contrast anchor; their nearest 3D structural)
```

Each T2-weighted modality is registered to the FLAIR anchor, then its transforms are **composed** with the existing FLAIR→T1 transforms so it reaches T1 (and onward to MNI/atlas) in a **single `antsApplyTransforms` application** — avoiding the double interpolation of warping twice.

## Composed-transform persistence

Per modality, under `${RESULTS_DIR}/registered/contrast_matched/`:
- `<mod>_to_flair*` — the modality→FLAIR registration outputs
- `<mod>_to_t1_composedWarped.nii.gz` — modality resampled into T1 space (one application)
- `<mod>_to_t1_forward_transforms.txt` — composed FORWARD `-t` list (mod→T1)
- `<mod>_to_t1_inverse_transforms.txt` — composed INVERSE `-t` list (T1→mod)
- `<mod>_transform_manifest.txt` — human-readable provenance

The inverse list is persisted because the future DICOM cluster→source mapping needs it. Transform ORDER/DIRECTION were verified against the existing working `apply_transformation` usage (ANTs applies `-t` entries right-to-left; later cascade stages listed first for forward, reversed for inverse).

## Default OFF

`CONTRAST_MATCHED_REGISTRATION=false` by default — the flag-off path is byte-identical to today. The block runs only when enabled AND T1 is the reference (the master); when FLAIR is the reference it skips cleanly rather than composing in the wrong direction.

## Verification

- `git ls-files '*.sh' | xargs bash -n` and `| xargs shellcheck --severity=error` clean
- 3 required unit suites + `pipeline.sh --help` smoke pass
- New 31-assertion unit suite (`tests/test_contrast_matched_registration_unit.sh`) covering anchor resolution, transform order/direction, composition + persistence, and selection/skipping
- Functional (FSL+ANTs) on synthetic asymmetric T1/FLAIR/DWI volumes: (a) DWI registers to FLAIR; (b) the composed transform resamples DWI into T1 space in one application with correct orientation (composed center-of-mass matched T1, not raw DWI — no L-R flip / mis-order); (c) the persisted inverse round-trips T1 back into DWI space

## Merge note

Edits are confined to the REGISTRATION stage of `src/pipeline.sh` and a clearly-delimited config block. A concurrent analysis-rework PR touches the analysis stage + config of the same files, so a trivial merge of `src/pipeline.sh` / `config/default_config.sh` may be needed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)