### PR TITLE
Multi-modality: SWI/DWI/T2 end-to-end via contrast-matched cascade + per-cluster cross-modal corroboration analysis

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -51,6 +51,8 @@ src/modules/             # 35+ modules, each sourced by pipeline.sh
   brainstem_aanseg.sh    # EXPLORATORY: FreeSurfer AANSegment arousal-network nuclei (≤1mm only; off by default)
   analysis.sh            # hyperintensity detection, cluster analysis
   gmm_threshold.py       # standalone GMM thresholder (called by analysis.sh)
+  cross_modal_analysis.sh # MULTI-MODAL: per-cluster corroboration of FLAIR clusters with co-registered SWI/DWI-trace/ADC/T2 (default on, graceful)
+  cross_modal_sample.py  # samples co-registered modalities per cluster, emits the cross-modal table + flags (called by cross_modal_analysis.sh)
   fp_filter.sh           # post-detection false-positive suppression (config-gated; complements CSF/PV exclusion)
   wmh_bianca.sh          # optional supervised WMH: FSL BIANCA (needs training data); off by default
   wmh_lst_samseg.sh      # optional WMH: LST-AI + FreeSurfer SAMSEG (pretrained, no training data); off by default
@@ -121,6 +123,14 @@ The single-method values (`freesurfer`/`multi_atlas`/`bianciardi`/`atlas`/`harva
 **Atlas-on-disk prerequisite** — `atlas`/`multi_atlas`/`bianciardi` need the atlases pre-downloaded under `$FSLDIR/data/atlases` (`ATLAS_DIR`): `Bianciardi/`, `CIT168/`, `AAL3/`, `HarvardOxford/`. The startup `check_atlas_availability` step (`environment.sh`, called from `pipeline.sh`) reports presence/absence per atlas and warns if the selected method needs a missing one; absence is **non-fatal** — the pipeline degrades to the HO gross mask. Override layout via `ATLAS_{BIANCIARDI,CIT168,AAL3,HARVARDOXFORD}_REL`.
 
 **Optional WMH / seg modules (all default-OFF)** — supervised/DL add-ons, each intersected with the brainstem mask: `wmh_bianca.sh` (FSL BIANCA), `wmh_lst_samseg.sh` (LST-AI + SAMSEG), `wmh_synthseg.sh` (WMH-SynthSeg), `wmh_segcsvd.sh` (segcsvdWMH), `wmh_shiva.sh` (SHIVA-WMH), `wmh_mars.sh` (MARS-WMH); plus `brainstem_aanseg.sh` (EXPLORATORY AANSegment, ≤1 mm only) and the post-detection `fp_filter.sh`. None is validated in the brainstem — keep conservative pons QA / human-in-the-loop.
+
+## Multi-modal (SWI / DWI / T2) end-to-end
+
+Beyond the T1/FLAIR backbone, the pipeline brings the **secondary** T2-weighted modalities — SWI magnitude, the DERIVED DWI **trace** + **ADC** (not raw 4D diffusion), and a true T2 — all the way through, **only when they are present** (a T1+FLAIR-only study is byte-identically unchanged):
+
+- **Import** keeps every dcm2niix series in `EXTRACT_DIR` (no modality filtering). `scan_selection.sh::discover_secondary_modality_specs` selects the best SWI/DWI-trace/ADC/T2 scan (filters out the T2-SPACE-FLAIR and the DWI-vs-ADC cross-contamination).
+- **Registration** routes secondaries through the **contrast-matched cascade** (`registration.sh::register_contrast_matched_cascade`, T1←FLAIR←{T2,DWI,ADC,SWI}, composed forward+inverse transforms persisted) into the common analysis space. Enabled by `CONTRAST_MATCHED_REGISTRATION=true` + `AUTO_REGISTER_ALL_MODALITIES=true` (both default on; the cascade is a no-op when no secondary is present). `CONTRAST_ANCHOR_MAP` anchors the whole T2-family {T2,DWI,ADC,SWI} on FLAIR.
+- **Cross-modal corroboration** (`cross_modal_analysis.sh`, default on, self-gated) samples the co-registered secondaries inside every PRIMARY FLAIR cluster and flags **DWI restriction** (trace↑ + ADC↓ → acute/ischemic), **SWI hypointensity** (→ hemorrhage/microbleed), **T2 hyperintensity** (→ corroborates FLAIR). It is corroboration ON TOP of the primary detection — it never re-detects or alters the lesion mask. Outputs the per-cluster table + summary under `analysis/cross_modal/`. Config: the `CROSS_MODAL_*` block (`MULTIMODAL_SECONDARY_MODALITIES`, per-modality z thresholds) in `config/default_config.sh`.
 
 ## Runtime notes
 

--- a/config/default_config.sh
+++ b/config/default_config.sh
@@ -397,15 +397,19 @@ export REG_LABEL_INTERPOLATION="GenericLabel"
 # list and its INVERSE are persisted (the inverse is needed by the downstream
 # DICOM cluster->source mapping).
 #
-# DEFAULT OFF preserves byte-identical current behaviour.  RECOMMENDED ON when a
-# good 3D FLAIR plus one or more T2-weighted series (T2/DWI/SWI) are present.
-export CONTRAST_MATCHED_REGISTRATION=false
+# DEFAULT ON, but GRACEFUL: the cascade only registers SECONDARY T2-weighted
+# series that are actually present (T2/DWI/SWI). When a study is T1+FLAIR only,
+# register_contrast_matched_cascade finds no specs and is a no-op — the T1/FLAIR
+# result is byte-identical to the legacy path. Set false to force the legacy
+# direct-to-T1 path for any present secondaries.
+export CONTRAST_MATCHED_REGISTRATION=true
 
 # Per-family contrast anchor map.  Each entry is "MODALITY:ANCHOR" where ANCHOR is
 # the modality whose registered space the MODALITY is matched to.  T2-weighted
-# family {T2,FLAIR,DWI,SWI} anchors on FLAIR; FLAIR anchors on T1; T1 anchors on
-# the MNI master.  Resolved by resolve_contrast_anchor() in registration.sh.
-export CONTRAST_ANCHOR_MAP=("T2:FLAIR" "DWI:FLAIR" "SWI:FLAIR" "FLAIR:T1" "T1:MNI")
+# family {T2,FLAIR,DWI,ADC,SWI} anchors on FLAIR (ADC shares the diffusion trace
+# geometry and registers well to the 3D FLAIR); FLAIR anchors on T1; T1 anchors
+# on the MNI master.  Resolved by resolve_contrast_anchor() in registration.sh.
+export CONTRAST_ANCHOR_MAP=("T2:FLAIR" "DWI:FLAIR" "ADC:FLAIR" "SWI:FLAIR" "FLAIR:T1" "T1:MNI")
 
 # Metric for the same-contrast modality->FLAIR step.  MI is always safe; CC only
 # if the pair is genuinely same-contrast (e.g. a true T2 vs 3D-FLAIR).  Left at MI
@@ -421,6 +425,72 @@ export CONTRAST_MATCHED_INTENSITY_INTERP="Linear"
 # outputs: per-modality registration to FLAIR, the composed-to-T1 resample, the
 # persisted composed forward/inverse transform lists, and a transform manifest.
 export CONTRAST_MATCHED_SUBDIR="contrast_matched"
+
+# ===========================================================================
+# MULTI-MODALITY PROCESSING  (SWI / DWI / T2 end-to-end + cross-modal analysis)
+# ===========================================================================
+# BrainStemX is genuinely MULTI-modal: beyond the T1/FLAIR backbone it can bring
+# the SECONDARY T2-weighted modalities (SWI magnitude, the DERIVED DWI trace and
+# ADC, and a true T2) all the way through the pipeline — preprocess -> contrast-
+# matched cascade into the common T1/analysis space -> per-cluster cross-modal
+# corroboration of every primary FLAIR hyperintensity.
+#
+# GRACEFUL BY CONSTRUCTION: each secondary modality is processed *only when it is
+# present on disk*. A study that contains only T1+FLAIR behaves EXACTLY as before
+# — nothing below changes the T1/FLAIR result, it only ADDS corroboration when
+# extra contrasts exist. The toggles default ON precisely because they are no-ops
+# in the absence of the relevant series.
+#
+# DWI NOTE: the diffusion input is treated as the DERIVED trace/ADC volumes (the
+# clinically exported b>0 trace and the ADC map), NOT raw 4D diffusion. SWI is a
+# magnitude (t2_hemo-style) volume. 2D / derived series are handled gracefully.
+
+# Secondary modalities the pipeline will try to bring end-to-end when present.
+# Each entry is matched against EXTRACT_DIR filenames (see detect_modality() in
+# preprocess.sh for the keyword families). T1 and FLAIR are the backbone and are
+# always processed; this list is the ADDITIVE set processed only when found.
+export MULTIMODAL_SECONDARY_MODALITIES=("T2" "SWI" "DWI" "ADC")
+
+# ---------------------------------------------------------------------------
+# Cross-modal corroboration analysis  (src/modules/cross_modal_analysis.sh)
+# ---------------------------------------------------------------------------
+# AFTER the primary FLAIR hyperintensity clusters are detected, sample each
+# co-registered secondary modality inside every cluster ROI and annotate
+# corroboration:
+#   DWI restriction (trace UP AND ADC DOWN)  -> acute / ischemic flag
+#   SWI hypointensity                        -> hemorrhage / microbleed flag
+#   T2 hyperintensity                        -> corroborates the FLAIR finding
+# Emits a per-cluster cross-modal TABLE (cluster id, region, FLAIR intensity/z,
+# plus each available modality's intensity + flag) and a corroboration summary.
+# This is CORROBORATION ON TOP OF the existing primary detection — it never
+# re-detects lesions and never alters the primary mask.
+#
+# DEFAULT ON but fully gated/graceful: with no co-registered secondary modality
+# the step logs "nothing to corroborate" and returns success (no-op).
+export CROSS_MODAL_ANALYSIS_ENABLED=true
+
+# Minimum cluster size (voxels) to include in the cross-modal table. Tiny
+# clusters are dominated by partial-volume and rarely worth corroborating.
+export CROSS_MODAL_MIN_CLUSTER_VOXELS=5
+
+# --- Per-modality corroboration thresholds (intensity z within the brainstem) -
+# Each modality is z-scored within the brainstem ROI (robust mean/SD over the
+# segmentation mask) so the thresholds are scanner/scale independent. A cluster's
+# per-modality z is its MEAN z over the cluster voxels.
+#
+# DWI restriction: acute ischemia shows trace HYPER-intensity AND ADC HYPO-
+# intensity. Flag "RESTRICTION" when trace z >= +DWI and ADC z <= -ADC.
+export CROSS_MODAL_DWI_TRACE_Z=1.0     # DWI trace z at/above this = elevated
+export CROSS_MODAL_ADC_Z=-1.0          # ADC z at/below this = reduced diffusion
+# SWI hemorrhage/microbleed: susceptibility blooming -> strong HYPO-intensity.
+export CROSS_MODAL_SWI_Z=-1.5          # SWI z at/below this = hypointense (blood)
+# T2 corroboration of FLAIR: lesion is HYPER-intense on T2 as well.
+export CROSS_MODAL_T2_Z=1.0            # T2 z at/above this = hyperintense
+
+# Subdirectory (under ${RESULTS_DIR}/analysis) for the cross-modal outputs:
+# the per-cluster table (CSV), the corroboration summary, and the per-modality
+# brainstem-resampled volumes used for sampling.
+export CROSS_MODAL_SUBDIR="cross_modal"
 
 # ANTs specific parameters - if not set, ANTs will use defaults
 # export METRIC_SAMPLING_STRATEGY="NONE"  # Options: NONE (use all voxels), REGULAR, RANDOM
@@ -987,8 +1057,14 @@ export FLAIR_SELECTION_MODE="original"    # Prefer ORIGINAL acquisitions over DE
 
 # Advanced registration options
 
-# Auto-register all modalities to T1 (if false, only FLAIR is registered)
-export AUTO_REGISTER_ALL_MODALITIES=false
+# Bring ALL present modalities (not just FLAIR) into the common analysis space.
+# DEFAULT ON and GRACEFUL: with only T1+FLAIR present this is a no-op beyond the
+# standard FLAIR<->T1 registration. When CONTRAST_MATCHED_REGISTRATION=true (the
+# default) the SECONDARY T2-weighted modalities (T2/DWI/SWI) are routed through
+# the contrast-matched cascade (T1<-FLAIR<-{T2,DWI,SWI}) rather than the legacy
+# direct-to-T1 MI path, which registers them far better. Set false to register
+# only FLAIR and skip secondaries entirely.
+export AUTO_REGISTER_ALL_MODALITIES=true
 
 # Auto-detect resolution and use appropriate template
 # When true, the pipeline will select between 1mm and 2mm templates based on input image resolution

--- a/src/modules/cross_modal_analysis.sh
+++ b/src/modules/cross_modal_analysis.sh
@@ -1,0 +1,265 @@
+#!/usr/bin/env bash
+#
+# cross_modal_analysis.sh - per-cluster cross-modal corroboration of FLAIR
+#                           hyperintensities using co-registered SWI/DWI/T2/ADC.
+#
+# This is the step that makes BrainStemX genuinely MULTI-modal. The PRIMARY
+# detection (analysis.sh detect_hyperintensities) finds and clusters brainstem
+# FLAIR hyperintensities. AFTER that, this module samples the co-registered
+# SECONDARY modalities inside each cluster ROI and annotates corroboration:
+#
+#   DWI restriction (trace UP + ADC DOWN) -> acute / ischemic
+#   SWI hypointensity                     -> hemorrhage / microbleed
+#   T2 hyperintensity                     -> corroborates the FLAIR finding
+#
+# It NEVER re-detects lesions and NEVER alters the primary mask — it is pure
+# corroboration on top of the primary clusters, with full per-cluster provenance.
+#
+# GRACEFUL: with no co-registered secondary modality present (e.g. a T1+FLAIR-only
+# study) the step logs "nothing to corroborate" and returns success (no-op). Each
+# modality is gated on its own presence, so partial sets (say SWI but no DWI)
+# work fine.
+#
+# Conventions: log_* / ERR_* from environment.sh, safe_fslmaths/apply_transform
+# wrappers, config toggles in config/default_config.sh (CROSS_MODAL_* block).
+
+# Lightweight include guard.
+if [ -n "${_CROSS_MODAL_ANALYSIS_LOADED:-}" ]; then return 0 2>/dev/null || true; fi
+_CROSS_MODAL_ANALYSIS_LOADED=1
+
+# Lightweight environment guard (fast no-op when the pipeline already loaded it;
+# fails fast with instructions if a user sources this module standalone).
+# shellcheck source=/dev/null
+source "$(dirname "${BASH_SOURCE[0]}")/require_env.sh"
+
+# ---------------------------------------------------------------------------
+# _cross_modal_python
+#   Echo a python launcher that has numpy + nibabel (prefer uv, then fslpython,
+#   then python3). Returns non-zero if none is usable.
+# ---------------------------------------------------------------------------
+_cross_modal_python() {
+    if command -v uv >/dev/null 2>&1 && \
+       uv run python -c "import numpy, nibabel" >/dev/null 2>&1; then
+        echo "uv run python"
+        return 0
+    fi
+    if [ -n "${FSLDIR:-}" ] && [ -x "${FSLDIR}/bin/fslpython" ] && \
+       "${FSLDIR}/bin/fslpython" -c "import numpy, nibabel" >/dev/null 2>&1; then
+        echo "${FSLDIR}/bin/fslpython"
+        return 0
+    fi
+    if command -v python3 >/dev/null 2>&1 && \
+       python3 -c "import numpy, nibabel" >/dev/null 2>&1; then
+        echo "python3"
+        return 0
+    fi
+    return 1
+}
+
+# ---------------------------------------------------------------------------
+# _cross_modal_find_coregistered <modality_name> <reg_dir>
+#   Find the best co-registered volume for a secondary modality produced by the
+#   contrast-matched cascade. Prefers the FLAIR-anchor-space resample
+#   (<base>_to_flairWarped.nii.gz) since the analysis runs in (a regrid of)
+#   FLAIR space; falls back to the composed-to-T1 resample. Echoes the path or
+#   empty. The cascade names outputs from the source basename, so we match on
+#   the modality keyword family within the contrast_matched dir.
+# ---------------------------------------------------------------------------
+_cross_modal_find_coregistered() {
+    local modality="$1"
+    local reg_dir="$2"
+    local cm_dir="${reg_dir}/${CONTRAST_MATCHED_SUBDIR:-contrast_matched}"
+    [ -d "$cm_dir" ] || { echo ""; return 1; }
+
+    # Keyword set per modality (mirrors scan selection / detect_modality).
+    local kw
+    case "${modality^^}" in
+        T2)  kw="T2 SPACE" ;;
+        SWI) kw="SWI SWAN susceptib t2_hemo venobold" ;;
+        DWI) kw="DWI trace TRACE b1000 diffusion" ;;
+        ADC) kw="ADC adc" ;;
+        *)   kw="$modality" ;;
+    esac
+
+    # The DWI trace and the ADC map can share the "DWI" keyword (e.g. an ADC map
+    # named EPI_DWI_ADC). Exclude any ADC match from the DWI trace slot BEFORE
+    # collapsing to one result, so the trace is never lost to find ordering.
+    local dwi_excl="cat"
+    [ "${modality^^}" = "DWI" ] && dwi_excl="grep -vi adc"
+
+    local k found suffix
+    # Pass 1: FLAIR-anchor-space resample (closest to the analysis space).
+    # Pass 2: composed-to-T1 resample.
+    for suffix in "_to_flairWarped.nii.gz" "_to_t1_composedWarped.nii.gz"; do
+        for k in $kw; do
+            found=$(find "$cm_dir" -maxdepth 1 -type f -iname "*${k}*${suffix}" \
+                        ! -iname "*FLAIR*to_flair*" 2>/dev/null \
+                        | $dwi_excl | head -1)
+            [ -n "$found" ] && { echo "$found"; return 0; }
+        done
+    done
+    echo ""
+    return 1
+}
+
+# ---------------------------------------------------------------------------
+# run_cross_modal_analysis
+#   <clusters_index_nifti> <brainstem_mask> <flair_analysis_space> <reg_dir>
+#   <output_dir>
+#
+#   clusters_index_nifti : integer cluster-label volume from the primary
+#                          detection (analyze_hyperintensity_clusters' clusters.nii.gz),
+#                          in the analysis (FLAIR) space.
+#   brainstem_mask       : brainstem segmentation in the analysis space (ROI for
+#                          z-scoring); falls back to whole-volume if missing.
+#   flair_analysis_space : the FLAIR intensity image the clusters were detected on.
+#   reg_dir              : RESULTS_DIR/registered (holds contrast_matched/ outputs).
+#   output_dir           : where the per-cluster table + summary are written.
+#
+# Returns 0 on success or graceful no-op; non-zero only on hard failure with the
+# feature enabled and inputs present but unusable.
+# ---------------------------------------------------------------------------
+run_cross_modal_analysis() {
+    local clusters="$1"
+    local brainstem_mask="$2"
+    local flair_img="$3"
+    local reg_dir="$4"
+    local output_dir="$5"
+
+    if [ "${CROSS_MODAL_ANALYSIS_ENABLED:-true}" != "true" ]; then
+        log_message "Cross-modal analysis disabled (CROSS_MODAL_ANALYSIS_ENABLED != true) - skipping"
+        return 0
+    fi
+
+    log_formatted "INFO" "===== CROSS-MODAL CORROBORATION ANALYSIS ====="
+
+    if [ -z "$clusters" ] || [ ! -f "$clusters" ]; then
+        log_formatted "WARNING" "Cross-modal: cluster index volume not found ($clusters) - nothing to corroborate"
+        return 0
+    fi
+    if [ -z "$flair_img" ] || [ ! -f "$flair_img" ]; then
+        log_formatted "WARNING" "Cross-modal: FLAIR image not found ($flair_img) - skipping"
+        return 0
+    fi
+
+    mkdir -p "$output_dir"
+    local resampled_dir="${output_dir}/resampled"
+    mkdir -p "$resampled_dir"
+
+    # Discover + regrid the co-registered secondary modalities onto the cluster
+    # grid. Each modality is gated on its own presence (graceful partial sets).
+    # Default the list element-by-element (NOT "${arr[@]:-a b c}", which collapses
+    # the fallback into a single 'a b c' element when the array is unset).
+    # ${var+x} is the set-test that is safe under `set -u` even when fully unset.
+    local mods=()
+    if [ -n "${MULTIMODAL_SECONDARY_MODALITIES+x}" ] && \
+       [ "${#MULTIMODAL_SECONDARY_MODALITIES[@]}" -gt 0 ]; then
+        mods=("${MULTIMODAL_SECONDARY_MODALITIES[@]}")
+    else
+        mods=(T2 SWI DWI ADC)
+    fi
+    local mod_args=()
+    local mod found resampled present_count=0
+    for mod in "${mods[@]}"; do
+        found="$(_cross_modal_find_coregistered "$mod" "$reg_dir" 2>/dev/null || true)"
+        if [ -z "$found" ] || [ ! -f "$found" ]; then
+            log_message "Cross-modal: ${mod} not co-registered (skipping)"
+            continue
+        fi
+        log_message "Cross-modal: ${mod} co-registered volume: $found"
+
+        # Regrid onto the EXACT cluster grid so voxelwise sampling is valid.
+        resampled="${resampled_dir}/${mod}_on_clusters.nii.gz"
+        if apply_transform "$found" "$clusters" "-usesqform" "$resampled" "trilinear" \
+                && [ -f "$resampled" ]; then
+            mod_args+=("--modality" "${mod}:${resampled}")
+            present_count=$((present_count + 1))
+        else
+            log_formatted "WARNING" "Cross-modal: failed to regrid ${mod} onto cluster grid (skipping)"
+        fi
+    done
+
+    if [ "$present_count" -eq 0 ]; then
+        log_message "Cross-modal: no co-registered secondary modalities present; nothing to corroborate (T1+FLAIR-only behaviour)"
+        # Leave a stub so downstream tools find a deterministic path. The header
+        # MUST match cross_modal_sample.py's zero-modality schema (build_header
+        # with no modality columns) so the same filename never has two schemas.
+        local stub="${output_dir}/cross_modal_clusters.csv"
+        printf 'cluster_id,n_voxels,cog_x,cog_y,cog_z,flair_mean,flair_z,corroboration,n_corroborating\n' > "$stub"
+        log_message "Cross-modal: wrote empty table stub: $stub"
+        return 0
+    fi
+
+    # Resolve a python launcher with numpy + nibabel.
+    local py
+    if ! py="$(_cross_modal_python)"; then
+        log_formatted "WARNING" "Cross-modal: no python with numpy+nibabel available - skipping (non-fatal)"
+        return 0
+    fi
+
+    local script="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)/cross_modal_sample.py"
+    if [ ! -f "$script" ]; then
+        log_formatted "WARNING" "Cross-modal: sampler script not found ($script) - skipping"
+        return 0
+    fi
+
+    # Brainstem ROI for z-scoring; tolerate absence. Pass the sentinel "NONE"
+    # (NOT the cluster volume) so the sampler z-scores over the nonzero-FLAIR
+    # brain extent rather than only the lesion voxels (which would make every
+    # cluster z degenerate toward 0 and suppress all corroboration flags).
+    local bs_arg="$brainstem_mask"
+    if [ -z "$bs_arg" ] || [ ! -f "$bs_arg" ]; then
+        log_message "Cross-modal: brainstem mask unavailable; sampler will z-score over the nonzero-FLAIR brain extent"
+        bs_arg="NONE"
+    fi
+
+    local out_csv="${output_dir}/cross_modal_clusters.csv"
+    local out_summary="${output_dir}/cross_modal_summary.txt"
+
+    log_message "Cross-modal: sampling ${present_count} modality(ies) over clusters via: $py"
+    local cm_out cm_status=0
+    # shellcheck disable=SC2086
+    cm_out=$($py "$script" "$clusters" "$bs_arg" "$flair_img" \
+        "${mod_args[@]}" \
+        --out-csv "$out_csv" \
+        --out-summary "$out_summary" \
+        --min-voxels "${CROSS_MODAL_MIN_CLUSTER_VOXELS:-5}" \
+        --dwi-trace-z "${CROSS_MODAL_DWI_TRACE_Z:-1.0}" \
+        --adc-z "${CROSS_MODAL_ADC_Z:--1.0}" \
+        --swi-z "${CROSS_MODAL_SWI_Z:--1.5}" \
+        --t2-z "${CROSS_MODAL_T2_Z:-1.0}" \
+        2>"${output_dir}/cross_modal_sampler.log") || cm_status=$?
+
+    # Surface the sampler diagnostics into the pipeline log.
+    if [ -f "${output_dir}/cross_modal_sampler.log" ]; then
+        while IFS= read -r line; do
+            log_message "Cross-modal: $line"
+        done < "${output_dir}/cross_modal_sampler.log"
+    fi
+
+    if [ "$cm_status" -ne 0 ]; then
+        log_formatted "WARNING" "Cross-modal sampler exited non-zero (status $cm_status) - non-fatal"
+        return 0
+    fi
+
+    # Echo the key=value summary the sampler emitted on stdout.
+    if [ -n "$cm_out" ]; then
+        while IFS= read -r kv; do
+            [ -n "$kv" ] && log_message "Cross-modal result: $kv"
+        done <<< "$cm_out"
+    fi
+
+    if [ -f "$out_csv" ]; then
+        log_formatted "SUCCESS" "Cross-modal per-cluster table: $out_csv"
+    fi
+    if [ -f "$out_summary" ]; then
+        log_message "Cross-modal corroboration summary: $out_summary"
+    fi
+    return 0
+}
+
+export -f _cross_modal_python
+export -f _cross_modal_find_coregistered
+export -f run_cross_modal_analysis
+
+log_message "Cross-modal analysis module loaded (SWI/DWI/T2 per-cluster corroboration)"

--- a/src/modules/cross_modal_sample.py
+++ b/src/modules/cross_modal_sample.py
@@ -1,0 +1,306 @@
+#!/usr/bin/env python3
+"""cross_modal_sample.py - per-cluster cross-modal corroboration sampling.
+
+Given the PRIMARY FLAIR hyperintensity cluster index volume and one or more
+co-registered secondary modalities (already resampled onto the cluster grid),
+sample each modality inside every cluster ROI and emit a per-cluster table plus
+a corroboration summary.
+
+This is CORROBORATION on top of the primary detection: it never re-detects
+lesions and never modifies the primary mask. Each modality is z-scored within
+the brainstem ROI (robust mean/SD) so thresholds are scale independent.
+
+Flags (a cluster's per-modality z is its MEAN z over the cluster voxels):
+  DWI restriction  : trace z >= DWI_TRACE_Z AND ADC z <= ADC_Z  -> "RESTRICTION"
+  SWI hypointensity: SWI z <= SWI_Z                             -> "HEMORRHAGE"
+  T2 hyperintensity: T2  z >= T2_Z                              -> "T2_CORROB"
+
+All output goes to the CSV (and a summary file); diagnostics go to stderr.
+Exit non-zero only on hard failure (missing/invalid primary inputs).
+"""
+
+import argparse
+import csv
+import sys
+
+import numpy as np
+
+try:
+    import nibabel as nib
+except ImportError as exc:  # pragma: no cover - environment guard
+    sys.stderr.write(f"cross_modal_sample: nibabel unavailable: {exc}\n")
+    sys.exit(2)
+
+# Clinical reading order for the modality columns; only present ones are emitted.
+PREFERRED_ORDER = ["T2", "SWI", "DWI", "ADC"]
+
+
+def log(msg):
+    """Write one diagnostic line to stderr (captured in the pipeline log)."""
+    sys.stderr.write(f"cross_modal_sample: {msg}\n")
+
+
+def load(path):
+    """Load a NIfTI as a float64 ndarray."""
+    img = nib.load(path)
+    return np.asanyarray(img.dataobj).astype(np.float64)
+
+
+def robust_stats(values):
+    """Return (mean, sd) over finite values; sd floored to avoid /0."""
+    finite = values[np.isfinite(values)]
+    if finite.size == 0:
+        return 0.0, 1.0
+    mean = float(np.mean(finite))
+    sd = float(np.std(finite))
+    if not np.isfinite(sd) or sd < 1e-6:
+        sd = 1.0
+    return mean, sd
+
+
+def parse_modspec(spec):
+    """Parse 'NAME:/path/to.nii.gz' into ('NAME', '/path/to.nii.gz')."""
+    name, _, path = spec.partition(":")
+    return name.strip().upper(), path.strip()
+
+
+def build_modality_zmaps(modspecs, clusters_shape, brainstem):
+    """Load each present modality and z-score it within the brainstem ROI.
+
+    Returns (mod_z, mod_raw, present) where mod_z/mod_raw are name->ndarray dicts
+    aligned to the cluster grid and `present` is the ordered list of usable names.
+    Modalities that fail to load or mismatch the cluster grid are skipped.
+    """
+    mod_z, mod_raw = {}, {}
+    for spec in modspecs:
+        name, path = parse_modspec(spec)
+        if not path:
+            continue
+        try:
+            vol = load(path)
+        except (OSError, ValueError, nib.filebasedimages.ImageFileError) as exc:
+            log(f"skipping {name}: load failed ({exc})")
+            continue
+        if vol.shape != clusters_shape:
+            log(f"skipping {name}: shape {vol.shape} != clusters {clusters_shape}")
+            continue
+        mean, sd = robust_stats(vol[brainstem])
+        mod_z[name] = (vol - mean) / sd
+        mod_raw[name] = vol
+        log(f"{name}: brainstem mean={mean:.3f} sd={sd:.3f}")
+
+    present = [m for m in PREFERRED_ORDER if m in mod_z]
+    present += [m for m in mod_z if m not in present]
+    return mod_z, mod_raw, present
+
+
+def flag_cluster(zmean, row, thresholds, counts):
+    """Apply the corroboration flags for one cluster.
+
+    Mutates `row` (per-modality *_flag fields) and `counts`, and returns the
+    list of corroboration tags that fired for this cluster.
+    """
+    corrob = []
+
+    if "T2" in zmean and zmean["T2"] >= thresholds["t2"]:
+        row["T2_flag"] = "HYPER"
+        corrob.append("T2_CORROB")
+        counts["T2_CORROB"] += 1
+
+    if "SWI" in zmean and zmean["SWI"] <= thresholds["swi"]:
+        row["SWI_flag"] = "HYPO"
+        corrob.append("SWI_HEMORRHAGE")
+        counts["SWI_HEMORRHAGE"] += 1
+
+    if "DWI" in zmean and "ADC" in zmean:
+        trace_up = zmean["DWI"] >= thresholds["dwi"]
+        adc_down = zmean["ADC"] <= thresholds["adc"]
+        if trace_up and adc_down:
+            row["DWI_flag"] = "RESTRICT"
+            row["ADC_flag"] = "LOW"
+            corrob.append("DWI_RESTRICTION")
+            counts["DWI_RESTRICTION"] += 1
+        else:
+            if trace_up:
+                row["DWI_flag"] = "HIGH"
+            if adc_down:
+                row["ADC_flag"] = "LOW"
+    elif "DWI" in zmean and zmean["DWI"] >= thresholds["dwi"]:
+        # Trace present without ADC: report elevation, cannot confirm restriction.
+        row["DWI_flag"] = "HIGH"
+
+    return corrob
+
+
+def build_row(lab, roi, vols, mods):
+    """Assemble the base per-cluster row (id, geometry, intensities + z).
+
+    `vols` is (flair, flair_z); `mods` is (mod_z, mod_raw, present).
+    """
+    flair, flair_z = vols
+    mod_z, mod_raw, present = mods
+    idx = np.argwhere(roi)
+    cog = idx.mean(axis=0)
+    row = {
+        "cluster_id": int(lab),
+        "n_voxels": int(idx.shape[0]),
+        "cog_x": round(float(cog[0]), 1),
+        "cog_y": round(float(cog[1]), 1),
+        "cog_z": round(float(cog[2]), 1),
+        "flair_mean": round(float(np.mean(flair[roi])), 3),
+        "flair_z": round(float(np.mean(flair_z[roi])), 3),
+    }
+    zmean = {}
+    for mod in present:
+        mz = float(np.mean(mod_z[mod][roi]))
+        zmean[mod] = mz
+        row[f"{mod}_mean"] = round(float(np.mean(mod_raw[mod][roi])), 3)
+        row[f"{mod}_z"] = round(mz, 3)
+        row[f"{mod}_flag"] = ""
+    return row, zmean
+
+
+def build_header(present):
+    """Build the CSV header columns for the present modalities."""
+    header = ["cluster_id", "n_voxels", "cog_x", "cog_y", "cog_z",
+              "flair_mean", "flair_z"]
+    for mod in present:
+        header += [f"{mod}_mean", f"{mod}_z", f"{mod}_flag"]
+    header += ["corroboration", "n_corroborating"]
+    return header
+
+
+def sample_clusters(clusters, vols, mods, params):
+    """Sample every cluster ROI and return (rows, counts).
+
+    `vols` is (flair, flair_z); `mods` is (mod_z, mod_raw, present);
+    `params` is (thresholds, min_voxels).
+    """
+    thresholds, min_voxels = params
+    counts = {"clusters_total": 0, "clusters_reported": 0,
+              "DWI_RESTRICTION": 0, "SWI_HEMORRHAGE": 0, "T2_CORROB": 0,
+              "any_corroboration": 0}
+    rows = []
+    for lab in np.unique(clusters[clusters > 0]).astype(int):
+        counts["clusters_total"] += 1
+        roi = clusters == lab
+        if int(np.count_nonzero(roi)) < min_voxels:
+            continue
+        counts["clusters_reported"] += 1
+        row, zmean = build_row(lab, roi, vols, mods)
+        corrob = flag_cluster(zmean, row, thresholds, counts)
+        row["corroboration"] = ";".join(corrob) if corrob else "NONE"
+        row["n_corroborating"] = len(corrob)
+        if corrob:
+            counts["any_corroboration"] += 1
+        rows.append(row)
+    return rows, counts
+
+
+def write_outputs(paths, header, rows, summary_ctx):
+    """Write the per-cluster CSV table and the corroboration summary file.
+
+    `paths` is (out_csv, out_summary); `summary_ctx` is (present, counts,
+    min_voxels).
+    """
+    out_csv, out_summary = paths
+    present, counts, min_voxels = summary_ctx
+    with open(out_csv, "w", newline="", encoding="utf-8") as fh:
+        writer = csv.DictWriter(fh, fieldnames=header)
+        writer.writeheader()
+        for row in rows:
+            writer.writerow({k: row.get(k, "") for k in header})
+    log(f"wrote per-cluster table: {out_csv} ({len(rows)} row(s))")
+
+    with open(out_summary, "w", encoding="utf-8") as fh:
+        fh.write("Cross-modal corroboration summary\n")
+        fh.write("=================================\n")
+        fh.write(f"Modalities sampled: {', '.join(present) if present else '(none)'}\n")
+        fh.write(f"Clusters total: {counts['clusters_total']}\n")
+        fh.write(f"Clusters reported (>= {min_voxels} voxels): "
+                 f"{counts['clusters_reported']}\n")
+        fh.write(f"Clusters with ANY corroboration: {counts['any_corroboration']}\n")
+        fh.write(f"  DWI restriction (acute/ischemic): {counts['DWI_RESTRICTION']}\n")
+        fh.write(f"  SWI hypointensity (hemorrhage):   {counts['SWI_HEMORRHAGE']}\n")
+        fh.write(f"  T2 hyperintensity (corroborates): {counts['T2_CORROB']}\n")
+    log(f"wrote summary: {out_summary}")
+
+
+def parse_args():
+    """Parse CLI arguments."""
+    ap = argparse.ArgumentParser(description="Per-cluster cross-modal sampling")
+    ap.add_argument("clusters", help="cluster index NIfTI (integer labels)")
+    ap.add_argument("brainstem", help="brainstem mask NIfTI (ROI for z-scoring)")
+    ap.add_argument("flair", help="FLAIR intensity NIfTI (analysis space)")
+    ap.add_argument("--modality", action="append", default=[],
+                    help="NAME:path of a co-registered modality (repeatable)")
+    ap.add_argument("--out-csv", required=True)
+    ap.add_argument("--out-summary", required=True)
+    ap.add_argument("--min-voxels", type=int, default=5)
+    ap.add_argument("--dwi-trace-z", type=float, default=1.0)
+    ap.add_argument("--adc-z", type=float, default=-1.0)
+    ap.add_argument("--swi-z", type=float, default=-1.5)
+    ap.add_argument("--t2-z", type=float, default=1.0)
+    return ap.parse_args()
+
+
+def load_brainstem(path, flair):
+    """Return the boolean ROI mask used for per-modality z-scoring.
+
+    Normally the brainstem segmentation. When `path` is the sentinel "NONE"/""
+    or fails to load, fall back to the nonzero-FLAIR (brain) extent rather than
+    the cluster voxels or the whole padded volume — z-scoring over background
+    zeros or over only the lesion voxels would make the z-scores degenerate.
+    """
+    if path and path.upper() != "NONE":
+        try:
+            return load(path) > 0.5
+        except (OSError, ValueError, nib.filebasedimages.ImageFileError) as exc:
+            log(f"could not load brainstem mask ({exc}); using nonzero-FLAIR ROI")
+    else:
+        log("no brainstem mask supplied; using nonzero-FLAIR ROI for z-scoring")
+    roi = np.isfinite(flair) & (flair != 0)
+    if not roi.any():
+        roi = np.ones_like(flair, dtype=bool)
+    return roi
+
+
+def main():
+    """Sample co-registered modalities over the primary clusters; emit table."""
+    args = parse_args()
+    thresholds = {"dwi": args.dwi_trace_z, "adc": args.adc_z,
+                  "swi": args.swi_z, "t2": args.t2_z}
+
+    clusters = load(args.clusters)
+    flair = load(args.flair)
+    brainstem = load_brainstem(args.brainstem, flair)
+
+    if clusters.shape != flair.shape:
+        log(f"shape mismatch clusters {clusters.shape} vs flair {flair.shape}")
+        sys.exit(3)
+
+    mods = build_modality_zmaps(args.modality, clusters.shape, brainstem)
+    present = mods[2]
+
+    f_mean, f_sd = robust_stats(flair[brainstem])
+    vols = (flair, (flair - f_mean) / f_sd)
+
+    log(f"sampling {len(present)} modality column(s): {present}")
+    rows, counts = sample_clusters(
+        clusters, vols, mods, (thresholds, args.min_voxels))
+
+    write_outputs((args.out_csv, args.out_summary), build_header(present), rows,
+                  (present, counts, args.min_voxels))
+
+    # Compact key=value block on stdout for the bash caller to log.
+    print(f"modalities={','.join(present)}")
+    print(f"clusters_reported={counts['clusters_reported']}")
+    print(f"any_corroboration={counts['any_corroboration']}")
+    print(f"dwi_restriction={counts['DWI_RESTRICTION']}")
+    print(f"swi_hemorrhage={counts['SWI_HEMORRHAGE']}")
+    print(f"t2_corroboration={counts['T2_CORROB']}")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/src/modules/scan_selection.sh
+++ b/src/modules/scan_selection.sh
@@ -644,6 +644,149 @@ analyze_dicom_headers() {
     return 0
 }
 
+# ----------------------------------------------------------------------------
+# SECONDARY-MODALITY scan selection (multi-modal: SWI / DWI trace / ADC / T2)
+# ----------------------------------------------------------------------------
+# The T1/FLAIR backbone is selected above. These helpers pick the best SECONDARY
+# T2-weighted series for the contrast-matched cascade + cross-modal analysis.
+# They are graceful: a modality that is absent simply yields nothing.
+
+# Echo the case-insensitive find -iname include patterns for a secondary modality.
+# DWI is the DERIVED TRACE (b>0), kept distinct from the ADC map. Patterns mirror
+# detect_modality() in preprocess.sh so selection and denoising agree.
+_secondary_modality_patterns() {
+    local modality="$1"
+    case "${modality^^}" in
+        T2)  echo "*T2*.nii.gz *SPACE*.nii.gz" ;;
+        SWI) echo "*SWI*.nii.gz *SWAN*.nii.gz *susceptib*.nii.gz *t2_hemo*.nii.gz *venobold*.nii.gz" ;;
+        DWI) echo "*DWI*.nii.gz *trace*.nii.gz *TRACE*.nii.gz *b1000*.nii.gz *diffusion*.nii.gz" ;;
+        ADC) echo "*ADC*.nii.gz *adc*.nii.gz" ;;
+        *)   echo "*${modality}*.nii.gz" ;;
+    esac
+}
+
+# Select the best present scan for ONE secondary modality from a directory.
+# Echoes the chosen file path (empty if none usable) and returns 0 if found.
+# Excludes the FLAIR anchor, masks, and known intermediate products, and skips
+# T2 candidates that are actually FLAIR/DWI/SWI (so "T2_SPACE_FLAIR" is NOT
+# mis-picked as T2). 2D / degenerate series are tolerated: selection still works
+# but the cascade validates dimensionality before registering.
+select_secondary_modality_scan() {
+    local modality="$1"
+    local directory="$2"
+    local reference_scan="${3:-}"
+    local selection_mode="${4:-${SCAN_SELECTION_MODE:-highest_resolution}}"
+
+    [ -d "$directory" ] || { echo ""; return 1; }
+
+    log_message "Selecting best ${modality} scan in $directory"
+
+    # Collect candidates across all patterns for this modality.
+    local patterns pat
+    patterns="$(_secondary_modality_patterns "$modality")"
+    local candidates=()
+    for pat in $patterns; do
+        while IFS= read -r f; do
+            [ -n "$f" ] && candidates+=("$f")
+        done < <(find "$directory" -maxdepth 1 -type f -iname "$pat" 2>/dev/null | sort)
+    done
+
+    if [ ${#candidates[@]} -eq 0 ]; then
+        log_message "No ${modality} candidates found"
+        echo ""
+        return 1
+    fi
+
+    # Filter out non-target / intermediate files. For T2 specifically, drop any
+    # FLAIR/DWI/SWI/ADC contaminant so a "T2_SPACE_FLAIR" is never chosen as T2.
+    local filtered=() c base
+    for c in "${candidates[@]}"; do
+        base="$(basename "$c")"
+        case "$base" in
+            *[Mm]ask*|*_mean.nii.gz|*_n4.nii.gz|*_std.nii.gz|*BrainExtraction*|*_brain.nii.gz|*Warped.nii.gz) continue ;;
+        esac
+        if [ "${modality^^}" = "T2" ]; then
+            case "${base,,}" in
+                *flair*|*dwi*|*trace*|*swi*|*swan*|*adc*) continue ;;
+            esac
+        fi
+        # ADC must not also be a trace; DWI trace must not be an ADC map.
+        if [ "${modality^^}" = "DWI" ]; then
+            case "${base,,}" in *adc*) continue ;; esac
+        fi
+        filtered+=("$c")
+    done
+
+    if [ ${#filtered[@]} -eq 0 ]; then
+        log_message "All ${modality} candidates filtered out as intermediates/contaminants"
+        echo ""
+        return 1
+    fi
+
+    # Build a glob the existing select_best_scan can use by handing it the FIRST
+    # matching pattern but restricting via a temp symlink dir would be overkill;
+    # instead score directly here when >1 candidate, reusing select_best_scan's
+    # quality metric by deferring to it on a single-pattern when possible.
+    if [ ${#filtered[@]} -eq 1 ]; then
+        log_message "Single ${modality} scan: ${filtered[0]}"
+        echo "${filtered[0]}"
+        return 0
+    fi
+
+    # Multiple candidates: pick the highest quality via evaluate_scan_quality.
+    # Default to the first candidate so a usable result is always returned even
+    # if every score parse fails.
+    local best="${filtered[0]}" best_score="-1" cand score cmp
+    for cand in "${filtered[@]}"; do
+        score="$(evaluate_scan_quality "$cand" "$modality" 2>/dev/null || echo 0)"
+        # evaluate_scan_quality may emit log lines; keep only the numeric tail.
+        score="$(echo "$score" | tail -1 | tr -dc '0-9.')"
+        # Reject anything that is not a clean number (e.g. empty, lone '.',
+        # multiple dots) so bc never receives a malformed expression.
+        if ! [[ "$score" =~ ^[0-9]+([.][0-9]+)?$ ]]; then
+            score=0
+        fi
+        cmp="$(echo "$score > $best_score" | bc -l 2>/dev/null || echo 0)"
+        if [ "$cmp" = "1" ]; then
+            best_score="$score"
+            best="$cand"
+        fi
+    done
+
+    log_message "Selected ${modality}: $best (score $best_score)"
+    echo "$best"
+    return 0
+}
+
+# Discover the present secondary modalities under EXTRACT_DIR and echo, one per
+# line, "NAME=path" specs ready for register_contrast_matched_cascade. Only
+# modalities in MULTIMODAL_SECONDARY_MODALITIES that are present AND usable are
+# emitted. Absent modalities are silently skipped (graceful). Always returns 0.
+discover_secondary_modality_specs() {
+    local directory="$1"
+    local reference_scan="${2:-}"
+
+    # Default the list element-by-element (NOT "${arr[@]:-a b c}", which collapses
+    # the fallback into a single 'a b c' element when the array is unset).
+    # ${var+x} is the set-test that is safe under `set -u` even when fully unset.
+    local mods=()
+    if [ -n "${MULTIMODAL_SECONDARY_MODALITIES+x}" ] && \
+       [ "${#MULTIMODAL_SECONDARY_MODALITIES[@]}" -gt 0 ]; then
+        mods=("${MULTIMODAL_SECONDARY_MODALITIES[@]}")
+    else
+        mods=(T2 SWI DWI ADC)
+    fi
+
+    local mod chosen
+    for mod in "${mods[@]}"; do
+        chosen="$(select_secondary_modality_scan "$mod" "$directory" "$reference_scan" 2>/dev/null || true)"
+        if [ -n "$chosen" ] && [ -f "$chosen" ]; then
+            printf '%s=%s\n' "$mod" "$chosen"
+        fi
+    done
+    return 0
+}
+
 # Export functions
 export -f evaluate_scan_quality
 export -f calculate_pixdim_similarity
@@ -653,5 +796,8 @@ export -f calculate_aspect_ratio_similarity
 export -f check_exact_dimension_match
 export -f select_best_scan
 export -f analyze_dicom_headers
+export -f _secondary_modality_patterns
+export -f select_secondary_modality_scan
+export -f discover_secondary_modality_specs
 
 log_message "Scan selection module loaded with enhanced registration-aware selection modes"

--- a/src/pipeline.sh
+++ b/src/pipeline.sh
@@ -109,7 +109,7 @@ source "${PIPELINE_DIR}/modules/enhanced_registration_validation.sh"
 # "… module loaded" line when sourced. The [ -f ] guard keeps a missing
 # file from tripping `set -e`. Do NOT add multi_atlas.sh here — that
 # module owns its own source line (added by a concurrent PR).
-for _opt in wmh_bianca wmh_lst_samseg wmh_synthseg wmh_segcsvd wmh_shiva wmh_mars brainstem_aanseg fp_filter; do
+for _opt in wmh_bianca wmh_lst_samseg wmh_synthseg wmh_segcsvd wmh_shiva wmh_mars brainstem_aanseg fp_filter cross_modal_analysis; do
   _optf="${PIPELINE_DIR}/modules/${_opt}.sh"
   [ -f "$_optf" ] && source "$_optf"
 done
@@ -722,11 +722,20 @@ run_pipeline() {
     # Create output directory for registration
     local reg_dir=$(create_module_dir "registered")
     
-    # Determine whether to use automatic multi-modality registration
-    if [ "${AUTO_REGISTER_ALL_MODALITIES:-false}" = "true" ]; then
-      log_message "Performing automatic registration of all modalities to T1"
+    # Determine whether to use automatic multi-modality registration.
+    #
+    # When the contrast-matched cascade is enabled (the default multi-modal
+    # path), the SECONDARY modalities (T2/DWI/SWI) are handled by the cascade
+    # block below — which needs the standard FLAIR->T1 transforms produced by the
+    # main registration path. So even with AUTO_REGISTER_ALL_MODALITIES=true we
+    # take the standard FLAIR<->T1 path here and let the cascade route the
+    # secondaries (T1<-FLAIR<-{T2,DWI,SWI}). The legacy direct-to-T1 MI path
+    # (register_all_modalities) is only used when the cascade is explicitly off.
+    if [ "${AUTO_REGISTER_ALL_MODALITIES:-false}" = "true" ] && \
+       [ "${CONTRAST_MATCHED_REGISTRATION:-false}" != "true" ]; then
+      log_message "Performing automatic registration of all modalities to T1 (legacy direct-to-T1 path)"
       register_all_modalities "$t1_std" "$(get_module_dir "standardized")" "$reg_dir"
-      
+
       # Find the registered FLAIR file for downstream processing
       local flair_registered=$(find "$reg_dir" -iname "*FLAIR*Warped.nii.gz" | head -1)
       if [ -z "$flair_registered" ]; then
@@ -738,6 +747,11 @@ run_pipeline() {
       else
         log_message "Using automatically registered FLAIR: $flair_registered"
       fi
+      # The downstream post-registration validation references moving_registered_file
+      # (assigned in the main-registration branch). In this legacy path the registered
+      # FLAIR IS the moving-registered output; bind it so the validation under set -u
+      # has a defined value instead of an unbound-variable abort.
+      local moving_registered_file="$flair_registered"
     else
       # MAIN REGISTRATION EXECUTION - This was missing!
       log_formatted "INFO" "===== EXECUTING MAIN REGISTRATION ====="
@@ -865,29 +879,23 @@ run_pipeline() {
           local cm_dir="${reg_dir}/${CONTRAST_MATCHED_SUBDIR:-contrast_matched}"
           mkdir -p "$cm_dir"
 
-          # Locate present T2-weighted secondary modalities (T2/DWI/SWI).  These
-          # are not standardized like T1/FLAIR, so search the standard output dirs
-          # (brain_extraction -> bias_corrected -> extracted), excluding masks.
+          # Locate present SECONDARY T2-weighted modalities (T2/SWI/DWI-trace/ADC)
+          # via the modality-aware scan selector. These are not standardized like
+          # T1/FLAIR, so selection runs over EXTRACT_DIR (raw imported series).
+          # Absent modalities are skipped (graceful); a T1+FLAIR-only study yields
+          # no specs and the cascade is a no-op. ADC is registered alongside the
+          # DWI trace so the cross-modal step can read restriction (trace+ADC).
           local cm_specs=()
-          local cm_mod cm_found cm_search_dir
-          for cm_mod in T2 DWI SWI; do
-            # Exclude the T2-SPACE-FLAIR (already the anchor) via the FLAIR filter below.
-            cm_found=""
-            for cm_search_dir in "${RESULTS_DIR}/brain_extraction" "${RESULTS_DIR}/bias_corrected" "${EXTRACT_DIR}"; do
-              [ -d "$cm_search_dir" ] || continue
-              cm_found=$(find "$cm_search_dir" -iname "*${cm_mod}*.nii.gz" ! -iname "*FLAIR*" ! -iname "*Mask*" ! -iname "*_mean.nii.gz" 2>/dev/null | head -1)
-              [ -n "$cm_found" ] && break
-            done
-            if [ -n "$cm_found" ]; then
-              log_message "Contrast-matched: found ${cm_mod} candidate: $cm_found"
-              cm_specs+=("${cm_mod}=${cm_found}")
-            else
-              log_message "Contrast-matched: no ${cm_mod} present (skipping)"
-            fi
-          done
+          if declare -f discover_secondary_modality_specs >/dev/null 2>&1; then
+            while IFS= read -r cm_spec; do
+              [ -n "$cm_spec" ] || continue
+              log_message "Contrast-matched: secondary modality spec: $cm_spec"
+              cm_specs+=("$cm_spec")
+            done < <(discover_secondary_modality_specs "$EXTRACT_DIR" "$flair_std")
+          fi
 
           if [ ${#cm_specs[@]} -eq 0 ]; then
-            log_message "No T2-weighted secondary modalities present; contrast-matched cascade has nothing to do"
+            log_message "No secondary T2-weighted modalities present; contrast-matched cascade has nothing to do (T1+FLAIR-only behaviour unchanged)"
           else
             register_contrast_matched_cascade \
               "$t1_std" "$flair_std" "$flair_to_t1_prefix" "$cm_dir" "${cm_specs[@]}" \
@@ -1318,6 +1326,27 @@ run_pipeline() {
         fi
       else
         log_formatted "WARNING" "run_fp_filter reported a non-fatal failure"
+      fi
+    fi
+
+    # --- Cross-modal corroboration (MULTI-MODAL; self-gated; default ON) -----
+    # Sample the co-registered SECONDARY modalities (SWI/DWI-trace/ADC/T2 brought
+    # into the common space by the contrast-matched cascade) inside every PRIMARY
+    # FLAIR cluster ROI and annotate corroboration (DWI restriction -> acute,
+    # SWI hypointensity -> hemorrhage, T2 hyperintensity -> corroborates). This
+    # is corroboration ON TOP of the primary detection; it never re-detects or
+    # alters the primary mask. GRACEFUL: with only T1+FLAIR present (no cascade
+    # outputs) it is a no-op. Operates on the cluster INDEX volume produced by
+    # analyze_hyperintensity_clusters (same analysis space as $seg_orig/$orig_flair).
+    if declare -f run_cross_modal_analysis >/dev/null 2>&1; then
+      local cross_modal_dir="${RESULTS_DIR}/analysis/${CROSS_MODAL_SUBDIR:-cross_modal}"
+      local clusters_index="${hyperintensities_dir}/clusters/clusters.nii.gz"
+      if [ -f "$clusters_index" ]; then
+        run_cross_modal_analysis \
+          "$clusters_index" "$seg_orig" "$orig_flair" "$reg_dir" "$cross_modal_dir" || \
+          log_formatted "WARNING" "Cross-modal analysis reported a non-fatal failure"
+      else
+        log_message "Cross-modal: cluster index not found ($clusters_index) - skipping corroboration"
       fi
     fi
 

--- a/tests/test_cross_modal_unit.sh
+++ b/tests/test_cross_modal_unit.sh
@@ -1,0 +1,177 @@
+#!/usr/bin/env bash
+#
+# test_cross_modal_unit.sh - Unit tests for the MULTI-MODAL additions:
+#   - scan_selection.sh secondary-modality discovery (SWI/DWI-trace/ADC/T2),
+#     incl. the T2-vs-FLAIR and DWI-trace-vs-ADC contamination filters
+#   - registration.sh resolve_contrast_anchor() now maps ADC -> FLAIR
+#   - cross_modal_analysis.sh module load + include guard + graceful no-op
+#   - cross_modal_analysis.sh _cross_modal_find_coregistered discovery
+#
+# These are pure-logic / filesystem tests; no FSL/ANTs/Python required (the
+# Python sampler is exercised separately end-to-end). The graceful no-op path is
+# the load-bearing guarantee that T1+FLAIR-only studies are unaffected.
+#
+
+set -u
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+source "$SCRIPT_DIR/test_helpers.sh"
+
+init_test_suite "Multi-modal (cross-modal) Unit Tests"
+setup_test_environment
+
+# Mocks for FSL tools any sourced module might touch at load time.
+create_mock_fslmaths >/dev/null 2>&1 || true
+create_mock_fslstats >/dev/null 2>&1 || true
+create_mock_fslinfo  >/dev/null 2>&1 || true
+
+load_environment_module
+# Tests deliberately exercise graceful-failure paths; disable errexit (matches
+# the set +e convention used by the other unit suites).
+set +e
+
+# Load config defaults so MULTIMODAL_*/CONTRAST_ANCHOR_MAP/CROSS_MODAL_* exist.
+source "$PROJECT_ROOT/config/default_config.sh" 2>/dev/null || true
+source "$PROJECT_ROOT/src/modules/scan_selection.sh" 2>/dev/null || true
+source "$PROJECT_ROOT/src/modules/registration.sh" 2>/dev/null || true
+source "$PROJECT_ROOT/src/modules/cross_modal_analysis.sh" 2>/dev/null || true
+
+# ══════════════════════════════════════════════════════════════════════════════
+# 1. Config defaults reflect the multi-modal enablement
+# ══════════════════════════════════════════════════════════════════════════════
+begin_test_group "1. Multi-modal config defaults"
+
+assert_equals "true" "${CONTRAST_MATCHED_REGISTRATION:-}" "CONTRAST_MATCHED_REGISTRATION defaults true"
+assert_equals "true" "${AUTO_REGISTER_ALL_MODALITIES:-}" "AUTO_REGISTER_ALL_MODALITIES defaults true"
+assert_equals "true" "${CROSS_MODAL_ANALYSIS_ENABLED:-}" "CROSS_MODAL_ANALYSIS_ENABLED defaults true"
+assert_var_set "MULTIMODAL_SECONDARY_MODALITIES" "MULTIMODAL_SECONDARY_MODALITIES is set"
+assert_var_set "CROSS_MODAL_DWI_TRACE_Z" "CROSS_MODAL_DWI_TRACE_Z is set"
+
+# ══════════════════════════════════════════════════════════════════════════════
+# 2. Module load + function definitions + include guard
+# ══════════════════════════════════════════════════════════════════════════════
+begin_test_group "2. Module load + guards"
+
+assert_function_exists "select_secondary_modality_scan"     "select_secondary_modality_scan defined"
+assert_function_exists "discover_secondary_modality_specs"  "discover_secondary_modality_specs defined"
+assert_function_exists "_secondary_modality_patterns"       "_secondary_modality_patterns defined"
+assert_function_exists "resolve_contrast_anchor"            "resolve_contrast_anchor defined"
+assert_function_exists "run_cross_modal_analysis"           "run_cross_modal_analysis defined"
+assert_function_exists "_cross_modal_find_coregistered"     "_cross_modal_find_coregistered defined"
+
+_before="${_CROSS_MODAL_ANALYSIS_LOADED:-}"
+source "$PROJECT_ROOT/src/modules/cross_modal_analysis.sh" 2>/dev/null || true
+assert_equals "$_before" "${_CROSS_MODAL_ANALYSIS_LOADED:-}" "cross_modal double-source is a no-op (guard holds)"
+
+# ══════════════════════════════════════════════════════════════════════════════
+# 3. resolve_contrast_anchor: T2-family anchors on FLAIR, incl. ADC
+# ══════════════════════════════════════════════════════════════════════════════
+begin_test_group "3. Contrast anchor resolution"
+
+assert_equals "FLAIR" "$(resolve_contrast_anchor T2)"  "T2 anchors on FLAIR"
+assert_equals "FLAIR" "$(resolve_contrast_anchor SWI)" "SWI anchors on FLAIR"
+assert_equals "FLAIR" "$(resolve_contrast_anchor DWI)" "DWI anchors on FLAIR"
+assert_equals "FLAIR" "$(resolve_contrast_anchor ADC)" "ADC anchors on FLAIR (multi-modal addition)"
+assert_equals "T1"    "$(resolve_contrast_anchor FLAIR)" "FLAIR anchors on T1"
+
+# ══════════════════════════════════════════════════════════════════════════════
+# 4. Secondary-modality scan selection + contamination filters
+# ══════════════════════════════════════════════════════════════════════════════
+begin_test_group "4. Secondary-modality discovery"
+
+EXDIR="$TEMP_TEST_DIR/extract"
+mkdir -p "$EXDIR"
+# Realistic Siemens-style filenames. T2_SPACE_FLAIR must NOT be picked as T2,
+# and the DWI ADC map must NOT be picked as the DWI trace.
+create_fake_nifti "$EXDIR/T1_MPRAGE_SAG_12.nii.gz"
+create_fake_nifti "$EXDIR/T2_SPACE_5.nii.gz"
+create_fake_nifti "$EXDIR/T2_SPACE_FLAIR_Sag_CS_17.nii.gz"
+create_fake_nifti "$EXDIR/T2_SWI_AX_8.nii.gz"
+create_fake_nifti "$EXDIR/EPI_DWI_trace_b1000_5.nii.gz"
+create_fake_nifti "$EXDIR/EPI_DWI_ADC_6.nii.gz"
+
+specs="$(discover_secondary_modality_specs "$EXDIR" "" 2>/dev/null)"
+
+t2_spec="$(echo "$specs"  | grep '^T2=')"
+swi_spec="$(echo "$specs" | grep '^SWI=')"
+dwi_spec="$(echo "$specs" | grep '^DWI=')"
+adc_spec="$(echo "$specs" | grep '^ADC=')"
+
+assert_contains "$t2_spec"  "T2_SPACE_5.nii.gz"          "T2 selected (the true T2 SPACE)"
+assert_not_contains "$t2_spec" "FLAIR"                   "T2 selection excludes the T2_SPACE_FLAIR contaminant"
+assert_contains "$swi_spec" "T2_SWI_AX_8.nii.gz"         "SWI selected"
+assert_contains "$dwi_spec" "trace"                      "DWI selects the trace volume"
+assert_not_contains "$dwi_spec" "ADC"                    "DWI selection excludes the ADC map"
+assert_contains "$adc_spec" "EPI_DWI_ADC_6.nii.gz"       "ADC selected separately"
+
+# T1+FLAIR-only directory => no secondary specs (graceful).
+EXDIR2="$TEMP_TEST_DIR/extract_t1flair"
+mkdir -p "$EXDIR2"
+create_fake_nifti "$EXDIR2/T1_MPRAGE_SAG_12.nii.gz"
+create_fake_nifti "$EXDIR2/T2_SPACE_FLAIR_Sag_CS_17.nii.gz"
+specs2="$(discover_secondary_modality_specs "$EXDIR2" "" 2>/dev/null)"
+assert_equals "" "$(echo "$specs2" | tr -d '[:space:]')" "T1+FLAIR-only yields NO secondary specs (graceful)"
+
+# ══════════════════════════════════════════════════════════════════════════════
+# 5. _cross_modal_find_coregistered: cascade-output discovery
+# ══════════════════════════════════════════════════════════════════════════════
+begin_test_group "5. Co-registered modality discovery"
+
+REGDIR="$TEMP_TEST_DIR/registered"
+CMDIR="$REGDIR/${CONTRAST_MATCHED_SUBDIR:-contrast_matched}"
+mkdir -p "$CMDIR"
+create_fake_nifti "$CMDIR/T2_SPACE_5_to_flairWarped.nii.gz"
+create_fake_nifti "$CMDIR/T2_SWI_AX_8_to_flairWarped.nii.gz"
+create_fake_nifti "$CMDIR/EPI_DWI_trace_b1000_to_flairWarped.nii.gz"
+create_fake_nifti "$CMDIR/EPI_DWI_ADC_to_flairWarped.nii.gz"
+
+found_t2="$(_cross_modal_find_coregistered T2 "$REGDIR" 2>/dev/null)"
+found_swi="$(_cross_modal_find_coregistered SWI "$REGDIR" 2>/dev/null)"
+found_dwi="$(_cross_modal_find_coregistered DWI "$REGDIR" 2>/dev/null)"
+found_adc="$(_cross_modal_find_coregistered ADC "$REGDIR" 2>/dev/null)"
+
+assert_contains "$found_t2"  "T2_SPACE_5_to_flairWarped"            "T2 co-registered volume found"
+assert_contains "$found_swi" "T2_SWI_AX_8_to_flairWarped"           "SWI co-registered volume found"
+assert_contains "$found_dwi" "trace"                                "DWI co-registered trace found"
+assert_not_contains "$found_dwi" "ADC"                              "DWI discovery excludes ADC"
+assert_contains "$found_adc" "EPI_DWI_ADC_to_flairWarped"           "ADC co-registered volume found"
+
+# Empty cascade dir => nothing found.
+REGDIR_EMPTY="$TEMP_TEST_DIR/registered_empty"
+mkdir -p "$REGDIR_EMPTY/${CONTRAST_MATCHED_SUBDIR:-contrast_matched}"
+assert_equals "" "$(_cross_modal_find_coregistered T2 "$REGDIR_EMPTY" 2>/dev/null)" "no co-registered T2 in empty cascade dir"
+
+# ══════════════════════════════════════════════════════════════════════════════
+# 6. run_cross_modal_analysis graceful no-op (T1+FLAIR-only)
+# ══════════════════════════════════════════════════════════════════════════════
+begin_test_group "6. Graceful no-op (no secondaries co-registered)"
+
+NOOP_RES="$TEMP_TEST_DIR/noop_results"
+mkdir -p "$NOOP_RES/registered/${CONTRAST_MATCHED_SUBDIR:-contrast_matched}"
+create_fake_nifti "$NOOP_RES/clusters.nii.gz"
+create_fake_nifti "$NOOP_RES/brainstem.nii.gz"
+create_fake_nifti "$NOOP_RES/flair.nii.gz"
+
+( run_cross_modal_analysis \
+    "$NOOP_RES/clusters.nii.gz" "$NOOP_RES/brainstem.nii.gz" "$NOOP_RES/flair.nii.gz" \
+    "$NOOP_RES/registered" "$NOOP_RES/cross_modal" ) >/dev/null 2>&1
+noop_rc=$?
+assert_equals "0" "$noop_rc" "run_cross_modal_analysis returns 0 (graceful) with no secondaries"
+assert_file_exists "$NOOP_RES/cross_modal/cross_modal_clusters.csv" "no-op writes a header-only table stub"
+
+# Disabled toggle => immediate no-op success.
+( CROSS_MODAL_ANALYSIS_ENABLED=false run_cross_modal_analysis \
+    "$NOOP_RES/clusters.nii.gz" "$NOOP_RES/brainstem.nii.gz" "$NOOP_RES/flair.nii.gz" \
+    "$NOOP_RES/registered" "$NOOP_RES/cross_modal_off" ) >/dev/null 2>&1
+off_rc=$?
+assert_equals "0" "$off_rc" "disabled toggle returns 0 without doing work"
+
+# Missing cluster index => graceful skip (returns 0).
+( run_cross_modal_analysis \
+    "$NOOP_RES/does_not_exist.nii.gz" "$NOOP_RES/brainstem.nii.gz" "$NOOP_RES/flair.nii.gz" \
+    "$NOOP_RES/registered" "$NOOP_RES/cross_modal_missing" ) >/dev/null 2>&1
+miss_rc=$?
+assert_equals "0" "$miss_rc" "missing cluster index returns 0 (graceful skip)"
+
+print_test_summary
+cleanup_test_environment


### PR DESCRIPTION
## Summary

Makes BrainStemX genuinely **multi-modal**: brings the secondary T2-weighted modalities — **SWI** magnitude, the DERIVED **DWI trace + ADC** (not raw 4D diffusion), and a true **T2** — all the way through the pipeline, and uses them to **corroborate** the primary FLAIR hyperintensity findings. Fully graceful: a **T1+FLAIR-only study is unaffected** (every secondary step is a no-op when its modality is absent).

## Import / scan-selection
- Import already keeps every dcm2niix series in `EXTRACT_DIR` (no modality filtering). Added modality-aware secondary scan selection in `scan_selection.sh`: `select_secondary_modality_scan` / `discover_secondary_modality_specs` pick the best SWI / DWI-trace / ADC / T2 series, filtering out the `T2_SPACE_FLAIR` contaminant and the DWI-trace-vs-ADC overlap. 2D/derived series are handled gracefully (selection works; the cascade validates before registering).

## Cascade enablement
- Defaults flipped on (graceful): `CONTRAST_MATCHED_REGISTRATION=true`, `AUTO_REGISTER_ALL_MODALITIES=true`.
- Secondaries are routed through PR #134's `register_contrast_matched_cascade` (**T1←FLAIR←{T2,DWI,ADC,SWI}**, composing onto the existing FLAIR→T1 transforms; forward+inverse persisted) rather than the legacy direct-to-T1 MI path. The registration-stage branch was reworked so that with the cascade on, the standard FLAIR↔T1 path runs (producing the transforms the cascade needs) and the cascade handles secondaries; the legacy `register_all_modalities` path is used only when the cascade is explicitly disabled.
- `ADC` added to `CONTRAST_ANCHOR_MAP` (anchors on FLAIR) so the cascade does not skip it.
- The cascade's secondary discovery now uses `discover_secondary_modality_specs` over `EXTRACT_DIR` instead of a fragile `find | head -1`.

## Cross-modal corroboration (the multi-modal payoff)
- New `cross_modal_analysis.sh` + `cross_modal_sample.py`. For each **primary FLAIR cluster**, samples the co-registered secondaries inside the cluster ROI and flags:
  - **DWI restriction** (trace ↑ AND ADC ↓) → acute / ischemic
  - **SWI hypointensity** → hemorrhage / microbleed
  - **T2 hyperintensity** → corroborates the FLAIR finding
- Emits a **per-cluster table** (cluster id, geometry, FLAIR intensity/z + each available modality's intensity / z / flag) and a **corroboration summary** under `analysis/cross_modal/`. Each modality is z-scored within the brainstem ROI so thresholds are scale-independent.
- This is **corroboration on top of** the existing per-region detection + provenance — it never re-detects lesions and never alters the primary mask. Wired into Step 6 after `analyze_hyperintensity_clusters` produces the cluster index; self-gated by `CROSS_MODAL_ANALYSIS_ENABLED`.

## Graceful T1+FLAIR-only fallback
- No secondary present → cascade has nothing to do; cross-modal step logs "nothing to corroborate" and writes a header-only stub (schema-consistent with the full table) and returns success. Default T1/FLAIR behaviour is unchanged.

## Config
- New clearly-delimited **MULTI-MODALITY** block in `config/default_config.sh`: `MULTIMODAL_SECONDARY_MODALITIES`, `CROSS_MODAL_ANALYSIS_ENABLED`, per-modality z thresholds (`CROSS_MODAL_{DWI_TRACE,ADC,SWI,T2}_Z`), `CROSS_MODAL_MIN_CLUSTER_VOXELS`, `CROSS_MODAL_SUBDIR`. Documents that SWI/DWI/T2 are processed only when present.

## Tests / verification
- New `tests/test_cross_modal_unit.sh` (34 assertions): config defaults, module load + include guard, anchor resolution (incl. ADC→FLAIR), secondary discovery + contamination filters, co-registered-output discovery (incl. the DWI-vs-ADC ordering edge case), and the graceful no-op paths.
- All green: `bash -n` + `shellcheck --severity=error` over all `*.sh`; `test_environment_unit` (100), `test_pipeline_control_unit` (98), `test_import_unit` (29), `test_multi_atlas_unit` (22), `test_cross_modal_unit` (34); `pipeline.sh --help`; `pytest` (27); `pylint` 10/10 + `isort` clean on the new Python.
- Functional (FSL present): synthetic T1/FLAIR + SWI/DWI(trace)/ADC/T2 — cascade-style co-registered volumes are regridded onto the cluster grid and the cross-modal step emits the per-cluster table with the correct flags (cluster 1: `T2_CORROB;DWI_RESTRICTION`; cluster 2: `SWI_HEMORRHAGE`); T1+FLAIR-only input produces the graceful no-op.

## Code review
- Ran `/code-review` (high). Fixed: legacy-branch `moving_registered_file` unbound under `set -u`; degenerate z-scoring on the missing-brainstem fallback (now z-scores over the nonzero-FLAIR brain extent, not the cluster voxels); stub-vs-sampler CSV schema divergence; DWI/ADC discovery ordering (`grep -vi adc` now applied before `head -1`); `${arr[@]:-default}` single-element collapse under `set -u`; `bc` score-parse robustness.

🤖 Generated with [Claude Code](https://claude.com/claude-code)