### PR TITLE
Brainstem segmentation: run HO + multi-atlas + FreeSurfer as concurrent parallel paths (default all); parallel per-source analysis

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -102,17 +102,21 @@ _MODULE_LOADED=1
 | `SCAN_SELECTION_MODE` | `registration_optimized` \| `highest_resolution` \| `interactive` |
 | `THRESHOLD_WM_SD_MULTIPLIER` | authoritative fallback threshold (GMM inherits this) |
 | `GMM_*` (11 vars) | GMM per-region thresholding — see `config/default_config.sh` |
-| `BRAINSTEM_SEGMENTATION_METHOD` | `freesurfer` \| `atlas`/`harvard_oxford` \| `multi_atlas`/`bianciardi` |
+| `BRAINSTEM_SEGMENTATION_METHOD` | `all` (default, parallel) \| `freesurfer` \| `atlas`/`harvard_oxford` \| `multi_atlas`/`bianciardi` |
+| `SEG_RUN_HARVARD_OXFORD` / `SEG_RUN_MULTI_ATLAS` / `SEG_RUN_FREESURFER` | per-path toggles for `all` mode (all default on; `SEG_RUN_FREESURFER=false` skips the multi-hour recon-all) |
 | `USE_BIANCIARDI` / `USE_CIT168` / `USE_AAL3` | per-atlas enables for `multi_atlas` (AAL3 off by default) |
 | `ATLAS_DIR` | atlas root, default `${FSLDIR}/data/atlases` |
 
 ## Brainstem segmentation method & optional modules
 
-**`BRAINSTEM_SEGMENTATION_METHOD`** (default `freesurfer`) selects the brainstem labeling backend:
+**`BRAINSTEM_SEGMENTATION_METHOD`** (default `all`) selects the brainstem labeling backend:
 
-- `freesurfer` (default) — FreeSurfer `segmentBS`/`brainstemSsLabels` substructures (midbrain/pons/medulla/SCP) on the subject's own T1; gated by an FS↔HO agreement (Dice + leakage) check; falls back to the HO gross mask on disagreement or missing FreeSurfer/license.
+- `all` (default) — runs every ENABLED path below as **concurrent parallel paths** and analyses the UNION of all masks they produce. The fast paths (HO gross extent + multi-atlas warp, minutes) run alongside the multi-hour FreeSurfer recon-all; each path is independent and non-fatal (a failed/skipped path logs a WARNING, never aborts the others or the pipeline). The MNI→subject SyN warp is computed ONCE up front and reused by both the HO and multi-atlas paths (no race on the shared transform). Per-path toggles `SEG_RUN_HARVARD_OXFORD` / `SEG_RUN_MULTI_ATLAS` / `SEG_RUN_FREESURFER` (all default on) drop individual paths — set `SEG_RUN_FREESURFER=false` to keep the fast HO + multi-atlas paths and skip recon-all. Downstream per-region GMM (`find_all_atlas_regions` → `apply_per_region_gmm_analysis`) discovers the union of FS parcels + multi-atlas nuclei/subdivisions + HO gross mask and tags each region's provenance (`region_provenance.tsv`).
+- `freesurfer` — FreeSurfer `segmentBS`/`brainstemSsLabels` substructures (midbrain/pons/medulla/SCP) on the subject's own T1; gated by an FS↔HO agreement (Dice + leakage) check; falls back to the HO gross mask on disagreement or missing FreeSurfer/license.
 - `atlas` / `harvard_oxford` — Harvard-Oxford gross brainstem extent only (index 7, `maxprob-thr25`).
 - `multi_atlas` / `bianciardi` — additionally warps Bianciardi BrainstemNavigator / CIT168 / AAL3 into subject space (shared SyN→MNI + `GenericLabel`) for nucleus-level masks (`docs/multi_atlas_integration_spec.md`).
+
+The single-method values (`freesurfer`/`multi_atlas`/`bianciardi`/`atlas`/`harvard_oxford`) remain mutually exclusive and behave exactly as before.
 
 **Atlas-on-disk prerequisite** — `atlas`/`multi_atlas`/`bianciardi` need the atlases pre-downloaded under `$FSLDIR/data/atlases` (`ATLAS_DIR`): `Bianciardi/`, `CIT168/`, `AAL3/`, `HarvardOxford/`. The startup `check_atlas_availability` step (`environment.sh`, called from `pipeline.sh`) reports presence/absence per atlas and warns if the selected method needs a missing one; absence is **non-fatal** — the pipeline degrades to the HO gross mask. Override layout via `ATLAS_{BIANCIARDI,CIT168,AAL3,HARVARDOXFORD}_REL`.
 

--- a/config/default_config.sh
+++ b/config/default_config.sh
@@ -78,6 +78,17 @@ export DEFAULT_TEMPLATE_RES="${DEFAULT_TEMPLATE_RES:-1mm}"
 # ---------------------------------------------------------------------------
 # Controls how the brainstem and its substructures (midbrain/pons/medulla/SCP)
 # are obtained.
+#   all        : (DEFAULT) run every ENABLED path below as CONCURRENT PARALLEL
+#                paths and let downstream per-region detection analyse the UNION
+#                of all masks they produce. The fast paths (Harvard-Oxford gross
+#                extent + multi-atlas warp, minutes) and the slow FreeSurfer
+#                recon-all (multi-hour) run side-by-side; the fast outputs are
+#                usable as soon as they finish even while recon-all continues.
+#                Each path is INDEPENDENT and NON-FATAL: a failed/skipped path
+#                logs a WARNING and does not kill the others or the pipeline.
+#                Use the SEG_RUN_* toggles below to drop individual paths (e.g.
+#                SEG_RUN_FREESURFER=false avoids the multi-hour recon-all while
+#                keeping the fast HO + multi-atlas paths).
 #   freesurfer : recon-all + segmentBS (Iglesias 2015) for the substructures,
 #                with the Harvard-Oxford gross Brain-Stem mask as the extent and
 #                the FS<->HO agreement QC gate. Falls back gracefully to the HO
@@ -90,9 +101,26 @@ export DEFAULT_TEMPLATE_RES="${DEFAULT_TEMPLATE_RES:-1mm}"
 #                the Harvard-Oxford gross extent. Per-atlas enables below.
 #                (alias: bianciardi). Requires the atlases on disk under
 #                $FSLDIR/data/atlases — see multi_atlas.sh / docs.
+# The single-method values (freesurfer/multi_atlas/bianciardi/atlas/harvard_oxford)
+# remain MUTUALLY EXCLUSIVE and behave exactly as before.
 # Talairach has been removed entirely (single 1988 post-mortem brain; largest
 # MNI-mapping error inferiorly/posteriorly — worst exactly in the brainstem).
