### PR TITLE
FreeSurfer everything: full recon harvest (aseg/wmparc/aparc/subregions/stats) + ML methods (SynthSeg+/SynthSR/sclimbic); wire aseg CSF into FP-exclusion

### DIFF
--- a/config/default_config.sh
+++ b/config/default_config.sh
@@ -121,6 +121,44 @@ export BRAINSTEM_SEGMENTATION_METHOD="${BRAINSTEM_SEGMENTATION_METHOD:-all}"
 export SEG_RUN_HARVARD_OXFORD="${SEG_RUN_HARVARD_OXFORD:-true}"
 export SEG_RUN_MULTI_ATLAS="${SEG_RUN_MULTI_ATLAS:-true}"
 export SEG_RUN_FREESURFER="${SEG_RUN_FREESURFER:-true}"
+#   SEG_RUN_SYNTHSEG       : SynthSeg+ fast ML path (mri_synthseg --robust). ~1 min,
+#                            NO recon, contrast/resolution-agnostic (works on 2D/
+#                            thick-slice clinical T1). Yields aseg-equivalent
+#                            subcortical labels + CSF/ventricle masks + volumes
+#                            immediately. Its CSF/ventricle output is an ALTERNATE
+#                            fast source for the FP-exclusion CSF mask (so the
+#                            posterior-fossa pseudolesion filter works even without
+#                            a recon). Default ON (cheap).
+export SEG_RUN_SYNTHSEG="${SEG_RUN_SYNTHSEG:-true}"
+export SEG_SYNTHSEG_ROBUST="${SEG_SYNTHSEG_ROBUST:-true}"   # --robust => SynthSeg+ (slower, contrast-robust)
+export SEG_SYNTHSEG_PARC="${SEG_SYNTHSEG_PARC:-false}"      # --parc => add cortical parcellation (slower)
+
+# ---------------------------------------------------------------------------
+# FreeSurfer FULL-RECON HARVEST + extra ML methods (freesurfer_harvest.sh)
+# ---------------------------------------------------------------------------
+# recon-all is paid for ONCE; these harvest the rest of its output (NO second
+# recon). CHEAP harvests default ON; the multi-hour / extra-time pieces default
+# OFF (opt-in). Each piece is independently gated and degrades gracefully when
+# the relevant FreeSurfer tool is unavailable.
+export FS_HARVEST_ASEG_CSF="${FS_HARVEST_ASEG_CSF:-true}"   # CHEAP: aseg CSF/ventricle binary masks (FP-exclusion win)
+export FS_HARVEST_STATS="${FS_HARVEST_STATS:-true}"         # CHEAP: aseg/wmparc/aparc/aparc.a2009s + eTIV stats tables
+export FS_HARVEST_THALAMUS="${FS_HARVEST_THALAMUS:-false}"  # ADDS TIME (~minutes): segment_subregions thalamus
+export FS_HARVEST_HIPPO_AMYGDALA="${FS_HARVEST_HIPPO_AMYGDALA:-false}" # ADDS TIME (~up to 1h): segment_subregions hippo-amygdala
+export FS_HARVEST_HYPOTHALAMUS="${FS_HARVEST_HYPOTHALAMUS:-false}"     # ADDS TIME (~minutes): mri_segment_hypothalamic_subunits
+export FS_HARVEST_SCLIMBIC="${FS_HARVEST_SCLIMBIC:-false}"  # DL limbic subcortical seg (mri_sclimbic_seg); also a parallel path in 'all' mode
+
+# SynthSR pre-step (mri_synthsr): synthesize a 1mm isotropic T1 from a low-res /
+# 2D clinical T1, used as the recon-all input AND the T1->MNI registration master
+# (improves both on thick-slice T1). DEFAULT OFF — it adds a step + changes the
+# working T1; opt in for clinical thick-slice data. Graceful no-op if absent.
+export USE_SYNTHSR="${USE_SYNTHSR:-false}"
+
+# CSF source preference for the FP-exclusion (#114) + fp_filter CSF-distance
+# stages. When true (default) the FreeSurfer/SynthSeg aseg 4th-ventricle/CSF mask
+# (fs_harvest_find_csf_mask) is preferred over the FSL FAST CSF PVE for the
+# posterior-fossa pseudolesion problem; falls back to FAST PVE when absent. Set
+# to false to force the legacy FAST-PVE-only behaviour.
+export CSF_USE_FREESURFER_MASK="${CSF_USE_FREESURFER_MASK:-true}"
 
 # FreeSurfer brainstem-segmentation knobs (used by brainstem_freesurfer.sh).
 # FREESURFER_HOME / FS_LICENSE are honoured from the environment; the module