-export BRAINSTEM_SEGMENTATION_METHOD="${BRAINSTEM_SEGMENTATION_METHOD:-freesurfer}"
+export BRAINSTEM_SEGMENTATION_METHOD="${BRAINSTEM_SEGMENTATION_METHOD:-all}"
+
+# --- Per-method toggles for BRAINSTEM_SEGMENTATION_METHOD=all -----------------
+# In 'all' mode each ENABLED path runs as a concurrent parallel path. All default
+# ON. Disable a path to drop it from the parallel fan-out:
+#   SEG_RUN_HARVARD_OXFORD : Harvard-Oxford gross extent (fast; also the fallback
+#                            mask + the reference for the FS<->HO agreement gate).
+#   SEG_RUN_MULTI_ATLAS    : Bianciardi/CIT168/AAL3 warp (minutes; no recon-all).
+#   SEG_RUN_FREESURFER     : FreeSurfer substructures (recon-all -> segmentBS).
+#                            This is the MULTI-HOUR path; set it to false to keep
+#                            the fast HO + multi-atlas paths and skip recon-all.
+# These toggles only apply in 'all' mode; the exclusive single-method values
+# above ignore them.
+export SEG_RUN_HARVARD_OXFORD="${SEG_RUN_HARVARD_OXFORD:-true}"
+export SEG_RUN_MULTI_ATLAS="${SEG_RUN_MULTI_ATLAS:-true}"
+export SEG_RUN_FREESURFER="${SEG_RUN_FREESURFER:-true}"
 
 # FreeSurfer brainstem-segmentation knobs (used by brainstem_freesurfer.sh).
 # FREESURFER_HOME / FS_LICENSE are honoured from the environment; the module

--- a/src/modules/analysis.sh
+++ b/src/modules/analysis.sh
@@ -597,10 +597,18 @@ find_all_atlas_regions() {
         "${RESULTS_DIR}/comprehensive_analysis/original_space"
     )
 