--- a/src/modules/analysis.sh
+++ b/src/modules/analysis.sh
@@ -894,11 +894,18 @@ apply_gaussian_mixture_thresholding() {
 
 
 
-# Build a binary CSF exclusion mask (in the target/FLAIR space) from the FSL FAST
-# CSF PVE map.  The CSF map is region-independent, so this is computed ONCE per
-# subject and reused for every region (avoids re-resampling the whole-brain PVE
-# map per region).  Posterior-fossa CSF (4th ventricle, basal cisterns) is the
-# dominant FALSE-POSITIVE source for brainstem FLAIR.
+# Build a binary CSF exclusion mask (in the target/FLAIR space).  The CSF map is
+# region-independent, so this is computed ONCE per subject and reused for every
+# region (avoids re-resampling the whole-brain map per region).  Posterior-fossa
+# CSF (4th ventricle, basal cisterns) is the dominant FALSE-POSITIVE source for
+# brainstem FLAIR.
+#
+# CSF SOURCE PREFERENCE (#135 FreeSurfer harvest, task B):
+#   When available AND CSF_USE_FREESURFER_MASK=true, prefer the FreeSurfer aseg
+#   (or SynthSeg) 4th-ventricle / CSF mask harvested by freesurfer_harvest.sh
+#   (fs_harvest_find_csf_mask) — it delineates the posterior-fossa CSF far better
+#   than the FAST CSF PVE for the brainstem pseudolesion problem. Fall back to the
+#   FAST CSF PVE (<csf_prob>) when no FreeSurfer/SynthSeg mask is present.
 #
 # Usage: build_csf_exclusion_mask <csf_prob_map> <reference_image> <output_mask>
 # Returns 0 on success (output written), 1 if no usable exclusion mask could be
@@ -908,14 +915,48 @@ build_csf_exclusion_mask() {
     local reference_image="$2"
     local output_mask="$3"
 
+    local csf_pve_threshold="${CSF_PVE_THRESHOLD:-0.5}"
+
+    # Prefer the FreeSurfer/SynthSeg aseg CSF mask (already binary) when present.
+    # fs_harvest_find_csf_mask returns the best available aseg/synthseg csf_all
+    # (CSF + ventricles) mask, empty if none. Gated so the legacy FAST-PVE
+    # behaviour can be restored with CSF_USE_FREESURFER_MASK=false.
+    if [ "${CSF_USE_FREESURFER_MASK:-true}" = "true" ] && declare -f fs_harvest_find_csf_mask >/dev/null 2>&1; then
+        local fs_csf_mask
+        fs_csf_mask="$(fs_harvest_find_csf_mask)"
+        if [ -n "$fs_csf_mask" ] && [ -f "$fs_csf_mask" ]; then
+            log_message "Building CSF exclusion mask from FreeSurfer/SynthSeg aseg CSF mask (preferred over FAST PVE for posterior-fossa): $fs_csf_mask"
+            local work_dir_fs
+            work_dir_fs=$(mktemp -d)
+            local fs_resampled="$fs_csf_mask"
+            if ! _analysis_same_space "$reference_image" "$fs_csf_mask"; then
+                fs_resampled="${work_dir_fs}/fs_csf_resampled.nii.gz"
+                log_message "Resampling FreeSurfer CSF mask to reference space..."
+                if ! flirt -in "$fs_csf_mask" -ref "$reference_image" -out "$fs_resampled" -applyxfm -usesqform -interp nearestneighbour; then
+                    log_formatted "WARNING" "FreeSurfer CSF mask resampling failed; falling back to FAST CSF PVE"
+                    rm -rf "$work_dir_fs"
+                    fs_resampled=""
+                fi
+            fi
+            # The harvested mask is already binary; -bin guards against any
+            # interpolation residue introduced by a (nearest-neighbour) resample.
+            if [ -n "$fs_resampled" ] && safe_fslmaths "Build CSF exclusion mask (FreeSurfer aseg)" \
+                    "$fs_resampled" -bin "$output_mask"; then
+                rm -rf "$work_dir_fs"
+                log_message "✓ CSF exclusion mask built from FreeSurfer/SynthSeg aseg CSF"
+                return 0
+            fi
+            rm -rf "$work_dir_fs" 2>/dev/null || true
+            log_formatted "WARNING" "Could not use FreeSurfer CSF mask; falling back to FAST CSF PVE"
+        fi
+    fi
+
     log_message "Building CSF exclusion mask from FAST CSF PVE map..."
 
     if [ -z "$csf_prob" ] || [ ! -f "$csf_prob" ]; then
         log_formatted "WARNING" "CSF PVE map not available ($csf_prob); CSF subtraction will be skipped"
         return 1
     fi
-
-    local csf_pve_threshold="${CSF_PVE_THRESHOLD:-0.5}"
 
     local work_dir
     work_dir=$(mktemp -d)

--- a/src/modules/brainstem_freesurfer.sh
+++ b/src/modules/brainstem_freesurfer.sh
@@ -27,6 +27,10 @@ fi
 _BRAINSTEM_FS_LOADED=1
 
 source "$(dirname "${BASH_SOURCE[0]}")/require_env.sh"
+# Full-recon harvest + FreeSurfer ML methods (aseg CSF masks, stats, subregions,
+# SynthSeg+/SynthSR/sclimbic). Sourced here so extract_brainstem_freesurfer can
+# harvest everything from the SAME recon-all (no second recon).
+source "$(dirname "${BASH_SOURCE[0]}")/freesurfer_harvest.sh"
 
 # FreeSurfer brainstemSsLabels label values (FreeSurferColorLUT.txt):
 #   173 = Midbrain, 174 = Pons, 175 = Medulla, 178 = SCP
@@ -665,6 +669,17 @@ extract_brainstem_freesurfer() {
     if ! run_recon_all "$recon_input" "$subjects_dir" "$subject_id"; then
         log_formatted "WARNING" "recon-all failed — falling back to atlas/HO gross mask"
         return 1
+    fi
+
+    # Harvest the FULL recon (aseg CSF/ventricle masks + stats + gated subregions)
+    # from the SAME recon-all — NO second recon. This runs regardless of the
+    # brainstem-parcel agreement gate below, because the aseg CSF masks (the
+    # FP-exclusion win) and the volumetric stats are valuable independent of the
+    # brainstem-substructure confidence. Always non-fatal. The pipeline input
+    # geometry ($input_file) is used as the resample reference.
+    if declare -f fs_harvest_recon >/dev/null 2>&1; then
+        fs_harvest_recon "$subjects_dir" "$subject_id" "$input_file" || \
+            log_formatted "WARNING" "FreeSurfer recon harvest reported a non-fatal issue"
     fi
 
     local fs_labels

--- a/src/modules/freesurfer_harvest.sh
+++ b/src/modules/freesurfer_harvest.sh
@@ -1,0 +1,643 @@
+#!/usr/bin/env bash
+#
+# freesurfer_harvest.sh - harvest the FULL FreeSurfer output from one recon-all
+#                         + fast FreeSurfer ML methods (SynthSeg+/SynthSR/sclimbic).
+#
+# Rationale: recon-all is paid for ONCE (hours). Once it has completed for the
+# subject (aseg.mgz present), a long tail of additional outputs is essentially
+# free or cheap to extract from the SAME recon:
+#   - aseg subcortical seg  -> aseg.stats volumes + CSF/ventricle binary masks
+#   - wmparc               -> wmparc.stats
+#   - aparc (Desikan-Killiany) + aparc.a2009s (Destrieux) -> their .stats +
+#     surface morphometry (thickness/area/curv)
+#   - eTIV / brain volume   -> asegstats2table / mri_segstats
+#   - segment_subregions thalamus / hippo-amygdala         (minutes..~1h each)
+#   - mri_segment_hypothalamic_subunits                    (minutes)
+# All of these run on the FINISHED recon (NO second recon-all).
+#
+# Fast ML methods (NO recon required — run directly on a clinical/2D T1):
+#   - SynthSeg+  (mri_synthseg --robust)  : contrast/resolution-agnostic
+#       whole-brain seg in ~1 min. Yields aseg-equivalent subcortical labels +
+#       CSF/ventricle masks + per-structure volumes WITHOUT recon-all. Its
+#       CSF/ventricle output is an ALTERNATE fast source for the FP-exclusion
+#       CSF mask (so the posterior-fossa pseudolesion filter works even without
+#       a recon).
+#   - SynthSR    (mri_synthsr)            : synthesize a 1mm isotropic T1 from a
+#       thick-slice / low-res clinical T1; usable as the recon-all input AND the
+#       T1->MNI master. Optional pre-step (USE_SYNTHSR=false default).
+#   - mri_sclimbic_seg                    : DL limbic subcortical seg; gated.
+#
+# Conventions: every tool is detected with `command -v`; absent => clear WARNING
+# + non-fatal skip (never aborts the pipeline). All behaviour gated by config
+# toggles. CSF/ventricle masks the FP-exclusion path can consume are written to
+# a stable, discoverable location (RESULTS_DIR/freesurfer/harvest/csf_masks).
+#
+# This is a SOURCED module: it does NOT enable `set -e -u -o pipefail` at the
+# top (that would leak into the parent shell). Every function tolerates the
+# pipeline's `set -e -u -o pipefail` and returns 0 on tool-missing/disabled
+# paths so a run never aborts on the harvest.
+#
+
+# Include guard
+if [ -n "${_FREESURFER_HARVEST_LOADED:-}" ]; then
+    return 0 2>/dev/null || true
+fi
+_FREESURFER_HARVEST_LOADED=1
+
+source "$(dirname "${BASH_SOURCE[0]}")/require_env.sh"
+
+# ---------------------------------------------------------------------------
+# aseg / SynthSeg CSF + ventricle label values (FreeSurferColorLUT.txt). Both
+# aseg.mgz and SynthSeg output share the same label scheme, so one list serves
+# both.  4/43 = lateral ventricles, 5/44 = inferior-lateral ventricles,
+# 14 = 3rd ventricle, 15 = 4th ventricle (the posterior-fossa one that matters
+# most for brainstem pseudolesions), 24 = CSF, 72 = 5th ventricle.
+# ---------------------------------------------------------------------------
+export FS_VENTRICLE_LABELS="${FS_VENTRICLE_LABELS:-4 5 14 15 43 44 72}"
+export FS_CSF_LABEL="${FS_CSF_LABEL:-24}"
+export FS_FOURTH_VENTRICLE_LABEL="${FS_FOURTH_VENTRICLE_LABEL:-15}"
+
+# ---------------------------------------------------------------------------
+# Small wrapper around safe_fslmaths with a bare-fslmaths fallback (mirrors the
+# wmh_synthseg.sh helper) so the module also works in standalone debugging.
+# ---------------------------------------------------------------------------
+_fsh_fslmaths() {
+    local description="$1"
+    shift
+    if declare -F safe_fslmaths >/dev/null 2>&1; then
+        safe_fslmaths "$description" "$@"
+    else
+        log_message "$description (safe_fslmaths unavailable, using fslmaths): fslmaths $*"
+        fslmaths "$@"
+    fi
+}
+
+# Resolve the harvest output root for a subject (stable + discoverable).
+_fsh_harvest_dir() {
+    local dir="${RESULTS_DIR:-../mri_results}/freesurfer/harvest"
+    mkdir -p "$dir" 2>/dev/null || true
+    echo "$dir"
+}
+
+# Voxel count of a binary mask (0 on any failure). Never aborts.
+_fsh_voxels() {
+    local mask="$1"
+    local v
+    v=$(fslstats "$mask" -V 2>/dev/null | awk '{print $1}')
+    [[ "$v" =~ ^[0-9]+$ ]] || v=0
+    echo "$v"
+}
+
+# ===========================================================================
+# A. Harvest existing recon-all outputs (NO second recon)
+# ===========================================================================
+
+# ---------------------------------------------------------------------------
+# fs_harvest_extract_csf_masks - split aseg.mgz CSF/ventricle labels into binary
+# masks, resampled into the pipeline geometry. The 4th-ventricle / whole-CSF
+# masks are the real accuracy win for the posterior-fossa pseudolesion problem
+# (better than the FAST CSF PVE there). Written to a stable location the
+# FP-exclusion path discovers (fs_harvest_find_csf_mask).
+#
+# Args: <seg_volume(.mgz|.nii.gz)> <geometry_reference(.nii.gz)> <out_dir> <tag>
+#   <seg_volume>  aseg.mgz OR a SynthSeg label volume (same label scheme).
+#   <tag>         provenance tag baked into filenames ("aseg" | "synthseg").
+# Writes:
+#   <out_dir>/<tag>_csf.nii.gz             (LUT 24 only)
+#   <out_dir>/<tag>_fourth_ventricle.nii.gz (LUT 15)
+#   <out_dir>/<tag>_ventricles.nii.gz       (all ventricle labels)
+#   <out_dir>/<tag>_csf_all.nii.gz          (CSF + all ventricles; FP source)
+# Returns 0 if csf_all produced any voxels, 1 otherwise. Never aborts.
+# ---------------------------------------------------------------------------
+fs_harvest_extract_csf_masks() {
+    local seg_volume="$1"
+    local geom_ref="$2"
+    local out_dir="$3"
+    local tag="${4:-aseg}"
+
+    log_message "Harvesting ${tag} CSF/ventricle masks from: $seg_volume"
+
+    if [ ! -f "$seg_volume" ]; then
+        log_formatted "WARNING" "fs_harvest_extract_csf_masks: seg volume missing: $seg_volume"
+        return 1
+    fi
+    if ! command -v mri_convert >/dev/null 2>&1; then
+        log_formatted "WARNING" "fs_harvest_extract_csf_masks: mri_convert not found; cannot harvest CSF masks"
+        return 1
+    fi
+
+    mkdir -p "$out_dir"
+
+    local work_dir
+    work_dir=$(mktemp -d)
+
+    # Bring the label volume onto the pipeline geometry (nearest-neighbour keeps
+    # the discrete labels). When a geometry reference is supplied, resample to it;
+    # otherwise just convert to NIfTI on its own grid. `-odt int` is REQUIRED:
+    # without it mri_convert defaults to a scaled float output that corrupts the
+    # integer label values (observed range overflow), zeroing every extracted mask.
+    local seg_nii="${work_dir}/seg_geom.nii.gz"
+    if [ -n "$geom_ref" ] && [ -f "$geom_ref" ]; then
+        if ! mri_convert -rl "$geom_ref" -rt nearest -odt int "$seg_volume" "$seg_nii" >/dev/null 2>&1; then
+            log_formatted "WARNING" "fs_harvest_extract_csf_masks: resample to geometry reference failed; using native grid"
+            mri_convert -odt int "$seg_volume" "$seg_nii" >/dev/null 2>&1 || { rm -rf "$work_dir"; return 1; }
+        fi
+    else
+        mri_convert -odt int "$seg_volume" "$seg_nii" >/dev/null 2>&1 || { rm -rf "$work_dir"; return 1; }
+    fi
+
+    local csf_mask="${out_dir}/${tag}_csf.nii.gz"
+    local fourth_mask="${out_dir}/${tag}_fourth_ventricle.nii.gz"
+    local vent_mask="${out_dir}/${tag}_ventricles.nii.gz"
+    local csf_all="${out_dir}/${tag}_csf_all.nii.gz"
+
+    # Whole-CSF label (24).
+    _fsh_fslmaths "${tag} CSF (LUT ${FS_CSF_LABEL})" \
+        "$seg_nii" -thr "$FS_CSF_LABEL" -uthr "$FS_CSF_LABEL" -bin "$csf_mask" || true
+
+    # 4th ventricle (15) — the posterior-fossa one most relevant to brainstem.
+    _fsh_fslmaths "${tag} 4th ventricle (LUT ${FS_FOURTH_VENTRICLE_LABEL})" \
+        "$seg_nii" -thr "$FS_FOURTH_VENTRICLE_LABEL" -uthr "$FS_FOURTH_VENTRICLE_LABEL" -bin "$fourth_mask" || true
+
+    # All ventricles (union of FS_VENTRICLE_LABELS).
+    _fsh_fslmaths "${tag} ventricles init" "$seg_nii" -mul 0 "$vent_mask" || true
+    local lbl
+    for lbl in $FS_VENTRICLE_LABELS; do
+        local one="${work_dir}/.vent_${lbl}.nii.gz"
+        if _fsh_fslmaths "${tag} ventricle label $lbl" \
+                "$seg_nii" -thr "$lbl" -uthr "$lbl" -bin "$one"; then
+            _fsh_fslmaths "${tag} ventricle accumulate $lbl" \
+                "$vent_mask" -add "$one" -bin "$vent_mask" || true
+        fi
+        rm -f "$one" 2>/dev/null || true
+    done
+
+    # csf_all = CSF (24) + all ventricles — the FP-exclusion source mask.
+    _fsh_fslmaths "${tag} CSF+ventricles union" \
+        "$csf_mask" -add "$vent_mask" -bin "$csf_all" || true
+
+    rm -rf "$work_dir"
+
+    local csf_vox vent_vox fourth_vox all_vox
+    csf_vox=$(_fsh_voxels "$csf_mask")
+    vent_vox=$(_fsh_voxels "$vent_mask")
+    fourth_vox=$(_fsh_voxels "$fourth_mask")
+    all_vox=$(_fsh_voxels "$csf_all")
+    log_message "  ${tag} CSF=${csf_vox}  4th-vent=${fourth_vox}  ventricles=${vent_vox}  csf_all=${all_vox} voxels"
+
+    if [ "$all_vox" -gt 0 ]; then
+        log_formatted "SUCCESS" "${tag} CSF/ventricle masks harvested: $out_dir"
+        return 0
+    fi
+    log_formatted "WARNING" "${tag} CSF/ventricle harvest produced 0 voxels"
+    return 1
+}
+
+# ---------------------------------------------------------------------------
+# fs_harvest_find_csf_mask - locate the best FreeSurfer/SynthSeg CSF mask for
+# the FP-exclusion path. Preference order (best posterior-fossa fidelity first):
+#   1. aseg csf_all   (recon-derived; most accurate)
+#   2. synthseg csf_all (fast ML; available without recon)
+# Echoes the path (empty if none); always returns 0. The FP path falls back to
+# the FAST CSF PVE when this returns empty.
+# ---------------------------------------------------------------------------
+fs_harvest_find_csf_mask() {
+    local harvest_dir
+    harvest_dir="$(_fsh_harvest_dir)/csf_masks"
+    local candidate
+    for candidate in \
+        "${harvest_dir}/aseg_csf_all.nii.gz" \
+        "${harvest_dir}/synthseg_csf_all.nii.gz" \
+        "${harvest_dir}/aseg_csf.nii.gz" \
+        "${harvest_dir}/synthseg_csf.nii.gz"; do
+        if [ -f "$candidate" ]; then
+            local vox
+            vox=$(_fsh_voxels "$candidate")
+            if [ "$vox" -gt 0 ]; then
+                echo "$candidate"
+                return 0
+            fi
+        fi
+    done
+    echo ""
+    return 0
+}
+
+# ---------------------------------------------------------------------------
+# fs_harvest_stats - dump volumetric stats tables (aseg/wmparc/aparc) + eTIV via
+# asegstats2table / aparcstats2table. Each table is independent and gated by its
+# .stats file existing in the recon. Never aborts.
+#
+# Args: <subjects_dir> <subject_id> <out_dir>
+# ---------------------------------------------------------------------------
+fs_harvest_stats() {
+    local subjects_dir="$1"
+    local subject_id="$2"
+    local out_dir="$3"
+
+    log_message "Harvesting FreeSurfer stats tables (aseg/wmparc/aparc/eTIV)..."
+
+    local stats_src="${subjects_dir}/${subject_id}/stats"
+    if [ ! -d "$stats_src" ]; then
+        log_formatted "WARNING" "fs_harvest_stats: stats dir missing (recon incomplete?): $stats_src"
+        return 1
+    fi
+    mkdir -p "$out_dir"
+
+    # Copy the raw .stats files verbatim (cheap, authoritative provenance).
+    local f
+    for f in aseg.stats wmparc.stats lh.aparc.stats rh.aparc.stats \
+             lh.aparc.a2009s.stats rh.aparc.a2009s.stats brainvol.stats; do
+        if [ -f "${stats_src}/${f}" ]; then
+            cp "${stats_src}/${f}" "${out_dir}/${f}" 2>/dev/null || true
+        fi
+    done
+
+    # asegstats2table: per-structure volumes (includes eTIV / brain-vol rows).
+    if command -v asegstats2table >/dev/null 2>&1 && [ -f "${stats_src}/aseg.stats" ]; then
+        SUBJECTS_DIR="$subjects_dir" asegstats2table --subjects "$subject_id" \
+            --meas volume --tablefile "${out_dir}/aseg_volumes.tsv" >/dev/null 2>&1 \
+            && log_message "  ✓ aseg_volumes.tsv" \
+            || log_formatted "WARNING" "asegstats2table (aseg volumes) failed"
+    fi
+    if command -v asegstats2table >/dev/null 2>&1 && [ -f "${stats_src}/wmparc.stats" ]; then
+        SUBJECTS_DIR="$subjects_dir" asegstats2table --subjects "$subject_id" \
+            --stats wmparc.stats --meas volume --tablefile "${out_dir}/wmparc_volumes.tsv" >/dev/null 2>&1 \
+            && log_message "  ✓ wmparc_volumes.tsv" \
+            || log_formatted "WARNING" "asegstats2table (wmparc volumes) failed"
+    fi
+
+    # aparcstats2table: cortical morphometry (thickness + area) for both atlases.
+    if command -v aparcstats2table >/dev/null 2>&1; then
+        local parc meas
+        for parc in aparc aparc.a2009s; do
+            for meas in thickness area; do
+                if [ -f "${stats_src}/lh.${parc}.stats" ]; then
+                    SUBJECTS_DIR="$subjects_dir" aparcstats2table --subjects "$subject_id" \
+                        --hemi lh --parc "$parc" --meas "$meas" \
+                        --tablefile "${out_dir}/lh_${parc}_${meas}.tsv" >/dev/null 2>&1 \
+                        && log_message "  ✓ lh_${parc}_${meas}.tsv" || true
+                fi
+                if [ -f "${stats_src}/rh.${parc}.stats" ]; then
+                    SUBJECTS_DIR="$subjects_dir" aparcstats2table --subjects "$subject_id" \
+                        --hemi rh --parc "$parc" --meas "$meas" \
+                        --tablefile "${out_dir}/rh_${parc}_${meas}.tsv" >/dev/null 2>&1 \
+                        && log_message "  ✓ rh_${parc}_${meas}.tsv" || true
+                fi
+            done
+        done
+    fi
+
+    log_formatted "SUCCESS" "FreeSurfer stats harvested: $out_dir"
+    return 0
+}
+
+# ---------------------------------------------------------------------------
+# fs_harvest_subregions - run segment_subregions (thalamus, hippo-amygdala) and
+# mri_segment_hypothalamic_subunits on the FINISHED recon (NO extra recon).
+# Each is independently gated; each adds minutes..~1h, so each is opt-IN.
+#
+# Args: <subjects_dir> <subject_id> <geometry_reference> <out_dir>
+# ---------------------------------------------------------------------------
+fs_harvest_subregions() {
+    local subjects_dir="$1"
+    local subject_id="$2"
+    local geom_ref="$3"
+    local out_dir="$4"
+
+    log_message "Harvesting FreeSurfer subregion segmentations (gated, on finished recon)..."
+
+    local mri_dir="${subjects_dir}/${subject_id}/mri"
+    if [ ! -d "$mri_dir" ]; then
+        log_formatted "WARNING" "fs_harvest_subregions: recon mri dir missing: $mri_dir"
+        return 1
+    fi
+    mkdir -p "$out_dir"
+
+    local threads="${ANTS_THREADS:-4}"
+
+    # --- Thalamic nuclei (segment_subregions thalamus) -----------------------
+    if [ "${FS_HARVEST_THALAMUS:-false}" = "true" ] && command -v segment_subregions >/dev/null 2>&1; then
+        log_message "  segment_subregions thalamus (this adds time)..."
+        if SUBJECTS_DIR="$subjects_dir" segment_subregions thalamus \
+                --cross "$subject_id" --sd "$subjects_dir" --threads "$threads" >/dev/null 2>&1; then
+            _fsh_copy_subregion "$mri_dir" "ThalamicNuclei" "$geom_ref" "$out_dir" "thalamus"
+        else
+            log_formatted "WARNING" "segment_subregions thalamus failed (non-fatal)"
+        fi
+    else
+        log_message "  thalamus: skipped (FS_HARVEST_THALAMUS=${FS_HARVEST_THALAMUS:-false})"
+    fi
+
+    # --- Hippocampus + amygdala subfields ------------------------------------
+    if [ "${FS_HARVEST_HIPPO_AMYGDALA:-false}" = "true" ] && command -v segment_subregions >/dev/null 2>&1; then
+        log_message "  segment_subregions hippo-amygdala (this adds time)..."
+        if SUBJECTS_DIR="$subjects_dir" segment_subregions hippo-amygdala \
+                --cross "$subject_id" --sd "$subjects_dir" --threads "$threads" >/dev/null 2>&1; then
+            _fsh_copy_subregion "$mri_dir" "lh.hippoAmygLabels" "$geom_ref" "$out_dir" "hippo_amygdala_lh"
+            _fsh_copy_subregion "$mri_dir" "rh.hippoAmygLabels" "$geom_ref" "$out_dir" "hippo_amygdala_rh"
+        else
+            log_formatted "WARNING" "segment_subregions hippo-amygdala failed (non-fatal)"
+        fi
+    else
+        log_message "  hippo-amygdala: skipped (FS_HARVEST_HIPPO_AMYGDALA=${FS_HARVEST_HIPPO_AMYGDALA:-false})"
+    fi
+
+    # --- Hypothalamic subunits (mri_segment_hypothalamic_subunits) -----------
+    if [ "${FS_HARVEST_HYPOTHALAMUS:-false}" = "true" ] && command -v mri_segment_hypothalamic_subunits >/dev/null 2>&1; then
+        log_message "  mri_segment_hypothalamic_subunits (subject mode)..."
+        if SUBJECTS_DIR="$subjects_dir" mri_segment_hypothalamic_subunits \
+                --s "$subject_id" --sd "$subjects_dir" --threads "$threads" >/dev/null 2>&1; then
+            _fsh_copy_subregion "$mri_dir" "hypothalamic_subunits_seg" "$geom_ref" "$out_dir" "hypothalamus"
+        else
+            log_formatted "WARNING" "mri_segment_hypothalamic_subunits failed (non-fatal)"
+        fi
+    else
+        log_message "  hypothalamus: skipped (FS_HARVEST_HYPOTHALAMUS=${FS_HARVEST_HYPOTHALAMUS:-false})"
+    fi
+
+    return 0
+}
+
+# Copy the first matching subregion label volume from the recon mri dir into the
+# harvest dir, resampled to the pipeline geometry. Helper for fs_harvest_subregions.
+# Args: <mri_dir> <name_glob_stem> <geometry_reference> <out_dir> <out_tag>
+_fsh_copy_subregion() {
+    local mri_dir="$1"
+    local stem="$2"
+    local geom_ref="$3"
+    local out_dir="$4"
+    local tag="$5"
+
+    # FreeSurfer suffixes vary by version (e.g. ThalamicNuclei.v13.T1.mgz,
+    # ThalamicNuclei.mgz). `-print -quit` returns the first hit SIGPIPE-safely.
+    local src
+    src=$(find "$mri_dir" -maxdepth 1 -iname "${stem}*.mgz" -print -quit 2>/dev/null)
+    if [ -z "$src" ] || [ ! -f "$src" ]; then
+        log_formatted "WARNING" "  ${tag}: no ${stem}*.mgz produced in $mri_dir"
+        return 1
+    fi
+
+    # `-odt int` keeps the discrete label values intact across the resample (a
+    # scaled-float output would corrupt them — see fs_harvest_extract_csf_masks).
+    local out_nii="${out_dir}/${tag}_labels.nii.gz"
+    if [ -n "$geom_ref" ] && [ -f "$geom_ref" ] && command -v mri_convert >/dev/null 2>&1; then
+        mri_convert -rl "$geom_ref" -rt nearest -odt int "$src" "$out_nii" >/dev/null 2>&1 \
+            || mri_convert -odt int "$src" "$out_nii" >/dev/null 2>&1 || return 1
+    elif command -v mri_convert >/dev/null 2>&1; then
+        mri_convert -odt int "$src" "$out_nii" >/dev/null 2>&1 || return 1
+    else
+        return 1
+    fi
+    log_message "  ✓ ${tag}: $out_nii"
+    return 0
+}
+
+# ---------------------------------------------------------------------------
+# fs_harvest_recon - top-level harvest of a COMPLETED recon-all (NO new recon).
+# Caller invokes this only after run_recon_all has produced aseg.mgz. Each piece
+# is individually gated/graceful.
+#
+# Args: <subjects_dir> <subject_id> <geometry_reference>
+#   <geometry_reference> the pipeline-space image label volumes are resampled to.
+# Always returns 0 (harvest is value-add, never fatal).
+# ---------------------------------------------------------------------------
+fs_harvest_recon() {
+    local subjects_dir="$1"
+    local subject_id="$2"
+    local geom_ref="$3"
+
+    log_formatted "INFO" "=== HARVESTING FULL FREESURFER RECON OUTPUTS (no second recon) ==="
+
+    local mri_dir="${subjects_dir}/${subject_id}/mri"
+    local aseg="${mri_dir}/aseg.mgz"
+    if [ ! -f "$aseg" ]; then
+        log_formatted "WARNING" "fs_harvest_recon: aseg.mgz not found (recon not complete?): $aseg; skipping harvest"
+        return 0
+    fi
+
+    local harvest_dir
+    harvest_dir="$(_fsh_harvest_dir)"
+    local csf_dir="${harvest_dir}/csf_masks"
+    local stats_dir="${harvest_dir}/stats"
+    local subregions_dir="${harvest_dir}/subregions"
+
+    # A1. aseg CSF/ventricle masks (cheap; default ON). The real FP-exclusion win.
+    if [ "${FS_HARVEST_ASEG_CSF:-true}" = "true" ]; then
+        fs_harvest_extract_csf_masks "$aseg" "$geom_ref" "$csf_dir" "aseg" || \
+            log_formatted "WARNING" "aseg CSF/ventricle harvest unavailable (non-fatal)"
+    else
+        log_message "aseg CSF harvest skipped (FS_HARVEST_ASEG_CSF=${FS_HARVEST_ASEG_CSF:-true})"
+    fi
+
+    # A2. Stats tables (cheap; default ON).
+    if [ "${FS_HARVEST_STATS:-true}" = "true" ]; then
+        fs_harvest_stats "$subjects_dir" "$subject_id" "$stats_dir" || \
+            log_formatted "WARNING" "FreeSurfer stats harvest unavailable (non-fatal)"
+    else
+        log_message "stats harvest skipped (FS_HARVEST_STATS=${FS_HARVEST_STATS:-true})"
+    fi
+
+    # A3. Subregion segmentations (each adds time; each default OFF).
+    fs_harvest_subregions "$subjects_dir" "$subject_id" "$geom_ref" "$subregions_dir" || true
+
+    # Provenance note for the whole harvest.
+    {
+        echo "FreeSurfer recon harvest"
+        echo "========================"
+        echo "Date: $(date)"
+        echo "Subject: $subject_id"
+        echo "Subjects dir: $subjects_dir"
+        echo "aseg: $aseg"
+        echo "Harvested: aseg_csf=${FS_HARVEST_ASEG_CSF:-true} stats=${FS_HARVEST_STATS:-true}"
+        echo "           thalamus=${FS_HARVEST_THALAMUS:-false} hippo_amygdala=${FS_HARVEST_HIPPO_AMYGDALA:-false} hypothalamus=${FS_HARVEST_HYPOTHALAMUS:-false}"
+    } > "${harvest_dir}/harvest_provenance.txt" 2>/dev/null || true
+
+    log_formatted "SUCCESS" "FreeSurfer recon harvest complete: $harvest_dir"
+    return 0
+}
+
+# ===========================================================================
+# C. FreeSurfer ML methods (fast; no recon required)
+# ===========================================================================
+
+# ---------------------------------------------------------------------------
+# run_synthseg - SynthSeg+ contrast/resolution-agnostic whole-brain seg in
+# ~1 min, NO recon. Works on the 2D/thick-slice clinical T1. Yields aseg-
+# equivalent subcortical labels + per-structure volumes + QC, and CSF/ventricle
+# masks the FP-exclusion path can consume WITHOUT a recon (alternate fast source
+# for task B).
+#
+# Args: <input_t1> [<geometry_reference>] [<out_dir>]
+#   <geometry_reference> the pipeline-space image the CSF masks are resampled to
+#       (defaults to the input image).
+# Gated by SEG_RUN_SYNTHSEG (default true). Graceful skip if absent/disabled.
+# Always returns 0.
+# ---------------------------------------------------------------------------
+run_synthseg() {
+    local input_t1="${1:-}"
+    local geom_ref="${2:-$input_t1}"
+    local out_dir="${3:-}"
+
+    log_message "=== run_synthseg (SynthSeg+ contrast-agnostic whole-brain seg, no recon) ==="
+
+    if [ "${SEG_RUN_SYNTHSEG:-true}" != "true" ]; then
+        log_formatted "INFO" "SynthSeg disabled (SEG_RUN_SYNTHSEG=${SEG_RUN_SYNTHSEG:-true}); skipping"
+        return 0
+    fi
+    if [ -z "$input_t1" ] || [ ! -f "$input_t1" ]; then
+        log_formatted "WARNING" "SynthSeg: input T1 missing ($input_t1); skipping"
+        return 0
+    fi
+    if ! command -v mri_synthseg >/dev/null 2>&1; then
+        log_formatted "WARNING" "mri_synthseg not found on PATH (install FreeSurfer >=7.x); skipping SynthSeg (non-fatal)"
+        return 0
+    fi
+
+    [ -z "$out_dir" ] && out_dir="$(_fsh_harvest_dir)/synthseg"
+    mkdir -p "$out_dir"
+
+    local seg_out="${out_dir}/synthseg_seg.nii.gz"
+    local vol_csv="${out_dir}/synthseg_vols.csv"
+    local qc_csv="${out_dir}/synthseg_qc.csv"
+    local threads="${ANTS_THREADS:-4}"
+
+    # --robust => SynthSeg+ (slower but contrast/resolution robust; the right
+    # choice for 2D/thick-slice clinical T1). --vol/--qc emit volumes + QC.
+    # --parc adds cortical parcellation when SEG_SYNTHSEG_PARC=true.
+    local -a cmd=( mri_synthseg --i "$input_t1" --o "$seg_out"
+                   --vol "$vol_csv" --qc "$qc_csv" --threads "$threads" --cpu )
+    if [ "${SEG_SYNTHSEG_ROBUST:-true}" = "true" ]; then
+        cmd+=( --robust )
+    fi
+    if [ "${SEG_SYNTHSEG_PARC:-false}" = "true" ]; then
+        cmd+=( --parc )
+    fi
+
+    log_message "SynthSeg input: $input_t1"
+    log_message "SynthSeg command: ${cmd[*]}"
+
+    local rc=0
+    "${cmd[@]}" >/dev/null 2>&1 || rc=$?
+    if [ "$rc" -ne 0 ] || [ ! -f "$seg_out" ]; then
+        log_formatted "WARNING" "mri_synthseg exited $rc / no output; skipping SynthSeg downstream (non-fatal)"
+        return 0
+    fi
+    log_formatted "SUCCESS" "SynthSeg segmentation: $seg_out"
+
+    # Harvest CSF/ventricle masks from the SynthSeg labels into the shared
+    # FP-exclusion source location (tag=synthseg). Same label scheme as aseg.
+    local csf_dir
+    csf_dir="$(_fsh_harvest_dir)/csf_masks"
+    fs_harvest_extract_csf_masks "$seg_out" "$geom_ref" "$csf_dir" "synthseg" || \
+        log_formatted "WARNING" "SynthSeg CSF/ventricle harvest produced nothing (non-fatal)"
+
+    log_formatted "SUCCESS" "SynthSeg complete (subcortical seg + volumes + CSF masks): $out_dir"
+    return 0
+}
+
+# ---------------------------------------------------------------------------
+# run_synthsr - synthesize a 1mm isotropic T1 from a low-res / 2D clinical T1.
+# Optional pre-step (USE_SYNTHSR=false default). The synthesized 1mm T1 can be
+# used as the recon-all input AND the T1->MNI master, improving both on thick-
+# slice T1. Echoes the synthesized image path on success (for the caller to
+# adopt as FREESURFER_T1_INPUT / the registration master).
+#
+# Args: <input_t1> [<out_dir>]
+# Returns 0 + echoes path on success; returns 1 (echoes nothing) on
+# skip/absent/failure so the caller keeps the original T1. Diagnostic logging
+# goes to stderr so it never pollutes the echoed path.
+# ---------------------------------------------------------------------------
+run_synthsr() {
+    local input_t1="${1:-}"
+    local out_dir="${2:-}"
+
+    log_message "=== run_synthsr (synthesize 1mm T1 from low-res/2D clinical T1) ===" >&2
+
+    if [ "${USE_SYNTHSR:-false}" != "true" ]; then
+        log_formatted "INFO" "SynthSR disabled (USE_SYNTHSR=${USE_SYNTHSR:-false}); using original T1" >&2
+        return 1
+    fi
+    if [ -z "$input_t1" ] || [ ! -f "$input_t1" ]; then
+        log_formatted "WARNING" "SynthSR: input T1 missing ($input_t1); skipping" >&2
+        return 1
+    fi
+    if ! command -v mri_synthsr >/dev/null 2>&1; then
+        log_formatted "WARNING" "mri_synthsr not found on PATH; skipping SynthSR (non-fatal)" >&2
+        return 1
+    fi
+
+    [ -z "$out_dir" ] && out_dir="$(_fsh_harvest_dir)/synthsr"
+    mkdir -p "$out_dir"
+
+    local sr_out="${out_dir}/$(basename "$input_t1" .nii.gz)_synthsr_1mm.nii.gz"
+    local threads="${ANTS_THREADS:-4}"
+
+    log_message "SynthSR input: $input_t1 -> $sr_out" >&2
+    local rc=0
+    mri_synthsr --i "$input_t1" --o "$sr_out" --threads "$threads" --cpu >/dev/null 2>&1 || rc=$?
+    if [ "$rc" -ne 0 ] || [ ! -f "$sr_out" ]; then
+        log_formatted "WARNING" "mri_synthsr exited $rc / no output; using original T1 (non-fatal)" >&2
+        return 1
+    fi
+    log_formatted "SUCCESS" "SynthSR 1mm T1: $sr_out" >&2
+    echo "$sr_out"
+    return 0
+}
+
+# ---------------------------------------------------------------------------
+# run_sclimbic - DL limbic subcortical segmentation (mri_sclimbic_seg). Gated
+# harvest (FS_HARVEST_SCLIMBIC, default false). Works on a T1 directly (no recon
+# required). Always returns 0.
+#
+# Args: <input_t1> [<out_dir>]
+# ---------------------------------------------------------------------------
+run_sclimbic() {
+    local input_t1="${1:-}"
+    local out_dir="${2:-}"
+
+    log_message "=== run_sclimbic (DL limbic subcortical seg) ==="
+
+    if [ "${FS_HARVEST_SCLIMBIC:-false}" != "true" ]; then
+        log_formatted "INFO" "sclimbic disabled (FS_HARVEST_SCLIMBIC=${FS_HARVEST_SCLIMBIC:-false}); skipping"
+        return 0
+    fi
+    if [ -z "$input_t1" ] || [ ! -f "$input_t1" ]; then
+        log_formatted "WARNING" "sclimbic: input T1 missing ($input_t1); skipping"
+        return 0
+    fi
+    if ! command -v mri_sclimbic_seg >/dev/null 2>&1; then
+        log_formatted "WARNING" "mri_sclimbic_seg not found on PATH; skipping sclimbic (non-fatal)"
+        return 0
+    fi
+
+    [ -z "$out_dir" ] && out_dir="$(_fsh_harvest_dir)/sclimbic"
+    mkdir -p "$out_dir"
+
+    local seg_out="${out_dir}/sclimbic_seg.nii.gz"
+    local threads="${ANTS_THREADS:-4}"
+
+    local rc=0
+    mri_sclimbic_seg --i "$input_t1" --o "$seg_out" --write_volumes --threads "$threads" >/dev/null 2>&1 || rc=$?
+    if [ "$rc" -ne 0 ] || [ ! -f "$seg_out" ]; then
+        log_formatted "WARNING" "mri_sclimbic_seg exited $rc / no output; skipping sclimbic downstream (non-fatal)"
+        return 0
+    fi
+    log_formatted "SUCCESS" "sclimbic segmentation: $seg_out"
+    return 0
+}
+
+export -f _fsh_fslmaths
+export -f _fsh_harvest_dir
+export -f _fsh_voxels
+export -f fs_harvest_extract_csf_masks
+export -f fs_harvest_find_csf_mask
+export -f fs_harvest_stats
+export -f fs_harvest_subregions
+export -f _fsh_copy_subregion
+export -f fs_harvest_recon
+export -f run_synthseg
+export -f run_synthsr
+export -f run_sclimbic
+
+log_message "FreeSurfer harvest module loaded (recon harvest + SynthSeg+/SynthSR/sclimbic)"

--- a/src/modules/segmentation.sh
+++ b/src/modules/segmentation.sh
@@ -324,6 +324,23 @@ extract_brainstem_final() {
     log_formatted "INFO" "===== COMPREHENSIVE BRAINSTEM SEGMENTATION ====="
     log_message "Brainstem segmentation method: $seg_method"
 
+    # Optional SynthSR pre-step (USE_SYNTHSR=false default): synthesize a 1mm
+    # isotropic T1 from a thick-slice / 2D clinical T1, then use it as the
+    # segmentation/recon-all input AND the registration master (it improves both
+    # on thick-slice T1). Graceful no-op if disabled/absent (keeps the original).
+    if declare -f run_synthsr >/dev/null 2>&1; then
+        local sr_t1
+        if sr_t1=$(run_synthsr "$input_file"); then
+            if [ -n "$sr_t1" ] && [ -f "$sr_t1" ]; then
+                log_formatted "SUCCESS" "Using SynthSR 1mm T1 for segmentation + recon-all input: $sr_t1"
+                input_file="$sr_t1"
+                input_basename=$(basename "$input_file" .nii.gz)
+                # Adopt it as the recon-all input so FreeSurfer also benefits.
+                export FREESURFER_T1_INPUT="$sr_t1"
+            fi
+        fi
+    fi
+
     # Define output directory
     local brainstem_dir="${RESULTS_DIR}/segmentation/brainstem"
     mkdir -p "$brainstem_dir"
@@ -430,9 +447,14 @@ _extract_brainstem_all_parallel() {
     local run_ho="${SEG_RUN_HARVARD_OXFORD:-true}"
     local run_ma="${SEG_RUN_MULTI_ATLAS:-true}"
     local run_fs="${SEG_RUN_FREESURFER:-true}"
+    # SynthSeg+ is a FAST ML path (~1 min, NO recon): contrast/resolution-agnostic
+    # whole-brain seg yielding aseg-equivalent subcortical + CSF/ventricle masks +
+    # volumes immediately. Default on. sclimbic is a gated DL limbic seg (off by default).
+    local run_ss="${SEG_RUN_SYNTHSEG:-true}"
+    local run_sc="${FS_HARVEST_SCLIMBIC:-false}"
 
     log_formatted "INFO" "=== PARALLEL BRAINSTEM SEGMENTATION (method=all) ==="
-    log_message "Enabled paths: harvard_oxford=$run_ho  multi_atlas=$run_ma  freesurfer=$run_fs"
+    log_message "Enabled paths: harvard_oxford=$run_ho  multi_atlas=$run_ma  freesurfer=$run_fs  synthseg=$run_ss  sclimbic=$run_sc"
 
     # Compute the shared MNI->subject warp ONCE (before fan-out) so the HO and
     # multi-atlas paths reuse the same transform instead of racing on it.
@@ -525,6 +547,44 @@ _extract_brainstem_all_parallel() {
         log_message "  FreeSurfer path disabled (SEG_RUN_FREESURFER=false) — skipping multi-hour recon-all"
     fi
 
+    # SynthSeg+ : fast ML whole-brain seg (no recon). Yields aseg-equivalent
+    # subcortical labels + CSF/ventricle masks (an alternate fast CSF source for
+    # the FP-exclusion path) + per-structure volumes in ~1 min. Runs the SAME
+    # geometry reference as the other paths so its CSF masks align downstream.
+    local ss_pid="" sc_pid=""
+    if [ "$run_ss" = "true" ]; then
+        (
+            export ANTS_THREADS="$per_path_threads"
+            log_formatted "INFO" "[parallel] SynthSeg+ path starting (fast, no recon)"
+            if run_synthseg "$input_file" "$input_file"; then
+                log_formatted "SUCCESS" "[parallel] SynthSeg+ path complete"
+            else
+                log_formatted "WARNING" "[parallel] SynthSeg+ path unavailable (non-fatal)"
+                exit 1
+            fi
+        ) >"${log_dir}/synthseg.log" 2>&1 &
+        ss_pid=$!
+        log_message "  SynthSeg+ path PID=$ss_pid (log: ${log_dir}/synthseg.log)"
+    else
+        log_message "  SynthSeg+ path disabled (SEG_RUN_SYNTHSEG=false)"
+    fi
+
+    # sclimbic : gated DL limbic subcortical seg (no recon). Default off.
+    if [ "$run_sc" = "true" ]; then
+        (
+            export ANTS_THREADS="$per_path_threads"
+            log_formatted "INFO" "[parallel] sclimbic path starting"
+            if run_sclimbic "$input_file"; then
+                log_formatted "SUCCESS" "[parallel] sclimbic path complete"
+            else
+                log_formatted "WARNING" "[parallel] sclimbic path unavailable (non-fatal)"
+                exit 1
+            fi
+        ) >"${log_dir}/sclimbic.log" 2>&1 &
+        sc_pid=$!
+        log_message "  sclimbic path PID=$sc_pid (log: ${log_dir}/sclimbic.log)"
+    fi
+
     # ── Collect each path independently (failure is non-fatal) ──────────────
     # `wait <pid>` returns the job's exit status; we capture it without letting a
     # non-zero status abort the parent under set -e.
@@ -564,6 +624,30 @@ _extract_brainstem_all_parallel() {
             log_formatted "SUCCESS" "FreeSurfer path: OK"
         else
             log_formatted "WARNING" "FreeSurfer path: unavailable/low-confidence (rc=$fs_rc) — non-fatal"
+        fi
+    fi
+
+    if [ -n "$ss_pid" ]; then
+        local ss_rc=0; wait "$ss_pid" || ss_rc=$?
+        cat "${log_dir}/synthseg.log" 2>/dev/null || true
+        SEG_ALL_PATHS_RAN+=("synthseg")
+        if [ "$ss_rc" -eq 0 ]; then
+            SEG_ALL_PATHS_OK+=("synthseg")
+            log_formatted "SUCCESS" "SynthSeg+ path: OK"
+        else
+            log_formatted "WARNING" "SynthSeg+ path: unavailable (rc=$ss_rc) — non-fatal"
+        fi
+    fi
+
+    if [ -n "$sc_pid" ]; then
+        local sc_rc=0; wait "$sc_pid" || sc_rc=$?
+        cat "${log_dir}/sclimbic.log" 2>/dev/null || true
+        SEG_ALL_PATHS_RAN+=("sclimbic")
+        if [ "$sc_rc" -eq 0 ]; then
+            SEG_ALL_PATHS_OK+=("sclimbic")
+            log_formatted "SUCCESS" "sclimbic path: OK"
+        else
+            log_formatted "WARNING" "sclimbic path: unavailable (rc=$sc_rc) — non-fatal"
         fi
     fi
 
@@ -828,7 +912,78 @@ To visualize the segmentations overlaid on your images:
 ================================================================================
 EOF
 
+    # Surface the harvested FreeSurfer volumes/stats (aseg/aparc/subregions/eTIV/
+    # SynthSeg volumes + CSF masks) in the report when present.
+    _seg_append_freesurfer_harvest_report "$report_file"
+
     log_formatted "SUCCESS" "Comprehensive segmentation report generated: $report_file"
+    return 0
+}
+
+# ---------------------------------------------------------------------------
+# _seg_append_freesurfer_harvest_report - append a FreeSurfer-harvest summary
+# (aseg/aparc/subregion/eTIV stats + SynthSeg volumes + harvested CSF masks) to
+# the segmentation report. No-op when nothing was harvested. Never aborts.
+# Args: <report_file>
+# ---------------------------------------------------------------------------
+_seg_append_freesurfer_harvest_report() {
+    local report_file="$1"
+    local harvest_dir="${RESULTS_DIR}/freesurfer/harvest"
+
+    [ -d "$harvest_dir" ] || return 0
+
+    {
+        echo ""
+        echo "FREESURFER HARVEST (full recon + ML methods)"
+        echo "--------------------------------------------"
+    } >> "$report_file"
+
+    # Stats tables (aseg/wmparc/aparc/eTIV).
+    local stats_dir="${harvest_dir}/stats"
+    if [ -d "$stats_dir" ]; then
+        echo "Stats tables: $stats_dir" >> "$report_file"
+        local f
+        for f in "$stats_dir"/*.tsv "$stats_dir"/*.stats; do
+            [ -f "$f" ] && echo "  - $(basename "$f")" >> "$report_file"
+        done
+        # eTIV + brain volume from aseg.stats (the 'Measure ... eTIV/BrainSeg' lines).
+        if [ -f "${stats_dir}/aseg.stats" ]; then
+            grep -E '^# Measure (EstimatedTotalIntraCranialVol|BrainSeg|TotalGray|SupraTentorial),' \
+                "${stats_dir}/aseg.stats" 2>/dev/null \
+                | sed -E 's/^# Measure /  /' >> "$report_file" || true
+        fi
+    fi
+
+    # SynthSeg per-structure volumes (CSV header + values).
+    local ss_vols="${harvest_dir}/synthseg/synthseg_vols.csv"
+    if [ -f "$ss_vols" ]; then
+        echo "SynthSeg+ volumes: $ss_vols" >> "$report_file"
+    fi
+
+    # Harvested CSF/ventricle masks (with voxel counts) — the FP-exclusion source.
+    local csf_dir="${harvest_dir}/csf_masks"
+    if [ -d "$csf_dir" ]; then
+        echo "CSF/ventricle masks (FP-exclusion source): $csf_dir" >> "$report_file"
+        local m
+        for m in "$csf_dir"/*.nii.gz; do
+            [ -f "$m" ] || continue
+            local vox
+            vox=$(fslstats "$m" -V 2>/dev/null | awk '{print $1}')
+            echo "  - $(basename "$m"): ${vox:-0} voxels" >> "$report_file"
+        done
+    fi
+
+    # Subregion segmentations (thalamus / hippo-amygdala / hypothalamus).
+    local sub_dir="${harvest_dir}/subregions"
+    if [ -d "$sub_dir" ]; then
+        local any=0 s
+        for s in "$sub_dir"/*_labels.nii.gz; do
+            [ -f "$s" ] || continue
+            [ "$any" -eq 0 ] && { echo "Subregion segmentations: $sub_dir" >> "$report_file"; any=1; }
+            echo "  - $(basename "$s")" >> "$report_file"
+        done
+    fi
+
     return 0
 }
 
@@ -938,6 +1093,7 @@ export -f map_segmentation_files
 export -f validate_segmentation_outputs
 export -f create_combined_segmentation_map
 export -f generate_comprehensive_report
+export -f _seg_append_freesurfer_harvest_report
 export -f segment_tissues
 
 # Legacy exports for compatibility

--- a/src/pipeline.sh
+++ b/src/pipeline.sh
@@ -1288,10 +1288,19 @@ run_pipeline() {
     # Operates on the detected lesion mask. No-op (pass-through) unless
     # FP_FILTER_ENABLED=true, so default behaviour is unchanged.
     if declare -f run_fp_filter >/dev/null 2>&1 && [ -n "$hyperintensity_mask" ] && [ -f "$hyperintensity_mask" ]; then
-      # CSF probability map written by detect_hyperintensities (FSL FAST PVE 0).
+      # CSF map for the CSF-distance stage. Prefer the FreeSurfer/SynthSeg aseg
+      # CSF mask harvested by freesurfer_harvest.sh (better posterior-fossa CSF
+      # for the brainstem pseudolesion problem) when present and enabled; fall
+      # back to the FSL FAST CSF PVE (PVE 0) detect_hyperintensities wrote.
       # `|| true` keeps a transient find failure from aborting under set -e.
       local fp_csf_prob=""
-      fp_csf_prob=$(find "$hyperintensities_dir" -name "*_csf_prob.nii.gz" 2>/dev/null | head -1 || true)
+      if [ "${CSF_USE_FREESURFER_MASK:-true}" = "true" ] && declare -f fs_harvest_find_csf_mask >/dev/null 2>&1; then
+        fp_csf_prob=$(fs_harvest_find_csf_mask || true)
+        [ -n "$fp_csf_prob" ] && log_message "FP filter CSF source: FreeSurfer/SynthSeg aseg CSF mask ($fp_csf_prob)"
+      fi
+      if [ -z "$fp_csf_prob" ]; then
+        fp_csf_prob=$(find "$hyperintensities_dir" -name "*_csf_prob.nii.gz" 2>/dev/null | head -1 || true)
+      fi
       # Whole-brain mask for the brain-edge erosion stage. Prefer the brain mask
       # detect_hyperintensities emitted (already in the lesion mask's space);
       # fall back to the brain-extraction mask. NOT the brainstem segmentation

--- a/tests/test_segmentation.sh
+++ b/tests/test_segmentation.sh
@@ -183,6 +183,7 @@ test_function_availability() {
     # Source modules
     source "$MODULES_DIR/segmentation.sh" 2>/dev/null
     source "$MODULES_DIR/brainstem_freesurfer.sh" 2>/dev/null
+    source "$MODULES_DIR/freesurfer_harvest.sh" 2>/dev/null
 
     # Test core segmentation functions (live FreeSurfer/Harvard-Oxford path;
     # Talairach brainstem subdivision has been removed)
@@ -192,6 +193,88 @@ test_function_availability() {
     assert_function_exists "extract_brainstem_freesurfer" "extract_brainstem_freesurfer function exists"
     assert_function_exists "extract_brainstem_ants" "extract_brainstem_ants function exists"
     assert_function_exists "validate_segmentation" "validate_segmentation function exists"
+
+    # FreeSurfer full-recon harvest + ML methods (freesurfer_harvest.sh)
+    assert_function_exists "fs_harvest_recon" "fs_harvest_recon function exists"
+    assert_function_exists "fs_harvest_extract_csf_masks" "fs_harvest_extract_csf_masks function exists"
+    assert_function_exists "fs_harvest_find_csf_mask" "fs_harvest_find_csf_mask function exists"
+    assert_function_exists "fs_harvest_stats" "fs_harvest_stats function exists"
+    assert_function_exists "fs_harvest_subregions" "fs_harvest_subregions function exists"
+    assert_function_exists "run_synthseg" "run_synthseg function exists"
+    assert_function_exists "run_synthsr" "run_synthsr function exists"
+    assert_function_exists "run_sclimbic" "run_sclimbic function exists"
+    assert_function_exists "_seg_append_freesurfer_harvest_report" "_seg_append_freesurfer_harvest_report function exists"
+}
+
+# Test: FreeSurfer harvest gating + CSF mask extraction/discovery (task A/B/C)
+test_freesurfer_harvest() {
+    test_log "$YELLOW" "Testing FreeSurfer harvest (gating, CSF mask extraction, discovery)..."
+
+    source "$MODULES_DIR/freesurfer_harvest.sh" 2>/dev/null
+    source "$MODULES_DIR/analysis.sh" 2>/dev/null
+
+    # Gating: disabled toggles => graceful skip (return 0, no work).
+    local skip_out
+    skip_out=$(SEG_RUN_SYNTHSEG=false run_synthseg "$TEST_IMAGE" 2>&1)
+    if echo "$skip_out" | grep -qi "disabled"; then
+        test_log "$GREEN" "PASS: run_synthseg gated by SEG_RUN_SYNTHSEG=false"
+        TESTS_PASSED=$((TESTS_PASSED + 1))
+    else
+        test_log "$RED" "FAIL: run_synthseg not gated by SEG_RUN_SYNTHSEG=false"
+        TESTS_FAILED=$((TESTS_FAILED + 1))
+    fi
+    TESTS_RUN=$((TESTS_RUN + 1))
+
+    skip_out=$(FS_HARVEST_SCLIMBIC=false run_sclimbic "$TEST_IMAGE" 2>&1)
+    if echo "$skip_out" | grep -qi "disabled"; then
+        test_log "$GREEN" "PASS: run_sclimbic gated by FS_HARVEST_SCLIMBIC=false"
+        TESTS_PASSED=$((TESTS_PASSED + 1))
+    else
+        test_log "$RED" "FAIL: run_sclimbic not gated by FS_HARVEST_SCLIMBIC=false"
+        TESTS_FAILED=$((TESTS_FAILED + 1))
+    fi
+    TESTS_RUN=$((TESTS_RUN + 1))
+
+    # Functional CSF-extraction test (requires real FSL + mri_convert + a label
+    # volume). mri_synthseg gives us a label volume cheaply on the test image when
+    # available; otherwise we skip the functional portion (still non-fatal). The
+    # harvest writes into RESULTS_DIR/freesurfer/harvest/csf_masks, which
+    # fs_harvest_find_csf_mask discovers, so we run the whole test under a clean
+    # RESULTS_DIR and restore it afterwards.
+    if command -v fslmaths >/dev/null 2>&1 && command -v fslstats >/dev/null 2>&1 \
+       && command -v mri_convert >/dev/null 2>&1 && command -v mri_synthseg >/dev/null 2>&1 \
+       && [ -f "$TEST_IMAGE" ]; then
+        local fh_root="${TEST_TEMP_DIR:-/tmp}/fsharvest_test_$$"
+        mkdir -p "$fh_root"
+        local seg_out="${fh_root}/seg.nii.gz"
+        if mri_synthseg --i "$TEST_IMAGE" --o "$seg_out" --robust --threads 2 --cpu >/dev/null 2>&1 && [ -f "$seg_out" ]; then
+            local prev_results="${RESULTS_DIR:-}"
+            export RESULTS_DIR="$fh_root"
+            local csf_dir="${RESULTS_DIR}/freesurfer/harvest/csf_masks"
+            if fs_harvest_extract_csf_masks "$seg_out" "$TEST_IMAGE" "$csf_dir" "synthseg" >/dev/null 2>&1; then
+                assert_file_exists "${csf_dir}/synthseg_csf_all.nii.gz" "SynthSeg CSF/ventricle union mask produced"
+                # Discovery: fs_harvest_find_csf_mask should locate the mask.
+                local found
+                found=$(fs_harvest_find_csf_mask)
+                if [ -n "$found" ] && [ -f "$found" ]; then
+                    test_log "$GREEN" "PASS: fs_harvest_find_csf_mask discovered $found"
+                    TESTS_PASSED=$((TESTS_PASSED + 1))
+                else
+                    test_log "$RED" "FAIL: fs_harvest_find_csf_mask found nothing"
+                    TESTS_FAILED=$((TESTS_FAILED + 1))
+                fi
+                TESTS_RUN=$((TESTS_RUN + 1))
+            else
+                test_log "$YELLOW" "INFO: fs_harvest_extract_csf_masks did not produce masks (non-fatal)"
+            fi
+            export RESULTS_DIR="$prev_results"
+        else
+            test_log "$YELLOW" "INFO: mri_synthseg failed on the tiny synthetic test image; skipping functional CSF test (non-fatal)"
+        fi
+        rm -rf "$fh_root" 2>/dev/null || true
+    else
+        test_log "$YELLOW" "INFO: FSL/mri_convert/mri_synthseg not all available; skipping functional CSF-extraction test"
+    fi
 }
 
 # Test 3: Dependencies
@@ -342,6 +425,7 @@ main() {
     test_function_availability
     test_dependencies
     test_basic_functionality
+    test_freesurfer_harvest
     test_integration
     
     # Cleanup and results


### PR DESCRIPTION
Builds on PR #135's parallel "all" segmentation framework. Harvests the FULL FreeSurfer output from the ONE recon-all (no second recon) and adds the fast FreeSurfer ML methods. All new behavior gated, graceful (tool-missing -> WARNING + skip), and provenance-tagged.

New module: `src/modules/freesurfer_harvest.sh`.

## A. Harvest the completed recon (no second recon)
`fs_harvest_recon` runs from `extract_brainstem_freesurfer` once `aseg.mgz` exists:
- **aseg CSF/ventricle binary masks** — 4th ventricle (15), 3rd (14), lateral (4/43), inf-lat (5/44), CSF (24), 5th (72) — split via fslmaths, resampled into pipeline geometry (`mri_convert -odt int` to keep discrete labels). Writes `csf`, `fourth_ventricle`, `ventricles`, `csf_all` masks.
- **Stats**: copies `aseg.stats`/`wmparc.stats`/`lh|rh.aparc.stats` (Desikan-Killiany) + `aparc.a2009s.stats` (Destrieux); generates `asegstats2table` (aseg + wmparc volumes incl. eTIV/brain-vol) and `aparcstats2table` (thickness + area, both atlases).
- **Subregions**: `segment_subregions thalamus`, `segment_subregions hippo-amygdala`, `mri_segment_hypothalamic_subunits` — run on the finished recon, each independently gated, each resampled into pipeline space.

## B. aseg CSF -> FP-exclusion (the accuracy win)
`build_csf_exclusion_mask` (`analysis.sh`, #114) and the `fp_filter` CSF-distance stage (`pipeline.sh`) now **prefer the FreeSurfer/SynthSeg 4th-ventricle/CSF mask** (`fs_harvest_find_csf_mask`: aseg first, then SynthSeg) over the FAST CSF PVE for the posterior-fossa pseudolesion problem, falling back to FAST PVE when absent. Gated by `CSF_USE_FREESURFER_MASK` (default true).

## C. FreeSurfer ML methods
| Method | Toggle | Default | Cost |
|---|---|---|---|
| SynthSeg+ (`mri_synthseg --robust --vol --qc`) — fast parallel path in 'all'; aseg-equivalent subcortical + CSF/ventricle masks + volumes, NO recon, works on 2D/5mm T1; alternate fast CSF source for B | `SEG_RUN_SYNTHSEG` | **on** | ~1 min |
| SynthSR (`mri_synthsr`) — synthesize 1mm T1, used as recon-all input AND T1->MNI master | `USE_SYNTHSR` | off | adds a step |
| sclimbic (`mri_sclimbic_seg`) — DL limbic subcortical; parallel path in 'all' | `FS_HARVEST_SCLIMBIC` | off | minutes |
| aseg CSF masks | `FS_HARVEST_ASEG_CSF` | **on** | cheap |
| stats tables | `FS_HARVEST_STATS` | **on** | cheap |
| thalamus / hippo-amygdala / hypothalamus subregions | `FS_HARVEST_THALAMUS` / `FS_HARVEST_HIPPO_AMYGDALA` / `FS_HARVEST_HYPOTHALAMUS` | off | minutes..~1h each |

Each tool detected with `command -v` -> graceful WARNING + skip if absent.

## D. Report
The segmentation report surfaces the harvested aseg/aparc/subregion/eTIV + SynthSeg volumes + harvested CSF masks (with voxel counts).

## Verification
- `git ls-files '*.sh' | xargs -I{} bash -n {}` — clean
- `git ls-files '*.sh' | xargs shellcheck --severity=error` — clean
- `test_environment_unit` (100), `test_pipeline_control_unit` (98), `test_import_unit` (29), `test_multi_atlas_unit` (22), `test_fp_filter_unit` (100%), `test_segmentation` (26/26, incl. new harvest tests), `pipeline.sh --help` — all pass
- No Python touched (pytest not run)
- Functional (FreeSurfer present; recon-all NOT run): `mri_synthseg --robust` produces seg + volumes + QC + CSF/ventricle masks (4th-vent 245, csf_all 36364 vox); `fs_harvest_find_csf_mask` discovers them; `build_csf_exclusion_mask` prefers them over FAST PVE; the recon harvest path traced; every toggle confirmed to gate correctly
- Code review (high effort) run; no confirmed bugs (candidates were already-guarded numeric coercion, present exports, stderr-routed logs)

🤖 Generated with [Claude Code](https://claude.com/claude-code)