-    # Region patterns to find. These match the FreeSurfer parcel filenames
-    # (midbrain/pons/medulla/scp, with optional left/right hemisphere splits)
-    # written by brainstem_freesurfer.sh, e.g. <basename>_pons.nii.gz,
-    # <basename>_left_pons.nii.gz, <basename>_midbrain.nii.gz.
+    # Region patterns to find. The per-region GMM analyses the UNION of every
+    # mask the parallel segmentation paths produced:
+    #   - FreeSurfer parcels (brainstem_freesurfer.sh): <basename>_pons.nii.gz,
+    #     <basename>_left_pons.nii.gz, <basename>_midbrain.nii.gz, ... (gross
+    #     subdivisions, optional left/right splits).
+    #   - Multi-atlas gross subdivisions (multi_atlas.sh aggregation):
+    #     bianciardi_pons.nii.gz, bianciardi_left_midbrain.nii.gz, ... (matched by
+    #     the *_pons / *left_pons globs below).
+    #   - Multi-atlas NUCLEUS-level masks: bianciardi_*_label*, cit168_*_label*,
+    #     aal3_*_label* — added explicitly so the CIT168 / AAL3 / Bianciardi nuclei
+    #     are part of the union, not just the aggregated subdivisions.
+    # The voxel-size filter + sort -u dedup below keep the union clean.
     local region_patterns=(
         "*left_medulla*.nii.gz"
         "*right_medulla*.nii.gz"
@@ -614,6 +622,9 @@ find_all_atlas_regions() {
         "*_midbrain.nii.gz"
         "*_medulla.nii.gz"
         "*_scp.nii.gz"
+        "bianciardi_*_label*.nii.gz"
+        "cit168_*_label*.nii.gz"
+        "aal3_*_label*.nii.gz"
     )
     
     # Search for all region masks
@@ -681,6 +692,42 @@ find_all_atlas_regions() {
     fi
 
     return 0
+}
+
+# Determine the PROVENANCE (source segmentation path) of a region mask from its
+# path/filename. The parallel 'all' mode emits masks from several sources into
+# segmentation/detailed_brainstem; tagging each region by source keeps per-source
+# outputs non-clobbering (e.g. freesurfer_pons vs bianciardi_pons) and records
+# which path each detected region came from.
+#   freesurfer    : FreeSurfer parcels         <base>_{pons,midbrain,medulla,scp}*
+#   bianciardi    : Bianciardi nuclei/aggregate bianciardi_*
+#   cit168        : CIT168 nuclei              cit168_*
+#   aal3          : AAL3 regions               aal3_*
+#   harvard_oxford: gross HO fallback mask     *_brainstem.nii.gz (segmentation/brainstem)
+#   atlas         : anything else (unattributed)
+_region_source_from_path() {
+    local p="$1"
+    local b
+    b=$(basename "$p")
+    case "$b" in
+        bianciardi_*) echo "bianciardi" ;;
+        cit168_*)     echo "cit168" ;;
+        aal3_*)       echo "aal3" ;;
+        *)
+            case "$p" in
+                */segmentation/brainstem/*) echo "harvard_oxford" ;;
+                *)
+                    # FreeSurfer parcels are written as <base>_{region}.nii.gz under
+                    # detailed_brainstem (no atlas prefix); treat the remaining
+                    # subdivision masks there as FreeSurfer-sourced.
+                    case "$p" in
+                        */detailed_brainstem/*) echo "freesurfer" ;;
+                        *) echo "atlas" ;;
+                    esac
+                    ;;
+            esac
+            ;;
+    esac
 }
 
 # Function to apply Gaussian Mixture Model (n=3) thresholding
@@ -996,6 +1043,14 @@ apply_per_region_gmm_analysis() {
     # Initialize combined result as zeros
     fslmaths "$flair_image" -mul 0 "$combined_result"
 
+    # Provenance manifest: records which SOURCE path (freesurfer / bianciardi /
+    # cit168 / aal3 / harvard_oxford) each analysed region came from. The parallel
+    # 'all' segmentation mode produces masks from several sources; downstream the
+    # per-region GMM runs across the UNION, so tagging provenance keeps per-source
+    # outputs distinct and traceable in the report.
+    local provenance_manifest="${per_region_dir}/region_provenance.tsv"
+    printf 'region_tag\tregion_base\tsource\tmask_path\n' > "$provenance_manifest"
+
     # Build the CSF exclusion mask ONCE (FLAIR space) since it is region-independent.
     # Region masks are resampled to FLAIR space below, so this mask aligns with all
     # of them.  Empty string => CSF subtraction is skipped (PV erosion still applies).
@@ -1063,6 +1118,10 @@ apply_per_region_gmm_analysis() {
             elif [[ "$region_name" =~ right_ ]]; then
                 region_base="right_${region_base}"
             fi
+        elif [[ "$region_name" =~ ^(bianciardi|cit168|aal3)_(.+)_label[0-9]+$ ]]; then
+            # Multi-atlas nucleus mask <atlas>_<nucleus>_label<N>: use the nucleus
+            # name (atlas prefix is recorded separately as provenance below).
+            region_base="${BASH_REMATCH[2]}"
         else
             region_base=$(echo "$region_name" | sed -E 's/.*_([^_]+)$/\1/')
         fi
@@ -1071,11 +1130,21 @@ apply_per_region_gmm_analysis() {
         if [ -z "$region_base" ] || [[ "$region_base" == *"/"* ]]; then
             region_base="unknown_region_$(date +%s)"
         fi
-        
-        log_message "Processing region: $region_base (FLAIR hyperintensity analysis)"
-        
+
+        # Tag the region with its PROVENANCE so masks of the same anatomical name
+        # from DIFFERENT sources (e.g. FreeSurfer pons vs Bianciardi pons) do not
+        # clobber each other's work dir / per-region output, and so the report can
+        # attribute each detection to the path that produced it.
+        local region_source
+        region_source=$(_region_source_from_path "$region_mask")
+        local region_tag="${region_source}_${region_base}"
+        printf '%s\t%s\t%s\t%s\n' "$region_tag" "$region_base" "$region_source" "$region_mask" >> "$provenance_manifest"
+
+        log_message "Processing region: $region_base [source=$region_source] (FLAIR hyperintensity analysis)"
+
         # Create organized region-specific working directory with modality info
-        local region_work_dir="${per_region_dir}/${region_base}_FLAIR_analysis"
+        # (provenance-namespaced so parallel sources never share a work dir).
+        local region_work_dir="${per_region_dir}/${region_tag}_FLAIR_analysis"
         mkdir -p "$region_work_dir"
         
         # Create GMM analysis subdirectory for temp files
@@ -1159,10 +1228,12 @@ apply_per_region_gmm_analysis() {
                     fslmaths "$combined_result" -add "$region_connectivity" "$combined_result"
                     region_results+=("$region_connectivity")
                     
-                    log_message "✓ Successfully processed $region_base with GMM analysis"
-                    
-                    # Create region-specific output files
-                    local region_output="${out_prefix}_${region_base}_GMM.nii.gz"
+                    log_message "✓ Successfully processed $region_base [source=$region_source] with GMM analysis"
+
+                    # Create region-specific output files. Namespace by PROVENANCE
+                    # so same-named regions from different sources (e.g. FreeSurfer
+                    # vs Bianciardi pons) produce DISTINCT, non-clobbering outputs.
+                    local region_output="${out_prefix}_${region_tag}_GMM.nii.gz"
                     cp "$region_connectivity" "$region_output"
                     
                 else
@@ -1180,10 +1251,19 @@ apply_per_region_gmm_analysis() {
     if [ ${#region_results[@]} -gt 0 ]; then
         fslmaths "$combined_result" -bin "$combined_result"
         log_message "✓ Combined results from ${#region_results[@]} regions into atlas-based GMM detection"
-        
+
+        # Summarise per-source provenance of the analysed regions.
+        if [ -f "$provenance_manifest" ]; then
+            log_message "Region provenance (source: count):"
+            tail -n +2 "$provenance_manifest" | awk -F'\t' '{c[$3]++} END{for(s in c) printf "  %s: %d\n", s, c[s]}' | while IFS= read -r line; do
+                log_message "$line"
+            done
+            log_message "Provenance manifest: $provenance_manifest"
+        fi
+
         # Store combined result globally
         export ATLAS_GMM_RESULT="$combined_result"
-        
+
         return 0
     else
         log_formatted "ERROR" "No regions successfully processed with GMM analysis"
@@ -2412,6 +2492,7 @@ export -f _analysis_world_matrix
 export -f detect_hyperintensities
 export -f create_supratentorial_mask
 export -f find_all_atlas_regions
+export -f _region_source_from_path
 export -f build_csf_exclusion_mask
 export -f apply_csf_pv_exclusion
 export -f apply_per_region_gmm_analysis

--- a/src/modules/environment.sh
+++ b/src/modules/environment.sh
@@ -881,8 +881,21 @@ check_atlas_availability() {
   _report_atlas "HarvardOxford (subcortical)"     "$ho_ok"
 
   # Warn if the selected segmentation method needs an atlas that is missing.
-  local seg_method="${BRAINSTEM_SEGMENTATION_METHOD:-freesurfer}"
+  # Default mirrors config (BRAINSTEM_SEGMENTATION_METHOD default = 'all').
+  local seg_method="${BRAINSTEM_SEGMENTATION_METHOD:-all}"
   case "$seg_method" in
+    all)
+      # Parallel 'all' mode: warn per ENABLED path about its required atlases.
+      if [ "${SEG_RUN_HARVARD_OXFORD:-true}" = true ] && [ "$ho_ok" != true ]; then
+        log_formatted "WARNING" "BRAINSTEM_SEGMENTATION_METHOD='all' (SEG_RUN_HARVARD_OXFORD=true) needs the Harvard-Oxford subcortical atlas, which is ABSENT"
+      fi
+      if [ "${SEG_RUN_MULTI_ATLAS:-true}" = true ]; then
+        { [ "$bianciardi_ok" = true ] || [ "$cit168_ok" = true ] || [ "$aal3_ok" = true ]; } || \
+          log_formatted "WARNING" "BRAINSTEM_SEGMENTATION_METHOD='all' (SEG_RUN_MULTI_ATLAS=true) needs at least one of Bianciardi/CIT168/AAL3; ALL are ABSENT"
+      fi
+      # The FreeSurfer path needs no atlas (recon-all/segmentBS); HO is its
+      # gross-extent fallback, already reported above.
+      ;;
     atlas|harvard_oxford)
       [ "$ho_ok" = true ] || \
         log_formatted "WARNING" "BRAINSTEM_SEGMENTATION_METHOD='$seg_method' requires the Harvard-Oxford subcortical atlas, which is ABSENT"

--- a/src/modules/hierarchical_joint_fusion.sh
+++ b/src/modules/hierarchical_joint_fusion.sh
@@ -66,6 +66,35 @@ prepare_atlas_ensemble() {
     return 0
 }
 
+# Seed a destination transform prefix from the orchestrator's shared MNI->subject
+# warp (SEG_SHARED_MNI_REG_PREFIX) when it is present. Copies (does not symlink)
+# the 0GenericAffine.mat + 1Warp.nii.gz so the destination is self-contained.
+# Returns 0 only when both transform files are in place at <dest_prefix>; returns
+# 1 (caller computes its own warp) when no usable shared warp is available.
+_hojf_seed_from_shared_warp() {
+    local dest_prefix="$1"
+    local shared_prefix="${SEG_SHARED_MNI_REG_PREFIX:-}"
+    [ -n "$shared_prefix" ] || return 1
+
+    local src_affine="${shared_prefix}0GenericAffine.mat"
+    local src_warp="${shared_prefix}1Warp.nii.gz"
+    [ -f "$src_affine" ] && [ -f "$src_warp" ] || return 1
+
+    local dest_affine="${dest_prefix}0GenericAffine.mat"
+    local dest_warp="${dest_prefix}1Warp.nii.gz"
+    # Already seeded (idempotent / resumable).
+    if [ -f "$dest_affine" ] && [ -f "$dest_warp" ]; then
+        return 0
+    fi
+    cp -f "$src_affine" "$dest_affine" 2>/dev/null || return 1
+    cp -f "$src_warp" "$dest_warp" 2>/dev/null || return 1
+    # The inverse warp is optional here (HO only applies the forward chain) but
+    # copy it through when present so the workspace mirrors a full registration.
+    [ -f "${shared_prefix}1InverseWarp.nii.gz" ] && \
+        cp -f "${shared_prefix}1InverseWarp.nii.gz" "${dest_prefix}1InverseWarp.nii.gz" 2>/dev/null || true
+    return 0
+}
+
 extract_harvard_oxford_brainstem() {
     local input_file="$1"
     local workspace="$2"
@@ -87,21 +116,31 @@ extract_harvard_oxford_brainstem() {
         return 1
     fi
 
-    log_message "Registering MNI template to subject space (single SyN warp)..."
-    log_message "Template: $mni_template"
     local atlas_prefix="${registration_dir}/mni_to_subject_"
-
-    antsRegistrationSyN.sh \
-        -d 3 \
-        -f "$input_file" \
-        -m "$mni_template" \
-        -o "$atlas_prefix" \
-        -t s \
-        -j 1 \
-        -n "${ANTS_THREADS}" >/dev/null 2>/dev/null
-
     local atlas_affine="${atlas_prefix}0GenericAffine.mat"
     local atlas_warp="${atlas_prefix}1Warp.nii.gz"
+
+    # Concurrency-safe shared warp: in 'all' mode the orchestrator computes the
+    # MNI->subject SyN warp ONCE up front (before the parallel fan-out) and
+    # exports SEG_SHARED_MNI_REG_PREFIX. Seed this workspace from that cached
+    # transform instead of recomputing it — both the HO and multi-atlas paths
+    # reuse the SAME warp, so two background jobs never race on (or duplicate) the
+    # expensive registration. When the shared prefix is absent (single-method
+    # runs) we fall back to computing the warp here as before.
+    if _hojf_seed_from_shared_warp "$atlas_prefix"; then
+        log_message "Reusing pre-computed shared MNI->subject warp: ${SEG_SHARED_MNI_REG_PREFIX}"
+    else
+        log_message "Registering MNI template to subject space (single SyN warp)..."
+        log_message "Template: $mni_template"
+        antsRegistrationSyN.sh \
+            -d 3 \
+            -f "$input_file" \
+            -m "$mni_template" \
+            -o "$atlas_prefix" \
+            -t s \
+            -j 1 \
+            -n "${ANTS_THREADS}" >/dev/null 2>/dev/null
+    fi
 
     if [[ ! -f "$atlas_affine" ]] || [[ ! -f "$atlas_warp" ]]; then
         log_formatted "ERROR" "MNI-to-subject registration failed"
@@ -235,6 +274,7 @@ generate_hemisphere_masks() {
 
 export -f execute_hierarchical_joint_fusion
 export -f prepare_atlas_ensemble
+export -f _hojf_seed_from_shared_warp
 export -f extract_harvard_oxford_brainstem
 export -f generate_segmentation_outputs
 export -f generate_hemisphere_masks

--- a/src/modules/multi_atlas.sh
+++ b/src/modules/multi_atlas.sh
@@ -348,6 +348,28 @@ _multi_atlas_register_mni_to_subject() {
         return 0
     fi
 
+    # Concurrency-safe shared warp: in 'all' mode the orchestrator computes the
+    # MNI->subject SyN warp ONCE up front (before the parallel fan-out) and
+    # exports SEG_SHARED_MNI_REG_PREFIX. Seed this reg_dir from that cached
+    # transform so the HO and multi-atlas paths reuse the SAME warp rather than
+    # racing on / duplicating the expensive registration. Falls through to
+    # computing a fresh warp when no shared prefix is available (single-method).
+    local shared_prefix="${SEG_SHARED_MNI_REG_PREFIX:-}"
+    if [ -n "$shared_prefix" ] && \
+       [ -f "${shared_prefix}0GenericAffine.mat" ] && \
+       [ -f "${shared_prefix}1Warp.nii.gz" ]; then
+        mkdir -p "$reg_dir"
+        if cp -f "${shared_prefix}0GenericAffine.mat" "$affine" 2>/dev/null && \
+           cp -f "${shared_prefix}1Warp.nii.gz" "$warp" 2>/dev/null; then
+            [ -f "${shared_prefix}1InverseWarp.nii.gz" ] && \
+                cp -f "${shared_prefix}1InverseWarp.nii.gz" "${prefix}1InverseWarp.nii.gz" 2>/dev/null || true
+            log_message "  Reusing pre-computed shared MNI->subject warp: ${shared_prefix}"
+            echo "$prefix"
+            return 0
+        fi
+        log_formatted "WARNING" "Could not seed multi-atlas reg_dir from shared warp; computing a fresh one"
+    fi
+
     # Use TEMPLATE_RES when set (sibling modules export it as a side-effect),
     # else the authoritative DEFAULT_TEMPLATE_RES so a 2mm config is honoured even
     # when this module is used standalone.

--- a/src/modules/segmentation.sh
+++ b/src/modules/segmentation.sh
@@ -124,7 +124,7 @@ BRAINSTEM SEGMENTATION REPORT
 Generated: $(date)
 Subject: $(basename "$output_prefix")
 Template Resolution: ${DEFAULT_TEMPLATE_RES:-1mm}
-Brainstem method: ${BRAINSTEM_SEGMENTATION_METHOD:-freesurfer}
+Brainstem method: $(_seg_method_report_line)
 
 INPUT FILES
 -----------
@@ -223,11 +223,103 @@ extract_brainstem_with_flair() {
     return 0
 }
 
+# ---------------------------------------------------------------------------
+# _seg_method_report_line - human-readable "Method:" descriptor for the reports
+#
+# For the parallel 'all' mode it lists which paths were ENABLED and (when the
+# parallel run has populated SEG_ALL_PATHS_OK) which actually SUCCEEDED, so the
+# report reflects the real provenance of the masks. For the exclusive methods it
+# returns the legacy single-method description.
+# ---------------------------------------------------------------------------
+_seg_method_report_line() {
+    local m="${BRAINSTEM_SEGMENTATION_METHOD:-all}"
+    if [ "$m" != "all" ]; then
+        echo "$m"
+        return 0
+    fi
+    local enabled=""
+    [ "${SEG_RUN_HARVARD_OXFORD:-true}" = "true" ] && enabled="${enabled}harvard_oxford "
+    [ "${SEG_RUN_MULTI_ATLAS:-true}" = "true" ]    && enabled="${enabled}multi_atlas "
+    [ "${SEG_RUN_FREESURFER:-true}" = "true" ]     && enabled="${enabled}freesurfer "
+    enabled="${enabled% }"
+    local line="all (parallel paths enabled: ${enabled:-none})"
+    # Append the succeeded-paths list once the parallel run has populated the
+    # array. Use the array length (not "${SEG_ALL_PATHS_OK:-}", which only tests
+    # element 0) so an empty array is detected correctly. `declare -p` guards the
+    # case where the variable was never set (set -u safe).
+    if declare -p SEG_ALL_PATHS_OK >/dev/null 2>&1 && [ "${#SEG_ALL_PATHS_OK[@]}" -gt 0 ]; then
+        line="${line}; succeeded: ${SEG_ALL_PATHS_OK[*]}"
+    fi
+    echo "$line"
+}
+
+# ---------------------------------------------------------------------------
+# _compute_shared_mni_to_subject_warp - compute the MNI->subject SyN warp ONCE
+#
+# CONCURRENCY SAFETY: in 'all' mode the Harvard-Oxford path and the multi-atlas
+# path both need the SAME MNI->subject SyN transform. If two background jobs each
+# ran antsRegistrationSyN.sh into a shared cache prefix concurrently they could
+# corrupt the half-written transform. We instead compute it ONCE here, BEFORE the
+# parallel fan-out, into a canonical shared dir and export SEG_SHARED_MNI_REG_PREFIX.
+# Both paths then COPY (read-only) from that prefix into their own workspace, so
+# the background jobs never write the same registration file.
+#
+# Args: <subject_t1>
+# Echoes the shared transform prefix on success (also exported); returns 0 on
+# success, 1 if the warp could not be produced (callers fall back to computing
+# their own — still correct, just no longer shared).
+# ---------------------------------------------------------------------------
+_compute_shared_mni_to_subject_warp() {
+    local subject_t1="$1"
+
+    local shared_dir="${RESULTS_DIR}/segmentation/shared_mni_registration"
+    local prefix="${shared_dir}/mni_to_subject_"
+    local affine="${prefix}0GenericAffine.mat"
+    local warp="${prefix}1Warp.nii.gz"
+
+    # Cached / resumable: reuse an existing shared warp.
+    if [ -f "$affine" ] && [ -f "$warp" ]; then
+        export SEG_SHARED_MNI_REG_PREFIX="$prefix"
+        log_message "Shared MNI->subject warp already present (cached): $prefix"
+        echo "$prefix"
+        return 0
+    fi
+
+    local tres="${TEMPLATE_RES:-${DEFAULT_TEMPLATE_RES:-1mm}}"
+    local mni_template="${FSLDIR}/data/standard/MNI152_T1_${tres}_brain.nii.gz"
+    [ -f "$mni_template" ] || mni_template="${FSLDIR}/data/standard/MNI152_T1_${tres}.nii.gz"
+    if [ ! -f "$mni_template" ]; then
+        log_formatted "WARNING" "MNI template not found ($tres) — cannot pre-compute shared warp; paths will register independently"
+        return 1
+    fi
+
+    mkdir -p "$shared_dir"
+    log_formatted "INFO" "Pre-computing shared MNI->subject SyN warp (computed ONCE, reused by HO + multi-atlas paths)"
+    log_message "  Template: $mni_template"
+    antsRegistrationSyN.sh -d 3 -f "$subject_t1" -m "$mni_template" \
+        -o "$prefix" -t s -j 1 -n "${ANTS_THREADS:-1}" >/dev/null 2>&1
+
+    if [ ! -f "$affine" ] || [ ! -f "$warp" ]; then
+        log_formatted "WARNING" "Shared MNI->subject registration failed; paths will register independently"
+        return 1
+    fi
+
+    export SEG_SHARED_MNI_REG_PREFIX="$prefix"
+    log_formatted "SUCCESS" "Shared MNI->subject warp computed: $prefix"
+    echo "$prefix"
+    return 0
+}
+
 # Comprehensive segmentation with multiple methods (from original)
+#
+# Default method 'all' runs every ENABLED path (Harvard-Oxford gross extent,
+# multi-atlas warp, FreeSurfer substructures) as CONCURRENT PARALLEL paths. The
+# single-method values (freesurfer / multi_atlas / bianciardi / atlas /
+# harvard_oxford) remain mutually exclusive and behave exactly as before.
 extract_brainstem_final() {
     local input_file="$1"
     local input_basename=$(basename "$input_file" .nii.gz)
-    local seg_method="${BRAINSTEM_SEGMENTATION_METHOD:-freesurfer}"
+    local seg_method="${BRAINSTEM_SEGMENTATION_METHOD:-all}"
 
     log_formatted "INFO" "===== COMPREHENSIVE BRAINSTEM SEGMENTATION ====="
     log_message "Brainstem segmentation method: $seg_method"
@@ -235,6 +327,35 @@ extract_brainstem_final() {
     # Define output directory
     local brainstem_dir="${RESULTS_DIR}/segmentation/brainstem"
     mkdir -p "$brainstem_dir"
+
+    if [ "$seg_method" = "all" ]; then
+        _extract_brainstem_all_parallel "$input_file" "$input_basename" "$brainstem_dir"
+    else
+        _extract_brainstem_single_method "$input_file" "$input_basename" "$brainstem_dir" "$seg_method"
+    fi
+
+    # Validate segmentation
+    validate_segmentation_outputs "$input_file" "$input_basename"
+
+    # Generate comprehensive visualization report
+    generate_comprehensive_report "$input_file" "$input_basename"
+
+    log_formatted "SUCCESS" "Comprehensive segmentation complete"
+    return 0
+}
+
+# ---------------------------------------------------------------------------
+# _extract_brainstem_single_method - legacy mutually-exclusive dispatch
+#
+# Preserves the historical behaviour for the exclusive method values. Always
+# produces the Harvard-Oxford gross extent first (the fallback mask + the
+# FS<->HO agreement reference), then layers on the requested substructure source.
+# ---------------------------------------------------------------------------
+_extract_brainstem_single_method() {
+    local input_file="$1"
+    local input_basename="$2"
+    local brainstem_dir="$3"
+    local seg_method="$4"
 
     # Always produce the Harvard-Oxford gross brainstem extent. It is the
     # fallback mask AND the reference for the FS-HO agreement QC gate.
@@ -275,13 +396,270 @@ extract_brainstem_final() {
         log_formatted "WARNING" "Unknown BRAINSTEM_SEGMENTATION_METHOD='$seg_method'; defaulting to Harvard-Oxford gross mask only"
     fi
 
-    # Validate segmentation
-    validate_segmentation_outputs "$input_file" "$input_basename"
+    return 0
+}
 
-    # Generate comprehensive visualization report
-    generate_comprehensive_report "$input_file" "$input_basename"
+# ---------------------------------------------------------------------------
+# _extract_brainstem_all_parallel - run all ENABLED paths as concurrent parallel
+# paths (the new default 'all' mode).
+#
+# Paths (each gated by a SEG_RUN_* toggle, all default on):
+#   - Harvard-Oxford gross extent (extract_brainstem)         — fast
+#   - Multi-atlas warp (run_multi_atlas_brainstem)            — minutes, no recon
+#   - FreeSurfer substructures (extract_brainstem_freesurfer) — MULTI-HOUR recon
+#
+# Concurrency design:
+#   * The shared MNI->subject SyN warp is computed ONCE up front and reused by
+#     both the HO and multi-atlas paths (no race on the cached transform).
+#   * Each path runs in a BACKGROUND SUBSHELL writing to a per-path log; its exit
+#     code is collected with `wait <pid>`. A failing background job is NON-FATAL:
+#     it logs a WARNING and never aborts the parent or the other paths (the
+#     parent never runs `wait` under a propagating errexit on the job's status).
+#   * Heavy ANTs/recon thread counts are capped so concurrent paths don't
+#     oversubscribe the CPU (ANTS_THREADS split across the heavy paths, honouring
+#     MAX_CPU_INTENSIVE_JOBS).
+#   * Final outputs are non-clobbering: HO -> segmentation/brainstem/<base>_*,
+#     FS parcels -> segmentation/detailed_brainstem/<base>_{pons,midbrain,...},
+#     multi-atlas masks -> segmentation/detailed_brainstem/{bianciardi,cit168}_*.
+# ---------------------------------------------------------------------------
+_extract_brainstem_all_parallel() {
+    local input_file="$1"
+    local input_basename="$2"
+    local brainstem_dir="$3"
 
-    log_formatted "SUCCESS" "Comprehensive segmentation complete"
+    local run_ho="${SEG_RUN_HARVARD_OXFORD:-true}"
+    local run_ma="${SEG_RUN_MULTI_ATLAS:-true}"
+    local run_fs="${SEG_RUN_FREESURFER:-true}"
+
+    log_formatted "INFO" "=== PARALLEL BRAINSTEM SEGMENTATION (method=all) ==="
+    log_message "Enabled paths: harvard_oxford=$run_ho  multi_atlas=$run_ma  freesurfer=$run_fs"
+
+    # Compute the shared MNI->subject warp ONCE (before fan-out) so the HO and
+    # multi-atlas paths reuse the same transform instead of racing on it.
+    if [ "$run_ho" = "true" ] || [ "$run_ma" = "true" ]; then
+        _compute_shared_mni_to_subject_warp "$input_file" >/dev/null || \
+            log_formatted "WARNING" "Shared warp unavailable; HO/multi-atlas will each register independently (still correct, just slower)"
+    fi
+
+    # Cap heavy thread counts so concurrently-running ANTs/recon paths don't
+    # oversubscribe. Count the heavy paths (HO + multi-atlas both run ANTs warps;
+    # FreeSurfer runs recon-all) and divide the ANTS_THREADS budget across them.
+    local heavy_paths=0
+    [ "$run_ho" = "true" ] && heavy_paths=$((heavy_paths + 1))
+    [ "$run_ma" = "true" ] && heavy_paths=$((heavy_paths + 1))
+    [ "$run_fs" = "true" ] && heavy_paths=$((heavy_paths + 1))
+    [ "$heavy_paths" -lt 1 ] && heavy_paths=1
+
+    local total_threads="${ANTS_THREADS:-4}"
+    [[ "$total_threads" =~ ^[0-9]+$ ]] || total_threads=4
+    local per_path_threads=$(( total_threads / heavy_paths ))
+    [ "$per_path_threads" -lt 1 ] && per_path_threads=1
+    # Respect an explicit MAX_CPU_INTENSIVE_JOBS thread cap when set (>0).
+    local max_cpu="${MAX_CPU_INTENSIVE_JOBS:-0}"
+    if [[ "$max_cpu" =~ ^[0-9]+$ ]] && [ "$max_cpu" -gt 0 ] && [ "$per_path_threads" -gt "$max_cpu" ]; then
+        per_path_threads="$max_cpu"
+    fi
+    log_message "Per-path ANTs/recon thread cap: $per_path_threads (of $total_threads across $heavy_paths heavy path(s))"
+
+    local log_dir="${RESULTS_DIR}/logs/segmentation_parallel"
+    mkdir -p "$log_dir"
+
+    local output_prefix="${brainstem_dir}/${input_basename}"
+    local ho_brainstem_mask="${output_prefix}_brainstem.nii.gz"
+
+    # ── Launch background paths ─────────────────────────────────────────────
+    local ho_pid="" ma_pid="" fs_pid=""
+
+    if [ "$run_ho" = "true" ]; then
+        (
+            export ANTS_THREADS="$per_path_threads"
+            log_formatted "INFO" "[parallel] Harvard-Oxford gross extent path starting"
+            if extract_brainstem "$input_file" "$input_basename"; then
+                map_segmentation_files "$input_basename" "$brainstem_dir"
+                log_formatted "SUCCESS" "[parallel] Harvard-Oxford gross extent path complete"
+            else
+                log_formatted "WARNING" "[parallel] Harvard-Oxford gross extent path FAILED (non-fatal)"
+                exit 1
+            fi
+        ) >"${log_dir}/harvard_oxford.log" 2>&1 &
+        ho_pid=$!
+        log_message "  HO path PID=$ho_pid (log: ${log_dir}/harvard_oxford.log)"
+    else
+        log_message "  HO path disabled (SEG_RUN_HARVARD_OXFORD=false)"
+    fi
+
+    if [ "$run_ma" = "true" ]; then
+        (
+            export ANTS_THREADS="$per_path_threads"
+            log_formatted "INFO" "[parallel] Multi-atlas path starting"
+            if run_multi_atlas_brainstem "$input_file" "$input_basename"; then
+                log_formatted "SUCCESS" "[parallel] Multi-atlas path complete"
+            else
+                log_formatted "WARNING" "[parallel] Multi-atlas path FAILED (non-fatal)"
+                exit 1
+            fi
+        ) >"${log_dir}/multi_atlas.log" 2>&1 &
+        ma_pid=$!
+        log_message "  Multi-atlas path PID=$ma_pid (log: ${log_dir}/multi_atlas.log)"
+    else
+        log_message "  Multi-atlas path disabled (SEG_RUN_MULTI_ATLAS=false)"
+    fi
+
+    if [ "$run_fs" = "true" ]; then
+        (
+            export ANTS_THREADS="$per_path_threads"
+            log_formatted "INFO" "[parallel] FreeSurfer substructure path starting (recon-all may run for HOURS)"
+            # Pass the HO mask path for the FS<->HO agreement gate. The gate is
+            # skipped gracefully if the HO mask is not present when it runs (the
+            # FS path is the long pole, so HO normally finishes well before).
+            if extract_brainstem_freesurfer "$input_file" "$output_prefix" "$ho_brainstem_mask"; then
+                log_formatted "SUCCESS" "[parallel] FreeSurfer substructure path complete"
+            else
+                log_formatted "WARNING" "[parallel] FreeSurfer substructure path unavailable/low-confidence (non-fatal)"
+                exit 1
+            fi
+        ) >"${log_dir}/freesurfer.log" 2>&1 &
+        fs_pid=$!
+        log_message "  FreeSurfer path PID=$fs_pid (log: ${log_dir}/freesurfer.log)"
+    else
+        log_message "  FreeSurfer path disabled (SEG_RUN_FREESURFER=false) — skipping multi-hour recon-all"
+    fi
+
+    # ── Collect each path independently (failure is non-fatal) ──────────────
+    # `wait <pid>` returns the job's exit status; we capture it without letting a
+    # non-zero status abort the parent under set -e.
+    SEG_ALL_PATHS_RAN=()
+    SEG_ALL_PATHS_OK=()
+
+    if [ -n "$ho_pid" ]; then
+        local ho_rc=0; wait "$ho_pid" || ho_rc=$?
+        cat "${log_dir}/harvard_oxford.log" 2>/dev/null || true
+        SEG_ALL_PATHS_RAN+=("harvard_oxford")
+        if [ "$ho_rc" -eq 0 ]; then
+            SEG_ALL_PATHS_OK+=("harvard_oxford")
+            log_formatted "SUCCESS" "Harvard-Oxford path: OK"
+        else
+            log_formatted "WARNING" "Harvard-Oxford path: FAILED (rc=$ho_rc) — non-fatal"
+        fi
+    fi
+
+    if [ -n "$ma_pid" ]; then
+        local ma_rc=0; wait "$ma_pid" || ma_rc=$?
+        cat "${log_dir}/multi_atlas.log" 2>/dev/null || true
+        SEG_ALL_PATHS_RAN+=("multi_atlas")
+        if [ "$ma_rc" -eq 0 ]; then
+            SEG_ALL_PATHS_OK+=("multi_atlas")
+            log_formatted "SUCCESS" "Multi-atlas path: OK"
+        else
+            log_formatted "WARNING" "Multi-atlas path: FAILED (rc=$ma_rc) — non-fatal"
+        fi
+    fi
+
+    if [ -n "$fs_pid" ]; then
+        local fs_rc=0; wait "$fs_pid" || fs_rc=$?
+        cat "${log_dir}/freesurfer.log" 2>/dev/null || true
+        SEG_ALL_PATHS_RAN+=("freesurfer")
+        if [ "$fs_rc" -eq 0 ]; then
+            SEG_ALL_PATHS_OK+=("freesurfer")
+            log_formatted "SUCCESS" "FreeSurfer path: OK"
+        else
+            log_formatted "WARNING" "FreeSurfer path: unavailable/low-confidence (rc=$fs_rc) — non-fatal"
+        fi
+    fi
+
+    # NOTE: bash cannot export arrays; SEG_ALL_PATHS_RAN/OK remain plain shell
+    # variables in this process. _seg_method_report_line (called in-process via
+    # command substitution by the report generators) reads them via declare -p,
+    # so no export is needed or possible.
+    log_formatted "INFO" "Parallel segmentation paths ran: ${SEG_ALL_PATHS_RAN[*]:-none}; succeeded: ${SEG_ALL_PATHS_OK[*]:-none}"
+
+    # The canonical gross brainstem mask (segmentation/brainstem/<base>_brainstem.nii.gz)
+    # is a HARD pipeline requirement: pipeline.sh aborts the segmentation stage if
+    # it is missing. Only the Harvard-Oxford path writes it. When the HO path is
+    # disabled (SEG_RUN_HARVARD_OXFORD=false) or failed, but a substructure path
+    # (FreeSurfer / multi-atlas) succeeded, SYNTHESISE the gross mask from the
+    # union of the produced substructure masks so the contract holds and downstream
+    # gets a real fallback extent — rather than silently aborting the whole run.
+    if [ ! -f "$ho_brainstem_mask" ]; then
+        log_formatted "WARNING" "Harvard-Oxford gross brainstem mask absent; synthesising it from the union of the substructure masks that succeeded"
+        if _synthesize_gross_brainstem_from_substructures "$input_basename" "$ho_brainstem_mask"; then
+            log_formatted "SUCCESS" "Synthesised gross brainstem mask from substructure union: $ho_brainstem_mask"
+        else
+            log_formatted "WARNING" "Could not synthesise a gross brainstem mask (no substructure masks available)"
+        fi
+    fi
+
+    # Non-fatal overall: as long as SOMETHING ran, downstream find_all_atlas_regions
+    # discovers the union of whatever masks the successful paths produced.
+    if [ ${#SEG_ALL_PATHS_OK[@]} -eq 0 ]; then
+        log_formatted "ERROR" "All parallel segmentation paths failed"
+        return 1
+    fi
+    return 0
+}
+
+# ---------------------------------------------------------------------------
+# _synthesize_gross_brainstem_from_substructures - build the canonical gross
+# brainstem mask + hemisphere splits from the union of substructure masks.
+#
+# Used in 'all' mode when the Harvard-Oxford path did not produce
+# segmentation/brainstem/<base>_brainstem.nii.gz (HO disabled or failed) but a
+# substructure path (FreeSurfer parcels and/or multi-atlas aggregated
+# subdivisions) did. The union of those subdivision masks is a valid gross
+# brainstem extent, so it satisfies the pipeline's mandatory-output contract and
+# serves as the analysis fallback. Returns 0 on success (mask written), 1 if no
+# substructure masks were available to union.
+#
+# Args: <input_basename> <out_brainstem_mask>
+# ---------------------------------------------------------------------------
+_synthesize_gross_brainstem_from_substructures() {
+    local input_basename="$1"
+    local out_mask="$2"
+
+    local detailed_dir="${RESULTS_DIR}/segmentation/detailed_brainstem"
+    [ -d "$detailed_dir" ] || return 1
+
+    mkdir -p "$(dirname "$out_mask")"
+
+    # Union the gross subdivision masks (FreeSurfer parcels + multi-atlas
+    # aggregated subdivisions) — NOT the tiny individual nuclei — so the result
+    # is a coherent gross extent. Match the *_pons/*_midbrain/*_medulla/*_scp
+    # families (with optional left/right) from any source.
+    local first=1 f
+    local tmp_union; tmp_union=$(mktemp -d)/union.nii.gz
+    shopt -s nullglob
+    for f in \
+        "$detailed_dir"/*_midbrain.nii.gz "$detailed_dir"/*_pons.nii.gz \
+        "$detailed_dir"/*_medulla.nii.gz "$detailed_dir"/*_scp.nii.gz \
+        "$detailed_dir"/*left_midbrain*.nii.gz "$detailed_dir"/*right_midbrain*.nii.gz \
+        "$detailed_dir"/*left_pons*.nii.gz "$detailed_dir"/*right_pons*.nii.gz \
+        "$detailed_dir"/*left_medulla*.nii.gz "$detailed_dir"/*right_medulla*.nii.gz \
+        "$detailed_dir"/*left_scp*.nii.gz "$detailed_dir"/*right_scp*.nii.gz; do
+        [ -f "$f" ] || continue
+        case "$(basename "$f")" in *_intensity*|*_flair_*) continue ;; esac
+        if [ "$first" -eq 1 ]; then
+            safe_fslmaths "synth gross init" "$f" -bin "$tmp_union" >/dev/null 2>&1 || continue
+            first=0
+        else
+            safe_fslmaths "synth gross add" "$tmp_union" -max "$f" -bin "$tmp_union" >/dev/null 2>&1 || true
+        fi
+    done
+    shopt -u nullglob
+
+    if [ "$first" -eq 1 ] || [ ! -f "$tmp_union" ]; then
+        rm -rf "$(dirname "$tmp_union")"
+        return 1
+    fi
+
+    cp -f "$tmp_union" "$out_mask"
+    rm -rf "$(dirname "$tmp_union")"
+
+    # Produce the hemisphere splits the report/QC reference, mirroring
+    # generate_hemisphere_masks (hierarchical_joint_fusion.sh).
+    local output_prefix="${out_mask%_brainstem.nii.gz}"
+    if declare -f generate_hemisphere_masks >/dev/null 2>&1; then
+        generate_hemisphere_masks "$out_mask" "$output_prefix" >/dev/null 2>&1 || true
+    fi
     return 0
 }
 
@@ -423,7 +801,7 @@ Subject: $input_basename
 
 SEGMENTATION SUMMARY
 -------------------
-Method: ${BRAINSTEM_SEGMENTATION_METHOD:-freesurfer} (gross extent: Harvard-Oxford; substructures: FreeSurfer brainstemSsLabels)
+Method: $(_seg_method_report_line) (gross extent: Harvard-Oxford; substructures: FreeSurfer brainstemSsLabels and/or multi-atlas nuclei)
 Space: T1 Native Space
 Brainstem voxels: $brainstem_voxels
 
@@ -551,6 +929,11 @@ export -f enhance_segmentation_with_flair
 export -f generate_segmentation_report
 export -f extract_brainstem_with_flair
 export -f extract_brainstem_final
+export -f _extract_brainstem_single_method
+export -f _extract_brainstem_all_parallel
+export -f _synthesize_gross_brainstem_from_substructures
+export -f _compute_shared_mni_to_subject_warp
+export -f _seg_method_report_line
 export -f map_segmentation_files
 export -f validate_segmentation_outputs
 export -f create_combined_segmentation_map
@@ -566,4 +949,4 @@ export -f validate_segmentation
 export -f discover_and_map_segmentation_files
 export -f segment_brainstem
 
-log_message "Segmentation module loaded (Harvard-Oxford gross extent + FreeSurfer substructures)"
+log_message "Segmentation module loaded (parallel paths: Harvard-Oxford + multi-atlas + FreeSurfer; default method=all)"

--- a/tests/run_segmentation_tests.sh
+++ b/tests/run_segmentation_tests.sh
@@ -135,9 +135,11 @@ if [ -f "${TEMPLATE_DIR}/${EXTRACTION_TEMPLATE}" ]; then
         echo "⚠ Juelich pons extraction failed (expected with template input)"
     fi
     
-    # Test full brainstem extraction
+    # Test full brainstem extraction. Pin the exclusive 'atlas' method: the new
+    # default ('all') fans out to concurrent paths including the multi-hour
+    # FreeSurfer recon-all, which must not run in this diagnostic harness.
     echo "Testing full brainstem extraction..."
-    if extract_brainstem_final "$test_input" 2>/dev/null; then
+    if BRAINSTEM_SEGMENTATION_METHOD=atlas extract_brainstem_final "$test_input" 2>/dev/null; then
         echo "✓ Full brainstem extraction completed"
     else
         echo "⚠ Full brainstem extraction failed (expected with template input)"

--- a/tests/test_segmentation.sh
+++ b/tests/test_segmentation.sh
@@ -269,8 +269,14 @@ test_integration() {
         # '|| exit_code=$?', so the segmentation module's 'set -e' aborting on
         # mock/incomplete data only exits the subshell instead of tripping the
         # test process's own inherited 'set -e' and killing the suite.
+        #
+        # Pin the EXCLUSIVE 'atlas' method here: the new default ('all') fans out
+        # to concurrent paths INCLUDING the multi-hour FreeSurfer recon-all, which
+        # must never run in the unit suite. 'atlas' exercises the real
+        # extract_brainstem_final -> HO gross path (the function-can-be-called
+        # intent of this test) in bounded time, with no recon-all / fan-out.
         local exit_code=0
-        ( extract_brainstem_final "$TEST_IMAGE" ) >/dev/null 2>&1 || exit_code=$?
+        ( BRAINSTEM_SEGMENTATION_METHOD=atlas extract_brainstem_final "$TEST_IMAGE" ) >/dev/null 2>&1 || exit_code=$?
         
         # We expect this might fail due to missing dependencies, but it shouldn't
         # crash the suite. Any clean exit (0 = success, non-zero = graceful


### PR DESCRIPTION
## Summary

Makes BrainStemX-Full run **all** brainstem-segmentation methods as **concurrent parallel paths** (new default `BRAINSTEM_SEGMENTATION_METHOD=all`) instead of one mutually-exclusive sequential method, and processes each source as a parallel per-region analysis track.

Previously `extract_brainstem_final()` ran the Harvard-Oxford gross extent, then dispatched **mutually exclusively** on the method (default `freesurfer`), so only one substructure method ran, sequentially.

## Parallel design

`_extract_brainstem_all_parallel()` launches three independent paths as background subshells, collecting exit codes with `wait <pid>`:

| Path | Cost | Output |
|---|---|---|
| Harvard-Oxford gross extent (`extract_brainstem`) | fast | `segmentation/brainstem/<base>_brainstem.nii.gz` |
| Multi-atlas warp (`run_multi_atlas_brainstem`, Bianciardi/CIT168/AAL3) | minutes, no recon | `segmentation/detailed_brainstem/{bianciardi,cit168,aal3}_*` |
| FreeSurfer substructures (`extract_brainstem_freesurfer`, recon-all→segmentBS) | **multi-hour** | `segmentation/detailed_brainstem/<base>_{pons,midbrain,medulla,scp}` |

The fast paths' outputs are usable as soon as they finish, even while recon-all continues. Each path is **independent and non-fatal**: a failed/skipped path logs a WARNING and never kills the others or the pipeline (the parent collects exit codes via `wait` and never lets a non-zero background status abort it under `set -e`). Heavy ANTs/recon thread counts are capped by splitting `ANTS_THREADS` across the concurrent heavy paths (honouring `MAX_CPU_INTENSIVE_JOBS`).

## Shared-warp race mitigation

The MNI→subject SyN registration is needed by **both** the HO path and the multi-atlas path. Two background jobs writing the same cached transform prefix concurrently would corrupt it. Mitigation: `_compute_shared_mni_to_subject_warp()` computes the warp **once up front, before the fan-out**, into `segmentation/shared_mni_registration/` and exports `SEG_SHARED_MNI_REG_PREFIX`. Both paths then **copy** that transform (read-only) into their own workspace rather than recomputing/racing on it. When the shared warp is unavailable (single-method runs), each path falls back to computing its own — still correct, just no longer shared.

## Per-method toggles (default on, incl. the recon-all opt-out)

`SEG_RUN_HARVARD_OXFORD` / `SEG_RUN_MULTI_ATLAS` / `SEG_RUN_FREESURFER` (all default `true`) drop individual paths from the `all` fan-out. **`SEG_RUN_FREESURFER=false`** keeps the fast HO + multi-atlas paths and skips the multi-hour recon-all.

## Non-clobbering union outputs + parallel per-source analysis

- Final outputs are non-clobbering: FS parcels (`<base>_pons` …), multi-atlas masks (`bianciardi_*`/`cit168_*`), and the HO gross mask use distinct names/subdirs.
- `find_all_atlas_regions` now discovers the **union** of every produced mask (FS parcels + multi-atlas aggregated subdivisions + nucleus-level masks).
- `apply_per_region_gmm_analysis` runs the per-region GMM across that union, **tagging provenance** (`freesurfer` / `bianciardi` / `cit168` / `aal3` / `harvard_oxford`), namespacing per-source work dirs and `*_GMM.nii.gz` outputs so same-named regions from different sources (e.g. FreeSurfer pons vs Bianciardi pons) never clobber, and writing a `region_provenance.tsv` manifest.

## Robustness (code-review findings fixed)

- **Mandatory-output contract:** in `all` mode, when the HO path is disabled (`SEG_RUN_HARVARD_OXFORD=false`) or failed but a substructure path succeeded, the canonical `<base>_brainstem.nii.gz` is **synthesised from the union of substructure masks** (+ hemisphere splits), so the pipeline's required segmentation output exists instead of the whole run aborting at `pipeline.sh` validation.
- **`check_atlas_availability`** gains an `all` arm (warns per **enabled** path about missing atlases) and its default now matches the config default.
- Array handling cleaned up (`${#arr[@]}` length test instead of testing element 0; dropped the no-op array `export`).

## Backwards compatibility

The exclusive single-method values (`freesurfer` / `multi_atlas` / `bianciardi` / `atlas` / `harvard_oxford`) remain mutually exclusive and behave exactly as before, via `_extract_brainstem_single_method`.

## Verification

- `git ls-files '*.sh' | xargs -I{} bash -n {}` — clean
- `git ls-files '*.sh' | xargs shellcheck --severity=error` — clean
- Unit suites pass: `test_environment_unit` (100), `test_pipeline_control_unit` (98), `test_import_unit` (29), `test_multi_atlas_unit` (22), `test_segmentation` (15); `pipeline.sh --help` smoke OK.
- Functional traces (real FSL+ANTs+atlases present; FreeSurfer dry-run, **no recon-all executed**): confirmed `all` launches HO + multi-atlas concurrently, the shared MNI→subject warp is computed **exactly once** (no race/corruption), both emit non-clobbering masks, `find_all_atlas_regions` discovers the union, `SEG_RUN_FREESURFER=false` cleanly drops only the recon path, the FS path degrades gracefully without invoking recon-all, and the gross-mask synthesis satisfies the pipeline's output contract when HO is disabled.
- Unit/diagnostic tests that invoke the real `extract_brainstem_final` are pinned to a bounded method so the new `all` default never triggers recon-all in the suite.

🤖 Generated with [Claude Code](https://claude.com/claude-code)