### PR TITLE
Output layer: canonical results tree + visualizations + CSV/HTML summary tables + top-level report

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -60,10 +60,12 @@ src/modules/             # 35+ modules, each sourced by pipeline.sh
   wmh_segcsvd.sh         # optional WMH: segcsvdWMH CNN (FLAIR-only); off by default
   wmh_shiva.sh           # optional WMH: SHIVA-WMH small-lesion detector (high sensitivity); off by default
   wmh_mars.sh            # optional WMH: MARS-WMH deep-learning tool (MIAC); off by default
-  visualization.sh       # 3D rendering, HTML reports
+  visualization.sh       # 3D rendering, QC HTML report, + report visualizations (per-method seg overlays, hyperintensity-on-FLAIR, multi-modal montage)
+  reporting.sh           # FINAL stage: aggregation/reporting layer — discovers all outputs, builds CSV/TSV+HTML summary tables (reports/tables/) and the top-level report (reports/brainstemx_report.html + .md). Gated/graceful/idempotent.
+  reporting_tables.py    # stdlib-only aggregator behind reporting.sh (parses provenance/summaries, renders tables + top-level report; called via uv)
   qa.sh                  # 20+ validation checks
 config/default_config.sh # all pipeline defaults (has include guard)
-tests/                   # 22 bash test scripts + 1 pytest module
+tests/                   # 23 bash test scripts + 2 pytest modules
 ```
 
 ## Code style
@@ -131,6 +133,16 @@ Beyond the T1/FLAIR backbone, the pipeline brings the **secondary** T2-weighted 
 - **Import** keeps every dcm2niix series in `EXTRACT_DIR` (no modality filtering). `scan_selection.sh::discover_secondary_modality_specs` selects the best SWI/DWI-trace/ADC/T2 scan (filters out the T2-SPACE-FLAIR and the DWI-vs-ADC cross-contamination).
 - **Registration** routes secondaries through the **contrast-matched cascade** (`registration.sh::register_contrast_matched_cascade`, T1←FLAIR←{T2,DWI,ADC,SWI}, composed forward+inverse transforms persisted) into the common analysis space. Enabled by `CONTRAST_MATCHED_REGISTRATION=true` + `AUTO_REGISTER_ALL_MODALITIES=true` (both default on; the cascade is a no-op when no secondary is present). `CONTRAST_ANCHOR_MAP` anchors the whole T2-family {T2,DWI,ADC,SWI} on FLAIR.
 - **Cross-modal corroboration** (`cross_modal_analysis.sh`, default on, self-gated) samples the co-registered secondaries inside every PRIMARY FLAIR cluster and flags **DWI restriction** (trace↑ + ADC↓ → acute/ischemic), **SWI hypointensity** (→ hemorrhage/microbleed), **T2 hyperintensity** (→ corroborates FLAIR). It is corroboration ON TOP of the primary detection — it never re-detects or alters the lesion mask. Outputs the per-cluster table + summary under `analysis/cross_modal/`. Config: the `CROSS_MODAL_*` block (`MULTIMODAL_SECONDARY_MODALITIES`, per-modality z thresholds) in `config/default_config.sh`.
+
+## Output layer (canonical tree + summary tables + top-level report)
+
+The FINAL pipeline stage (Step 8.5, `reporting.sh::generate_summary_report`, after analysis/QA/viz) is the aggregation/reporting layer over every merged capability. It DISCOVERS outputs wherever modules wrote them (it does not require every module to use fixed paths) and emits:
+
+- **Summary tables** under `reports/tables/`, each as **CSV/TSV + HTML** (and a `manifest.json`): `hyperintensity_per_region` (region × source: cluster count, volume, mean/peak z — from per-region GMM `region_provenance.tsv` + a `region_stats.tsv` sidecar the bash layer computes via `fslstats`), `wmh_tool_volumes` (one row per enabled tool, total + brainstem-restricted volume + clusters from each `<tool>_wmh_summary.txt`), `segmentation_volumes` (HO gross / FS substructures / multi-atlas nuclei / SynthSeg-aseg / subregions), `cross_modal` (passthrough of `analysis/cross_modal/cross_modal_clusters.csv`), `freesurfer_morphometry` (aseg volumes + eTIV from `freesurfer/harvest/stats/aseg.stats`), and a `run_manifest` (which seg paths / WMH tools / modalities / tables actually ran).
+- **Report visualizations** under `visualizations/` (`visualization.sh::generate_report_visualizations`): per-method segmentation overlays on T1, hyperintensity clusters on FLAIR, and a multi-modal montage (lesion mask on FLAIR/DWI/SWI/T2). Honours `SKIP_VISUALIZATION`.
+- **Top-level report** `reports/brainstemx_report.html` (+ `.md` fallback): a one-stop dashboard embedding all populated tables, the run manifest, and the discovered visualizations.
+
+Heavy parsing/rendering is in the stdlib-only `reporting_tables.py` (run via `uv`); the bash layer owns only the FSL-dependent parts (mask discovery + `fslstats` volume sidecars). Everything is **gated/graceful** (a minimal T1+FLAIR run still produces a valid smaller report; absent sections render as "No data") and **idempotent**. Governed by `REPORTING_ENABLED` (default `true`). Canonical tree + table schemas: `docs/output_structure.md`.
 
 ## Runtime notes
 

--- a/config/default_config.sh
+++ b/config/default_config.sh
@@ -1144,3 +1144,16 @@ export PADDING_Y=5
 export PADDING_Z=5
 export C3D_CROP_THRESHOLD=0.1
 export C3D_PADDING_MM=5
+
+# ============================================================================
+# REPORTING / AGGREGATION (final stage)
+# ============================================================================
+# The reporting stage (src/modules/reporting.sh) aggregates every artefact a run
+# produced into summary tables (CSV/TSV + HTML under reports/tables/) and a
+# single top-level report (reports/brainstemx_report.html + .md fallback). It
+# DISCOVERS outputs wherever modules wrote them and is fully gated/graceful: a
+# minimal T1+FLAIR run still yields a valid (smaller) report; absent sections are
+# skipped cleanly. See docs/output_structure.md.
+export REPORTING_ENABLED=true     # master switch for the reporting stage
+# Note: reporting also reuses CROSS_MODAL_SUBDIR (cross-modal table location)
+# and SKIP_VISUALIZATION (skip the report visualizations) from the blocks above.

--- a/docs/output_structure.md
+++ b/docs/output_structure.md
@@ -1,0 +1,115 @@
+# BrainStemX-Full output structure
+
+This document defines the **canonical results tree** produced by a pipeline run
+and describes the **aggregation / reporting layer** that sits over it.
+
+The reporting layer (`src/modules/reporting.sh` + `reporting_tables.py`) does not
+require every module to write to a fixed path — it **discovers** outputs wherever
+they land. The tree below is the canonical layout the pipeline creates up front
+(`create_directories` in `environment.sh`) and that the reporting stage targets.
+Everything is **graceful**: a minimal `T1 + FLAIR` run produces a valid (smaller)
+set of tables and a top-level report; sections whose inputs are absent are
+skipped cleanly and recorded as `absent` in the run manifest.
+
+## Canonical tree
+
+```
+<RESULTS_DIR>/
+├── metadata/                       # DICOM header analysis, scan selection
+├── combined/                       # multi-axis combined volumes (when used)
+├── bias_corrected/                 # N4 bias-corrected inputs  (preprocess)
+├── brain_extraction/               # SynthStrip/ANTs/BET brain + masks
+├── standardized/                   # *_std.nii.gz reference-space inputs
+├── registered/                     # ANTs registration outputs
+│   └── contrast_matched/           # contrast-matched cascade (T2/DWI/ADC/SWI → FLAIR/T1)
+├── segmentation/
+│   ├── tissue/                     # tissue segmentation (FAST/Atropos)
+│   ├── brainstem/                  # Harvard-Oxford GROSS brainstem extent
+│   ├── pons/                       # pons subdivision
+│   ├── detailed_brainstem/         # FS substructures + multi-atlas nuclei + SynthSeg
+│   │                               #   FS parcels:        <base>_{midbrain,pons,medulla,scp}.nii.gz
+│   │                               #   Bianciardi nuclei: bianciardi_*.nii.gz
+│   │                               #   CIT168 nuclei:     cit168_*.nii.gz
+│   │                               #   AAL3 (optional):   aal3_*.nii.gz
+│   └── freesurfer/  (or freesurfer/ at top level — harvest under harvest/)
+├── freesurfer/
+│   └── harvest/                    # FS recon harvest (freesurfer_harvest.sh)
+│       ├── stats/                  # aseg.stats, wmparc.stats, *_volumes.tsv, aparc tsv
+│       ├── csf_masks/              # aseg/synthseg CSF + ventricle masks (FP-exclusion)
+│       ├── synthseg/               # synthseg_seg.nii.gz, synthseg_vols.csv
+│       ├── subregions/             # thalamus / hypothalamus / hippo-amygdala labels
+│       └── harvest_provenance.txt
+├── hyperintensities/               # primary per-region GMM lesion masks + clusters/
+│   └── clusters/                   # clusters.nii.gz (cluster index volume)
+├── per_region_analysis/            # per-region GMM working dirs + provenance
+│   ├── region_provenance.tsv       # region_tag / region_base / source / mask_path
+│   └── region_stats.tsv            # (built by reporting) volume / clusters / z per region
+├── analysis/
+│   ├── wmh/                        # optional WMH tools, one subdir each
+│   │   ├── bianca/ lst_samseg/ synthseg/ segcsvd/ shiva/ mars/
+│   │   └── …/<tool>_wmh_summary.txt   (key=value: whole_brain_wmh_mm3, brainstem_wmh_mm3, …)
+│   └── cross_modal/                # per-cluster corroboration table + summary
+│       ├── cross_modal_clusters.csv
+│       └── cross_modal_summary.txt
+├── qc_visualizations/              # legacy QC PNGs / fsleyes scripts
+├── advanced_visualization/         # 3D renderings, intensity profiles
+├── visualizations/                 # report visualizations (NEW)
+│   ├── seg_harvard_oxford_brainstem.png
+│   ├── seg_{freesurfer,bianciardi,cit168,aal3}.png
+│   ├── hyperintensities_on_flair.png
+│   └── montage_{FLAIR,DWI,SWI,T2}.png
+├── validation/                     # per-stage validation reports
+├── summary/                        # batch-level summaries
+└── reports/
+    ├── tables/                     # summary tables (NEW)
+    │   ├── hyperintensity_per_region.{tsv,html}
+    │   ├── wmh_tool_volumes.{tsv,html}
+    │   ├── segmentation_volumes.{tsv,html}
+    │   ├── cross_modal.{tsv,html}
+    │   ├── freesurfer_morphometry.{tsv,html}
+    │   ├── run_manifest.{tsv,html}
+    │   └── manifest.json
+    ├── brainstemx_report.html      # one-stop dashboard (NEW)
+    └── brainstemx_report.md        # markdown fallback (NEW)
+```
+
+## Summary tables
+
+The reporting stage emits each of these as **both** a CSV/TSV and an HTML
+fragment under `reports/tables/`. Each is gated on its inputs.
+
+| Table | Columns | Source |
+|---|---|---|
+| `hyperintensity_per_region` | region, source, cluster_count, volume_mm3, mean_z, peak_z | per-region GMM `region_provenance.tsv` + `region_stats.tsv` sidecar |
+| `wmh_tool_volumes` | tool, total_wmh_mm3, total_clusters, brainstem_wmh_mm3, brainstem_clusters | each enabled tool's `<tool>_wmh_summary.txt` |
+| `segmentation_volumes` | region, source, volume_mm3, n_voxels | discovered masks (HO / FS / multi-atlas / SynthSeg-aseg / subregions) via `fslstats` |
+| `cross_modal` | cluster_id, n_voxels, …, corroboration, n_corroborating | `analysis/cross_modal/cross_modal_clusters.csv` (passthrough) |
+| `freesurfer_morphometry` | structure, volume_mm3 | `freesurfer/harvest/stats/aseg.stats` (incl. eTIV) |
+| `run_manifest` | item, status, detail | which seg paths / WMH tools / modalities / tables ran |
+
+## Top-level report
+
+`reports/brainstemx_report.html` embeds all populated tables, the run manifest,
+and any discovered visualizations (from `visualizations/`, plus a few legacy QC
+PNGs). `reports/brainstemx_report.md` is a plain-text fallback. `manifest.json`
+records, machine-readably, which sections were populated.
+
+## Graceful minimal-run behaviour
+
+A `T1 + FLAIR`-only run typically produces only the HO gross brainstem mask, a
+per-region GMM hyperintensity table, and (if FreeSurfer ran) morphometry. In that
+case:
+
+- `hyperintensity_per_region` and `segmentation_volumes` are populated.
+- `wmh_tool_volumes`, `cross_modal`, and (without FS) `freesurfer_morphometry`
+  render as empty sections marked "No data for this section".
+- The `run_manifest` lists every optional capability as `absent`.
+- The top-level report still renders and is a valid dashboard.
+
+## Pipeline wiring
+
+The reporting stage runs as the FINAL step (Step 8.5, after analysis/QA/viz) in
+`run_pipeline()`. It is idempotent (re-running overwrites the same outputs) and
+never aborts the pipeline (every failure is logged as a non-fatal WARNING). It
+is governed by `REPORTING_ENABLED` (default `true`); report visualizations honour
+`SKIP_VISUALIZATION`.

--- a/src/modules/environment.sh
+++ b/src/modules/environment.sh
@@ -1162,7 +1162,17 @@ create_directories() {
   mkdir -p "$RESULTS_DIR/qc_visualizations"
   mkdir -p "$RESULTS_DIR/reports"
   mkdir -p "$RESULTS_DIR/summary"
-  
+
+  # Canonical aggregation/reporting output tree (see docs/output_structure.md).
+  # The reporting layer DISCOVERS outputs wherever modules wrote them; these
+  # dirs are created up front so the tree is consistent and the reporting stage
+  # always has somewhere to write even on a minimal run.
+  mkdir -p "$RESULTS_DIR/segmentation/detailed_brainstem"
+  mkdir -p "$RESULTS_DIR/analysis/wmh"
+  mkdir -p "$RESULTS_DIR/analysis/cross_modal"
+  mkdir -p "$RESULTS_DIR/visualizations"
+  mkdir -p "$RESULTS_DIR/reports/tables"
+
   log_message "Created directory structure"
 }
 

--- a/src/modules/reporting.sh
+++ b/src/modules/reporting.sh
@@ -1,0 +1,452 @@
+#!/usr/bin/env bash
+#
+# reporting.sh - the aggregation / reporting layer over all merged capabilities.
+#
+# This is the FINAL pipeline stage. It discovers every artefact a run produced
+# (wherever it landed) and aggregates it into:
+#
+#   * Summary tables (CSV/TSV + HTML) under  reports/tables/
+#       - hyperintensity per region x source (per-region GMM + provenance)
+#       - WMH-tool volumes (one row per enabled tool)
+#       - segmentation / subregion volumes (HO gross / FS substructures /
+#         multi-atlas nuclei / SynthSeg-aseg / thalamic-hypothalamic)
+#       - cross-modal per-cluster corroboration table
+#       - FreeSurfer morphometry (aseg volumes + eTIV)
+#       - a run manifest (which paths / tools / modalities actually ran)
+#   * A single top-level report:  reports/brainstemx_report.html (+ .md fallback)
+#
+# Heavy lifting (parsing + table/HTML rendering) is in the stdlib-only Python
+# helper reporting_tables.py (run via uv). This bash layer owns ONLY the parts
+# that need FSL: discovering masks and computing their volumes with fslstats,
+# written to TSV sidecars the Python helper consumes.
+#
+# GRACEFUL: every section is gated on the existence of its inputs. A minimal
+# T1+FLAIR run still produces a valid (smaller) report; absent sections are
+# skipped cleanly. IDEMPOTENT: re-running overwrites the same outputs.
+#
+# Conventions: log_* / ERR_* from environment.sh, safe_fslmaths/fslstats, config
+# toggles in config/default_config.sh (REPORTING_* block).
+
+# Lightweight include guard.
+if [ -n "${_REPORTING_LOADED:-}" ]; then return 0 2>/dev/null || true; fi
+_REPORTING_LOADED=1
+
+# Lightweight environment guard (fast no-op when the pipeline already loaded it).
+# shellcheck source=/dev/null
+source "$(dirname "${BASH_SOURCE[0]}")/require_env.sh"
+
+# ---------------------------------------------------------------------------
+# _reporting_python
+#   Echo a python launcher (prefer uv, then fslpython, then python3). The
+#   reporting helper is stdlib-only, so any of these works. Returns non-zero
+#   only if none is usable.
+# ---------------------------------------------------------------------------
+_reporting_python() {
+    if command -v uv >/dev/null 2>&1 && uv run python -c "import sys" >/dev/null 2>&1; then
+        echo "uv run python"
+        return 0
+    fi
+    if [ -n "${FSLDIR:-}" ] && [ -x "${FSLDIR}/bin/fslpython" ]; then
+        echo "${FSLDIR}/bin/fslpython"
+        return 0
+    fi
+    if command -v python3 >/dev/null 2>&1; then
+        echo "python3"
+        return 0
+    fi
+    return 1
+}
+
+# ---------------------------------------------------------------------------
+# _reporting_mask_volume <mask.nii.gz>
+#   Echo "<n_voxels>\t<volume_mm3>" for a (possibly labelled) mask. fslstats -V
+#   counts non-zero voxels regardless of label value, so no binarisation copy is
+#   needed. For a 4D input fslstats -V emits one nvox/vol pair PER timepoint on a
+#   single line; we sum all the pairs (every even/odd field) so a 4D label stack
+#   is counted in full rather than only its first volume. Echoes nothing on
+#   failure (caller skips the row).
+# ---------------------------------------------------------------------------
+_reporting_mask_volume() {
+    local mask="$1"
+    [ -n "$mask" ] && [ -f "$mask" ] || { echo ""; return 1; }
+    local stats
+    stats=$(fslstats "$mask" -V 2>/dev/null) || { echo ""; return 1; }
+    # Sum nvox (odd fields) and vol (even fields); for the common 3D case this is
+    # just field1/field2. Empty stats => no fields => empty output (caller skips).
+    local summed
+    summed=$(echo "$stats" | awk 'NF>=2 {n=0; v=0; for(i=1;i+1<=NF;i+=2){n+=$i; v+=$(i+1)} printf "%s\t%s", n, v}')
+    [ -n "$summed" ] || { echo ""; return 1; }
+    printf '%s\n' "$summed"
+    return 0
+}
+
+# ---------------------------------------------------------------------------
+# _reporting_same_grid <a.nii.gz> <b.nii.gz>
+#   True (0) when both volumes share dim1/dim2/dim3 (so a voxelwise -mas is
+#   valid). Conservative: any failure to read dims returns false.
+# ---------------------------------------------------------------------------
+_reporting_same_grid() {
+    command -v fslval >/dev/null 2>&1 || return 1
+    local a="$1" b="$2" d
+    for d in dim1 dim2 dim3; do
+        local av bv
+        av=$(fslval "$a" "$d" 2>/dev/null | tr -d ' ')
+        bv=$(fslval "$b" "$d" 2>/dev/null | tr -d ' ')
+        [ -n "$av" ] && [ "$av" = "$bv" ] || return 1
+    done
+    return 0
+}
+
+# ---------------------------------------------------------------------------
+# _reporting_source_for_mask <mask_path>
+#   Classify a detailed_brainstem / segmentation mask by provenance source from
+#   its filename, mirroring analysis.sh's _region_source_from_path tagging.
+# ---------------------------------------------------------------------------
+_reporting_source_for_mask() {
+    local base
+    base=$(basename "$1")
+    case "$base" in
+        bianciardi_*) echo "bianciardi" ;;
+        cit168_*)     echo "cit168" ;;
+        aal3_*)       echo "aal3" ;;
+        synthseg_*)   echo "synthseg" ;;
+        aseg_*)       echo "aseg" ;;
+        *)            echo "freesurfer" ;;
+    esac
+}
+
+# ---------------------------------------------------------------------------
+# build_segmentation_volume_sidecar <results_dir> <out_tsv>
+#   Discover every segmentation mask (HO gross, FS substructures, multi-atlas
+#   nuclei, SynthSeg/aseg, thalamic/hypothalamic) and write a
+#   region<TAB>source<TAB>volume_mm3<TAB>n_voxels sidecar for the Python helper.
+#   GRACEFUL: writes a header-only file if nothing is found.
+# ---------------------------------------------------------------------------
+build_segmentation_volume_sidecar() {
+    local results_dir="$1"
+    local out_tsv="$2"
+
+    printf 'region\tsource\tvolume_mm3\tn_voxels\n' > "$out_tsv"
+
+    local seg_dir="${results_dir}/segmentation"
+    local detailed="${seg_dir}/detailed_brainstem"
+    local brainstem="${seg_dir}/brainstem"
+    local count=0
+
+    # --- HO gross brainstem (segmentation/brainstem) ----------------------
+    local f
+    if [ -d "$brainstem" ]; then
+        for f in "$brainstem"/*_brainstem.nii.gz "$brainstem"/*_hemisphere.nii.gz; do
+            [ -f "$f" ] || continue
+            _reporting_emit_volume_row "$f" "harvard_oxford" "$out_tsv" && count=$((count + 1))
+        done
+    fi
+
+    # --- detailed_brainstem (FS parcels + multi-atlas nuclei) -------------
+    if [ -d "$detailed" ]; then
+        for f in "$detailed"/*.nii.gz; do
+            [ -f "$f" ] || continue
+            case "$(basename "$f")" in
+                *intensity*|*_zscore*|*_resampled*|*brainstemSsLabels*) continue ;;
+            esac
+            local src
+            src=$(_reporting_source_for_mask "$f")
+            _reporting_emit_volume_row "$f" "$src" "$out_tsv" && count=$((count + 1))
+        done
+    fi
+
+    # --- SynthSeg / aseg label volumes + subregions (FreeSurfer harvest) --
+    local harvest="${results_dir}/freesurfer/harvest"
+    for f in \
+        "${harvest}/synthseg/synthseg_seg.nii.gz" \
+        "${harvest}/subregions/thalamus_labels.nii.gz" \
+        "${harvest}/subregions/hypothalamus_labels.nii.gz" \
+        "${harvest}/subregions/hippo_amygdala_lh_labels.nii.gz" \
+        "${harvest}/subregions/hippo_amygdala_rh_labels.nii.gz"; do
+        [ -f "$f" ] || continue
+        local src="freesurfer"
+        case "$(basename "$f")" in synthseg_*) src="synthseg" ;; esac
+        _reporting_emit_volume_row "$f" "$src" "$out_tsv" && count=$((count + 1))
+    done
+
+    log_message "Reporting: segmentation volume sidecar rows=$count -> $out_tsv"
+    return 0
+}
+
+# Helper: append one "region<TAB>source<TAB>vol<TAB>nvox" row. Region name is the
+# mask basename with source prefix and .nii.gz stripped for readability.
+_reporting_emit_volume_row() {
+    local mask="$1" source="$2" out_tsv="$3"
+    local vol_line
+    vol_line=$(_reporting_mask_volume "$mask") || return 1
+    [ -n "$vol_line" ] || return 1
+    local nvox vol region
+    nvox=$(printf '%s' "$vol_line" | cut -f1)
+    vol=$(printf '%s' "$vol_line" | cut -f2)
+    region=$(basename "$mask" .nii.gz)
+    # Strip a leading atlas/source prefix so the region column is anatomy-focused.
+    region="${region#bianciardi_}"
+    region="${region#cit168_}"
+    region="${region#aal3_}"
+    region="${region#synthseg_}"
+    region="${region#aseg_}"
+    printf '%s\t%s\t%s\t%s\n' "$region" "$source" "$vol" "$nvox" >> "$out_tsv"
+    return 0
+}
+
+# ---------------------------------------------------------------------------
+# build_per_region_stats_sidecar <results_dir>
+#   For each analysed per-region GMM output (out_prefix_<tag>_GMM.nii.gz) compute
+#   volume + cluster count and write per_region_analysis/region_stats.tsv keyed
+#   by region_tag (matching region_provenance.tsv). GRACEFUL no-op if the
+#   per-region dir / provenance manifest is absent.
+# ---------------------------------------------------------------------------
+build_per_region_stats_sidecar() {
+    local results_dir="$1"
+    local prdir=""
+    if [ -d "${results_dir}/per_region_analysis" ]; then
+        prdir="${results_dir}/per_region_analysis"
+    elif [ -d "${results_dir}/analysis/per_region" ]; then
+        prdir="${results_dir}/analysis/per_region"
+    else
+        log_message "Reporting: per-region analysis dir absent - skipping region stats"
+        return 0
+    fi
+
+    local prov="${prdir}/region_provenance.tsv"
+    if [ ! -f "$prov" ]; then
+        log_message "Reporting: region_provenance.tsv absent - skipping region stats"
+        return 0
+    fi
+
+    local out_tsv="${prdir}/region_stats.tsv"
+    printf 'region_tag\tvolume_mm3\tn_voxels\tcluster_count\tmean_z\tpeak_z\n' > "$out_tsv"
+
+    # Per-region GMM masks are written next to the hyperintensities prefix as
+    # <prefix>_<region_tag>_GMM.nii.gz. Discover them under the hyperintensities
+    # dir; fall back to any *_GMM.nii.gz beneath the per-region work dirs.
+    local hyper_dir="${results_dir}/hyperintensities"
+    local rows=0 region_tag mask
+    while IFS=$'\t' read -r region_tag _region_base _source _mask_path; do
+        [ -n "$region_tag" ] || continue
+        [ "$region_tag" = "region_tag" ] && continue   # skip header
+
+        mask=""
+        local work_dir="${prdir}/${region_tag}_FLAIR_analysis"
+        # Preferred: the canonical per-region GMM output named by tag.
+        if [ -d "$hyper_dir" ]; then
+            mask=$(find "$hyper_dir" -maxdepth 1 -name "*_${region_tag}_GMM.nii.gz" 2>/dev/null | head -1 || true)
+        fi
+        # Fallback: the connectivity output kept inside the region work dir. Use a
+        # grouped expression with explicit precedence (find ... \( A -o B \)) so
+        # the GMM mask is preferred deterministically, not whatever find emits first.
+        if [ -z "$mask" ] && [ -d "$work_dir" ]; then
+            mask=$(find "$work_dir" \( -name "*_GMM.nii.gz" -o -name "*_connectivity.nii.gz" \) 2>/dev/null | sort | head -1 || true)
+        fi
+        [ -n "$mask" ] && [ -f "$mask" ] || continue
+
+        local vol_line nvox vol clusters mean_z peak_z
+        vol_line=$(_reporting_mask_volume "$mask") || continue
+        [ -n "$vol_line" ] || continue
+        nvox=$(printf '%s' "$vol_line" | cut -f1)
+        vol=$(printf '%s' "$vol_line" | cut -f2)
+
+        # Cluster count via FSL cluster (binarised); tolerate absence of tool.
+        clusters=""
+        if command -v cluster >/dev/null 2>&1; then
+            clusters=$(cluster --in="$mask" --thresh=0.0001 --connectivity=26 --no_table 2>/dev/null | tail -n +2 | wc -l | tr -d ' ' || true)
+        fi
+
+        # mean/peak z of the DETECTION, sampled from the region z-score image
+        # (the GMM mask is BINARY, so sampling it would always yield ~1). Mask the
+        # zscore image by the detection then take -M (mean over >0) and -R (max).
+        # Falls back to blank when the zscore image is unavailable.
+        mean_z=""
+        peak_z=""
+        local zscore=""
+        if [ -d "$work_dir" ]; then
+            zscore=$(find "$work_dir" -maxdepth 1 -name "*_zscore.nii.gz" 2>/dev/null | head -1 || true)
+        fi
+        if [ -n "$zscore" ] && [ -f "$zscore" ] && _reporting_same_grid "$zscore" "$mask"; then
+            local z_in_det="${work_dir}/.reporting_z_in_detection.nii.gz"
+            if fslmaths "$zscore" -mas "$mask" "$z_in_det" >/dev/null 2>&1; then
+                mean_z=$(fslstats "$z_in_det" -l 0.0000001 -M 2>/dev/null || echo "")
+                peak_z=$(fslstats "$z_in_det" -R 2>/dev/null | awk '{print $2}' || echo "")
+                rm -f "$z_in_det" 2>/dev/null
+            fi
+        fi
+
+        printf '%s\t%s\t%s\t%s\t%s\t%s\n' \
+            "$region_tag" "$vol" "$nvox" "${clusters:-}" "${mean_z:-}" "${peak_z:-}" >> "$out_tsv"
+        rows=$((rows + 1))
+    done < "$prov"
+
+    log_message "Reporting: per-region stats sidecar rows=$rows -> $out_tsv"
+    return 0
+}
+
+# ---------------------------------------------------------------------------
+# backfill_wmh_summaries <results_dir>
+#   Some WMH tools leave a lesion mask but NO key=value summary (BIANCA logs its
+#   volumes to stdout only). For any such tool we synthesize a summary the Python
+#   aggregator can read, so a tool that actually ran is never silently omitted
+#   from the WMH table. GRACEFUL no-op when fslstats is unavailable or the tool
+#   left no mask.
+# ---------------------------------------------------------------------------
+backfill_wmh_summaries() {
+    local results_dir="$1"
+    command -v fslstats >/dev/null 2>&1 || return 0
+    local wmh_root="${results_dir}/analysis/wmh"
+    [ -d "$wmh_root" ] || return 0
+
+    # Each spec: tool_subdir : summary_filename : whole-brain mask glob :
+    # brainstem mask glob. Only tools that leave a mask but NO summary need an
+    # entry here (currently just BIANCA, which logs volumes to stdout only).
+    local specs=(
+        "bianca:bianca_wmh_summary.txt:bianca_wmh_thr*_bin.nii.gz:bianca_wmh_brainstem.nii.gz"
+    )
+    local spec
+    for spec in "${specs[@]}"; do
+        local subdir sumname wb_glob bs_glob
+        IFS=':' read -r subdir sumname wb_glob bs_glob <<< "$spec"
+        local dir="${wmh_root}/${subdir}"
+        [ -d "$dir" ] || continue
+        # Respect an existing summary (idempotent; don't clobber the tool's own).
+        [ -f "${dir}/${sumname}" ] && continue
+
+        local wb_mask
+        wb_mask=$(find "$dir" -maxdepth 1 -name "$wb_glob" 2>/dev/null | head -1 || true)
+        [ -n "$wb_mask" ] && [ -f "$wb_mask" ] || continue
+
+        local wb_line wb_vol wb_clusters
+        wb_line=$(_reporting_mask_volume "$wb_mask") || continue
+        wb_vol=$(printf '%s' "$wb_line" | cut -f2)
+        wb_clusters=""
+        if command -v cluster >/dev/null 2>&1; then
+            wb_clusters=$(cluster --in="$wb_mask" --thresh=0.5 --connectivity=26 --no_table 2>/dev/null | tail -n +2 | wc -l | tr -d ' ' || true)
+        fi
+
+        local bs_vol="" bs_clusters=""
+        local bs_mask
+        bs_mask=$(find "$dir" -maxdepth 1 -name "$bs_glob" 2>/dev/null | head -1 || true)
+        if [ -n "$bs_mask" ] && [ -f "$bs_mask" ]; then
+            local bs_line
+            bs_line=$(_reporting_mask_volume "$bs_mask" || true)
+            [ -n "$bs_line" ] && bs_vol=$(printf '%s' "$bs_line" | cut -f2)
+            if command -v cluster >/dev/null 2>&1; then
+                bs_clusters=$(cluster --in="$bs_mask" --thresh=0.5 --connectivity=26 --no_table 2>/dev/null | tail -n +2 | wc -l | tr -d ' ' || true)
+            fi
+        fi
+
+        {
+            printf 'tool=%s\n' "$subdir"
+            printf 'note=summary synthesized by reporting.sh (tool wrote no summary)\n'
+            printf 'lesion_mask=%s\n' "$wb_mask"
+            printf 'whole_brain_wmh_mm3=%s\n' "$wb_vol"
+            [ -n "$wb_clusters" ] && printf 'whole_brain_wmh_clusters=%s\n' "$wb_clusters"
+            [ -n "$bs_vol" ] && printf 'brainstem_wmh_mm3=%s\n' "$bs_vol"
+            [ -n "$bs_clusters" ] && printf 'brainstem_wmh_clusters=%s\n' "$bs_clusters"
+        } > "${dir}/${sumname}"
+        log_message "Reporting: synthesized WMH summary for '${subdir}' -> ${dir}/${sumname}"
+    done
+    return 0
+}
+
+# ---------------------------------------------------------------------------
+# generate_summary_report <subject_id> <results_dir>
+#   Top-level entry point for the reporting stage. Builds the volume sidecars,
+#   then runs the Python aggregator to emit the tables + the top-level report.
+#   GRACEFUL: missing inputs => smaller report; never aborts the pipeline.
+# ---------------------------------------------------------------------------
+generate_summary_report() {
+    local subject_id="$1"
+    local results_dir="$2"
+
+    if [ "${REPORTING_ENABLED:-true}" != "true" ]; then
+        log_message "Reporting disabled (REPORTING_ENABLED != true) - skipping"
+        return 0
+    fi
+
+    log_formatted "INFO" "===== REPORTING: AGGREGATION + SUMMARY TABLES + REPORT ====="
+
+    if [ -z "$results_dir" ] || [ ! -d "$results_dir" ]; then
+        log_formatted "WARNING" "Reporting: results dir not found ($results_dir) - skipping"
+        return 0
+    fi
+
+    local tables_dir="${results_dir}/reports/tables"
+    mkdir -p "$tables_dir"
+
+    # 1) Segmentation volume sidecar (needs FSL; owned by bash).
+    local seg_sidecar="${tables_dir}/segmentation_volume_sidecar.tsv"
+    if command -v fslstats >/dev/null 2>&1; then
+        build_segmentation_volume_sidecar "$results_dir" "$seg_sidecar" || \
+            log_formatted "WARNING" "Reporting: segmentation sidecar build reported a non-fatal failure"
+        build_per_region_stats_sidecar "$results_dir" || \
+            log_formatted "WARNING" "Reporting: per-region stats build reported a non-fatal failure"
+        backfill_wmh_summaries "$results_dir" || \
+            log_formatted "WARNING" "Reporting: WMH summary backfill reported a non-fatal failure"
+    else
+        log_formatted "WARNING" "Reporting: fslstats unavailable - volume columns will be blank"
+        printf 'region\tsource\tvolume_mm3\tn_voxels\n' > "$seg_sidecar"
+    fi
+
+    # 2) Run the Python aggregator (stdlib only).
+    local py
+    if ! py="$(_reporting_python)"; then
+        log_formatted "WARNING" "Reporting: no python available - skipping table aggregation (non-fatal)"
+        return 0
+    fi
+
+    local script
+    script="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)/reporting_tables.py"
+    if [ ! -f "$script" ]; then
+        log_formatted "WARNING" "Reporting: aggregator script not found ($script) - skipping"
+        return 0
+    fi
+
+    local report_html="${results_dir}/reports/brainstemx_report.html"
+    local report_md="${results_dir}/reports/brainstemx_report.md"
+
+    log_message "Reporting: aggregating tables + building report via: $py"
+    local rep_status=0
+    # shellcheck disable=SC2086
+    $py "$script" \
+        --results-dir "$results_dir" \
+        --out-dir "$tables_dir" \
+        --subject-id "$subject_id" \
+        --seg-volumes "$seg_sidecar" \
+        --cross-modal-subdir "${CROSS_MODAL_SUBDIR:-cross_modal}" \
+        --report-html "$report_html" \
+        --report-md "$report_md" \
+        2>"${tables_dir}/reporting.log" || rep_status=$?
+
+    # Surface the aggregator diagnostics into the pipeline log.
+    if [ -f "${tables_dir}/reporting.log" ]; then
+        while IFS= read -r line; do
+            [ -n "$line" ] && log_message "Reporting: $line"
+        done < "${tables_dir}/reporting.log"
+    fi
+
+    if [ "$rep_status" -ne 0 ]; then
+        log_formatted "WARNING" "Reporting: aggregator exited non-zero (status $rep_status) - non-fatal"
+        return 0
+    fi
+
+    [ -f "$report_html" ] && log_formatted "SUCCESS" "Top-level report: $report_html"
+    [ -f "$report_md" ] && log_message "Markdown report: $report_md"
+    log_message "Summary tables (CSV/TSV + HTML): $tables_dir"
+    return 0
+}
+
+export -f _reporting_python
+export -f _reporting_mask_volume
+export -f _reporting_same_grid
+export -f _reporting_source_for_mask
+export -f _reporting_emit_volume_row
+export -f build_segmentation_volume_sidecar
+export -f build_per_region_stats_sidecar
+export -f backfill_wmh_summaries
+export -f generate_summary_report
+
+log_message "Reporting module loaded (aggregation + summary tables + top-level report)"

--- a/src/modules/reporting_tables.py
+++ b/src/modules/reporting_tables.py
@@ -1,0 +1,684 @@
+#!/usr/bin/env python3
+"""reporting_tables.py - aggregate BrainStemX-Full results into summary tables.
+
+This is the Python helper behind ``src/modules/reporting.sh``. It DISCOVERS the
+various artefacts a run produced (wherever they landed), normalises them, and
+emits each summary table as BOTH a CSV/TSV and an HTML fragment, plus a small
+``manifest.json`` describing which sections were populated.
+
+Design goals (mirror the bash conventions of this repo):
+  * GRACEFUL - every section is gated on the existence of its inputs. A minimal
+    T1+FLAIR run that only produced a brainstem mask and a hyperintensity table
+    still yields a valid (smaller) set of tables; absent sections are skipped
+    cleanly and recorded as "absent" in the manifest.
+  * STDLIB ONLY - no numpy/nibabel/pandas dependency. We parse the CSV/TSV the
+    upstream modules already wrote; volume numbers are passed in as a sidecar
+    TSV the bash layer prepares (it owns fslstats), so this script never shells
+    out itself.
+  * DETERMINISTIC - stable column order and row sorting so test fixtures match.
+
+Invocation (see reporting.sh)::
+
+    uv run python reporting_tables.py \
+        --results-dir   <RESULTS_DIR> \
+        --out-dir       <RESULTS_DIR>/reports/tables \
+        --subject-id    <SUBJECT_ID> \
+        [--seg-volumes  <sidecar.tsv>]   # region\tsource\tvolume_mm3\tn_voxels
+
+Outputs (under --out-dir):
+    hyperintensity_per_region.{tsv,html}
+    wmh_tool_volumes.{tsv,html}
+    segmentation_volumes.{tsv,html}
+    cross_modal.{tsv,html}
+    freesurfer_morphometry.{tsv,html}
+    run_manifest.{tsv,html}
+    manifest.json
+"""
+
+from __future__ import annotations
+
+import argparse
+import csv
+import glob
+import html
+import json
+import os
+import re
+import sys
+from typing import Dict, List, Optional, Sequence, Tuple
+
+# --------------------------------------------------------------------------- #
+# Small generic helpers
+# --------------------------------------------------------------------------- #
+
+
+def _read_delim(path: str, delim: Optional[str] = None) -> Tuple[List[str], List[List[str]]]:
+    """Read a delimited file; returns (header, rows).
+
+    When ``delim`` is given it is used verbatim (callers that KNOW the format —
+    e.g. an always-CSV cross-modal table — should pass it so a header that
+    happens to contain the other separator can't flip the auto-detection). When
+    omitted, tab vs comma is detected from the WHOLE file (max count wins),
+    which is more robust than sampling only the first line.
+    """
+    if not path or not os.path.isfile(path):
+        return [], []
+    with open(path, newline="", encoding="utf-8", errors="replace") as fh:
+        text = fh.read()
+    if delim is None:
+        delim = "\t" if text.count("\t") >= text.count(",") else ","
+    reader = csv.reader(text.splitlines(), delimiter=delim)
+    rows = [r for r in reader if any(c.strip() for c in r)]
+    if not rows:
+        return [], []
+    return rows[0], rows[1:]
+
+
+def _safe_float(value) -> Optional[float]:
+    try:
+        return float(str(value).strip())
+    except (TypeError, ValueError):
+        return None
+
+
+def _fmt_num(value, ndigits: int = 1) -> str:
+    f = value if isinstance(value, (int, float)) else _safe_float(value)
+    if f is None:
+        return str(value) if value not in (None, "") else ""
+    # NaN/Inf would crash int(f) (ValueError/OverflowError) and abort the whole
+    # aggregation; pass them through verbatim instead. fslstats -M over an empty
+    # region returns "nan" on some FSL builds, so this WILL be hit in practice.
+    if f != f or f in (float("inf"), float("-inf")):
+        return str(value)
+    if f == int(f):
+        return str(int(f))
+    return f"{f:.{ndigits}f}"
+
+
+def _first_existing(*candidates: str) -> Optional[str]:
+    for c in candidates:
+        if c and os.path.isfile(c):
+            return c
+    return None
+
+
+def _glob_sorted(pattern: str) -> List[str]:
+    return sorted(glob.glob(pattern))
+
+
+def _parse_kv_summary(path: str) -> Dict[str, str]:
+    """Parse a ``key=value`` summary file (the WMH-tool convention)."""
+    out: Dict[str, str] = {}
+    if not path or not os.path.isfile(path):
+        return out
+    with open(path, encoding="utf-8", errors="replace") as fh:
+        for line in fh:
+            line = line.strip()
+            if not line or line.startswith("#") or "=" not in line:
+                continue
+            key, _, val = line.partition("=")
+            out[key.strip()] = val.strip()
+    return out
+
+
+# --------------------------------------------------------------------------- #
+# Table container + writers
+# --------------------------------------------------------------------------- #
+
+
+class Table:
+    """An ordered table: title, columns, rows. Knows how to render TSV + HTML."""
+
+    def __init__(self, key: str, title: str, columns: Sequence[str]):
+        self.key = key
+        self.title = title
+        self.columns = list(columns)
+        self.rows: List[List[str]] = []
+
+    def add(self, row: Sequence) -> None:
+        self.rows.append(["" if c is None else str(c) for c in row])
+
+    @property
+    def populated(self) -> bool:
+        return len(self.rows) > 0
+
+    def write_tsv(self, path: str) -> None:
+        with open(path, "w", newline="", encoding="utf-8") as fh:
+            writer = csv.writer(fh, delimiter="\t")
+            writer.writerow(self.columns)
+            writer.writerows(self.rows)
+
+    def html_fragment(self) -> str:
+        parts = [f"<h2 id='{html.escape(self.key)}'>{html.escape(self.title)}</h2>"]
+        if not self.populated:
+            parts.append(
+                "<p class='absent'>No data for this section "
+                "(inputs absent for this run).</p>"
+            )
+            return "\n".join(parts)
+        parts.append("<table>")
+        parts.append(
+            "<thead><tr>"
+            + "".join(f"<th>{html.escape(c)}</th>" for c in self.columns)
+            + "</tr></thead>"
+        )
+        parts.append("<tbody>")
+        for row in self.rows:
+            parts.append(
+                "<tr>"
+                + "".join(f"<td>{html.escape(str(c))}</td>" for c in row)
+                + "</tr>"
+            )
+        parts.append("</tbody></table>")
+        return "\n".join(parts)
+
+    def write_html(self, path: str) -> None:
+        with open(path, "w", encoding="utf-8") as fh:
+            fh.write(self.html_fragment() + "\n")
+
+
+# --------------------------------------------------------------------------- #
+# Section builders - each returns a Table (possibly empty) and is fully gated.
+# --------------------------------------------------------------------------- #
+
+
+def _find_per_region_dir(results_dir: str) -> Optional[str]:
+    for cand in (
+        os.path.join(results_dir, "per_region_analysis"),
+        os.path.join(results_dir, "analysis", "per_region"),
+    ):
+        if os.path.isdir(cand):
+            return cand
+    return None
+
+
+def _load_region_stats_sidecar(path: str) -> Dict[str, Dict[str, str]]:
+    """region_tag -> {volume_mm3, n_voxels, cluster_count, mean_z, peak_z}."""
+    header, rows = _read_delim(path)
+    if not rows:
+        return {}
+    idx = {name: i for i, name in enumerate(header)}
+    out: Dict[str, Dict[str, str]] = {}
+    for r in rows:
+        if "region_tag" not in idx:
+            continue
+        tag = r[idx["region_tag"]] if idx["region_tag"] < len(r) else ""
+        if not tag:
+            continue
+        out[tag] = {
+            k: (r[idx[k]] if k in idx and idx[k] < len(r) else "")
+            for k in ("volume_mm3", "n_voxels", "cluster_count", "mean_z", "peak_z")
+        }
+    return out
+
+
+def build_hyperintensity_per_region(results_dir: str) -> Table:
+    """Hyperintensity per region x per source.
+
+    Columns: region, source, cluster_count, volume_mm3, mean_z, peak_z.
+
+    The per-region GMM (analysis.sh apply_per_region_gmm_analysis) writes a
+    provenance manifest (region_provenance.tsv: region_tag/region_base/source/
+    mask_path) and one ``*_<source>_<region>_GMM.nii.gz`` per analysed region.
+    A numeric sidecar (region_stats.tsv, built by the bash layer with fslstats
+    over each region output) supplies the numeric columns keyed by region_tag.
+    """
+    table = Table(
+        "hyperintensity_per_region",
+        "Hyperintensity detection per region x source (per-region GMM)",
+        ["region", "source", "cluster_count", "volume_mm3", "mean_z", "peak_z"],
+    )
+    prdir = _find_per_region_dir(results_dir)
+    if not prdir:
+        return table
+    prov = os.path.join(prdir, "region_provenance.tsv")
+    header, rows = _read_delim(prov)
+    if not rows:
+        return table
+    idx = {name: i for i, name in enumerate(header)}
+    stats = _load_region_stats_sidecar(os.path.join(prdir, "region_stats.tsv"))
+    out_rows = []
+    for r in rows:
+
+        def cell(col: str, row=r) -> str:
+            return row[idx[col]] if col in idx and idx[col] < len(row) else ""
+
+        tag = cell("region_tag")
+        st = stats.get(tag, {})
+        out_rows.append(
+            [
+                cell("region_base"),
+                cell("source"),
+                st.get("cluster_count", ""),
+                _fmt_num(st.get("volume_mm3", "")),
+                _fmt_num(st.get("mean_z", ""), 2),
+                _fmt_num(st.get("peak_z", ""), 2),
+            ]
+        )
+    for row in sorted(out_rows, key=lambda x: (x[1], x[0])):
+        table.add(row)
+    return table
+
+
+# WMH tools and where each one's per-tool summary lands (relative to the WMH
+# root under analysis/wmh). Each tool writes a key=value summary file.
+_WMH_TOOLS = [
+    ("BIANCA", "bianca", "bianca_wmh_summary.txt"),
+    ("LST-AI", "lst_samseg/lst_ai", "lstai_wmh_summary.txt"),
+    ("SAMSEG", "lst_samseg/samseg", "samseg_wmh_summary.txt"),
+    ("WMH-SynthSeg", "synthseg", "wmh_synthseg_wmh_summary.txt"),
+    ("segcsvd", "segcsvd", "segcsvd_wmh_summary.txt"),
+    ("SHIVA", "shiva", "shiva_wmh_summary.txt"),
+    ("MARS", "mars", "mars_wmh_summary.txt"),
+]
+
+
+def build_wmh_tool_volumes(results_dir: str) -> Table:
+    """One row per WMH tool that actually ran (summary file present)."""
+    table = Table(
+        "wmh_tool_volumes",
+        "WMH-tool volumes (one row per enabled tool)",
+        [
+            "tool",
+            "total_wmh_mm3",
+            "total_clusters",
+            "brainstem_wmh_mm3",
+            "brainstem_clusters",
+        ],
+    )
+    wmh_root = os.path.join(results_dir, "analysis", "wmh")
+    for name, subdir, fname in _WMH_TOOLS:
+        cand = os.path.join(wmh_root, subdir, fname)
+        summary = cand if os.path.isfile(cand) else None
+        if not summary:
+            matches = _glob_sorted(os.path.join(wmh_root, subdir, "*_summary.txt"))
+            summary = matches[0] if matches else None
+        if not summary:
+            continue
+        kv = _parse_kv_summary(summary)
+        total = kv.get("whole_brain_wmh_mm3") or kv.get("whole_brain_wmh_volume", "")
+        bs = kv.get("brainstem_wmh_mm3", "")
+        table.add(
+            [
+                name,
+                _fmt_num(total),
+                kv.get("whole_brain_wmh_clusters", ""),
+                _fmt_num(bs),
+                kv.get("brainstem_wmh_clusters", ""),
+            ]
+        )
+    return table
+
+
+def build_segmentation_volumes(results_dir: str, seg_volumes_tsv: str) -> Table:
+    """Segmentation / subregion volumes from a precomputed sidecar.
+
+    The bash layer discovers every mask (HO gross, FS substructures, multi-atlas
+    nuclei, SynthSeg/aseg, thalamic/hypothalamic) and runs ``fslstats -V`` to
+    build a ``region\tsource\tvolume_mm3\tn_voxels`` sidecar; we render it sorted
+    by source then region. Keeping fslstats in bash respects the repo convention
+    (safe_fslmaths / no nibabel dependency here).
+    """
+    table = Table(
+        "segmentation_volumes",
+        "Segmentation / subregion volumes",
+        ["region", "source", "volume_mm3", "n_voxels"],
+    )
+    header, rows = _read_delim(seg_volumes_tsv)
+    if not rows:
+        return table
+    idx = {name: i for i, name in enumerate(header)}
+    if not all(k in idx for k in ("region", "source")):
+        return table
+    out_rows = []
+    for r in rows:
+        out_rows.append(
+            [
+                (r[idx["region"]] if idx["region"] < len(r) else ""),
+                (r[idx["source"]] if idx["source"] < len(r) else ""),
+                _fmt_num(r[idx["volume_mm3"]])
+                if "volume_mm3" in idx and idx["volume_mm3"] < len(r)
+                else "",
+                (r[idx["n_voxels"]] if "n_voxels" in idx and idx["n_voxels"] < len(r) else ""),
+            ]
+        )
+    for row in sorted(out_rows, key=lambda x: (x[1], x[0])):
+        table.add(row)
+    return table
+
+
+def build_cross_modal(results_dir: str, subdir: str) -> Table:
+    """Per-cluster cross-modal corroboration table (passthrough of the CSV)."""
+    cm_csv = _first_existing(
+        os.path.join(results_dir, "analysis", subdir, "cross_modal_clusters.csv"),
+        os.path.join(results_dir, "analysis", "cross_modal", "cross_modal_clusters.csv"),
+    )
+    # The cross-modal table is ALWAYS comma-delimited (cross_modal_sample.py /
+    # the bash stub use csv.DictWriter), so force the delimiter rather than
+    # auto-detecting (a header with a stray tab must not flip detection).
+    header, rows = _read_delim(cm_csv, delim=",") if cm_csv else ([], [])
+    title = "Cross-modal per-cluster corroboration (DWI / SWI / T2)"
+    if not header:
+        return Table(
+            "cross_modal",
+            title,
+            ["cluster_id", "n_voxels", "flair_z", "corroboration", "n_corroborating"],
+        )
+    table = Table("cross_modal", title, header)
+    for r in rows:
+        table.add(r)
+    return table
+
+
+# FreeSurfer aseg structures of primary interest for a brainstem study, plus
+# eTIV/BrainSeg measures (these appear as ``# Measure`` rows in aseg.stats).
+_ASEG_KEEP = re.compile(
+    r"(Brain-Stem|Cerebellum|Thalamus|VentralDC|4th-Ventricle|"
+    r"Lateral-Ventricle|CSF|Hippocampus|Amygdala)",
+    re.IGNORECASE,
+)
+_ASEG_MEASURES = (
+    "EstimatedTotalIntraCranialVol",
+    "BrainSegVol",
+    "TotalGrayVol",
+    "SupraTentorialVol",
+    "CerebralWhiteMatterVol",
+)
+
+
+def build_freesurfer_morphometry(results_dir: str) -> Table:
+    """aseg volumes + eTIV from the FreeSurfer harvest stats."""
+    table = Table(
+        "freesurfer_morphometry",
+        "FreeSurfer morphometry (aseg volumes + eTIV)",
+        ["structure", "volume_mm3"],
+    )
+    stats_dir = os.path.join(results_dir, "freesurfer", "harvest", "stats")
+    aseg_stats = _first_existing(
+        os.path.join(stats_dir, "aseg.stats"),
+        os.path.join(results_dir, "segmentation", "freesurfer", "stats", "aseg.stats"),
+    )
+    measures: List[Tuple[str, str]] = []
+    structures: List[Tuple[str, str]] = []
+    if aseg_stats:
+        with open(aseg_stats, encoding="utf-8", errors="replace") as fh:
+            for line in fh:
+                line = line.rstrip("\n")
+                if line.startswith("# Measure"):
+                    # "# Measure EstimatedTotalIntraCranialVol, eTIV, ..., 1.5e6, mm^3"
+                    # The unit column is optional across FS versions, so locate the
+                    # numeric value by scanning from the right rather than assuming
+                    # a fixed -2 position (a short line would otherwise emit the
+                    # free-text description as the "volume").
+                    body = line[len("# Measure"):].strip()
+                    fields = [f.strip() for f in body.split(",")]
+                    if len(fields) >= 4 and fields[0] in _ASEG_MEASURES:
+                        val = next(
+                            (f for f in reversed(fields) if _safe_float(f) is not None),
+                            "",
+                        )
+                        if val:
+                            measures.append((fields[0], val))
+                elif not line.startswith("#") and line.strip():
+                    cols = line.split()
+                    # aseg.stats data: Index SegId NVoxels Volume_mm3 StructName ...
+                    if len(cols) >= 5 and _ASEG_KEEP.search(cols[4]):
+                        structures.append((cols[4], cols[3]))
+    # If raw aseg.stats absent, fall back to the harvested aseg_volumes.tsv.
+    if not structures and not measures:
+        header, rows = _read_delim(os.path.join(stats_dir, "aseg_volumes.tsv"))
+        if rows:
+            # asegstats2table is wide (one row, many structure columns). Emit the
+            # brainstem-relevant columns we recognise.
+            for name in header[1:]:
+                if _ASEG_KEEP.search(name) or name in _ASEG_MEASURES:
+                    col = header.index(name)
+                    val = rows[0][col] if col < len(rows[0]) else ""
+                    if name in _ASEG_MEASURES:
+                        measures.append((name, val))
+                    else:
+                        structures.append((name, val))
+    for name, val in measures:
+        table.add([name, _fmt_num(val)])
+    for name, val in sorted(structures):
+        table.add([name, _fmt_num(val)])
+    return table
+
+
+def _present(flag: bool) -> str:
+    return "present" if flag else "absent"
+
+
+def build_run_manifest(
+    results_dir: str, subject_id: str, populated: Dict[str, bool]
+) -> Table:
+    """Which segmentation paths, WMH tools, modalities, and tables ran."""
+    table = Table(
+        "run_manifest",
+        "Run manifest (provenance: what actually ran)",
+        ["item", "status", "detail"],
+    )
+    table.add(["subject_id", "info", subject_id or "(unknown)"])
+
+    seg = os.path.join(results_dir, "segmentation")
+    table.add([
+        "segmentation: HO gross",
+        _present(os.path.isdir(os.path.join(seg, "brainstem"))),
+        "segmentation/brainstem",
+    ])
+    detailed = os.path.join(seg, "detailed_brainstem")
+    has_fs = bool(_glob_sorted(os.path.join(detailed, "*_pons.nii.gz")))
+    has_bianciardi = bool(_glob_sorted(os.path.join(detailed, "bianciardi_*.nii.gz")))
+    has_cit168 = bool(_glob_sorted(os.path.join(detailed, "cit168_*.nii.gz")))
+    has_aal3 = bool(_glob_sorted(os.path.join(detailed, "aal3_*.nii.gz")))
+    table.add(["segmentation: FS substructures", _present(has_fs), "detailed_brainstem (FS parcels)"])
+    table.add(["segmentation: Bianciardi nuclei", _present(has_bianciardi), "detailed_brainstem (bianciardi_*)"])
+    table.add(["segmentation: CIT168 nuclei", _present(has_cit168), "detailed_brainstem (cit168_*)"])
+    table.add(["segmentation: AAL3", _present(has_aal3), "detailed_brainstem (aal3_*)"])
+
+    fs_harvest = os.path.join(results_dir, "freesurfer", "harvest")
+    table.add([
+        "FreeSurfer recon harvest",
+        _present(os.path.isdir(fs_harvest)),
+        "freesurfer/harvest",
+    ])
+
+    wmh_root = os.path.join(results_dir, "analysis", "wmh")
+    for name, subdir, fname in _WMH_TOOLS:
+        cand = os.path.join(wmh_root, subdir, fname)
+        ran = os.path.isfile(cand) or bool(
+            _glob_sorted(os.path.join(wmh_root, subdir, "*_summary.txt"))
+        )
+        table.add([f"WMH tool: {name}", _present(ran), f"analysis/wmh/{subdir}"])
+
+    cm = os.path.join(results_dir, "registered", "contrast_matched")
+    for mod, kw in (("T2", "*T2*"), ("SWI", "*SWI*"), ("DWI", "*DWI*"), ("ADC", "*ADC*")):
+        ran = bool(_glob_sorted(os.path.join(cm, f"{kw}_to_*Warped.nii.gz")))
+        table.add([f"modality: {mod}", _present(ran), "registered/contrast_matched"])
+
+    for key, ok in populated.items():
+        table.add([f"table: {key}", _present(ok), "reports/tables"])
+    return table
+
+
+# --------------------------------------------------------------------------- #
+# Top-level HTML / Markdown report
+# --------------------------------------------------------------------------- #
+
+_CSS = """
+body { font-family: Arial, Helvetica, sans-serif; line-height: 1.5; margin: 0;
+       padding: 24px; color: #222; }
+h1 { color: #1a3c5e; border-bottom: 3px solid #2980b9; padding-bottom: 8px; }
+h2 { color: #2471a3; margin-top: 36px; }
+table { border-collapse: collapse; margin: 12px 0 28px; width: auto; }
+th, td { border: 1px solid #ccc; padding: 6px 12px; text-align: left;
+         font-size: 14px; }
+th { background: #eef4fa; }
+tr:nth-child(even) td { background: #f7f9fb; }
+.absent { color: #888; font-style: italic; }
+.toc a { margin-right: 16px; }
+.meta { color: #555; font-size: 13px; }
+.viz img { max-width: 460px; border: 1px solid #ddd; margin: 8px; }
+.viz figure { display: inline-block; margin: 8px; text-align: center; }
+.viz figcaption { font-size: 12px; color: #555; }
+"""
+
+
+def _discover_visualizations(results_dir: str) -> List[Tuple[str, str]]:
+    """Return (relpath_from_reports, caption) for embeddable PNGs."""
+    reports_dir = os.path.join(results_dir, "reports")
+    out: List[Tuple[str, str]] = []
+    seen = set()
+
+    def _add_from(d: str, limit: Optional[int] = None) -> None:
+        pngs = _glob_sorted(os.path.join(d, "*.png"))
+        if limit is not None:
+            pngs = pngs[:limit]
+        for png in pngs:
+            if png in seen:
+                continue
+            seen.add(png)
+            try:
+                rel = os.path.relpath(png, reports_dir)
+            except ValueError:
+                # Different drive/mount (Windows shares) -> relpath raises; fall
+                # back to the absolute path so the link still resolves and the
+                # report write never aborts.
+                rel = png
+            cap = os.path.splitext(os.path.basename(png))[0].replace("_", " ")
+            out.append((rel, cap))
+
+    _add_from(os.path.join(results_dir, "visualizations"))
+    # Surface a handful of legacy QC PNGs so a minimal run still shows something.
+    _add_from(os.path.join(results_dir, "qc_visualizations"), limit=6)
+    _add_from(os.path.join(results_dir, "advanced_visualization"), limit=6)
+    return out
+
+
+def write_top_level_report(
+    results_dir: str,
+    subject_id: str,
+    tables: Sequence[Table],
+    html_path: str,
+    md_path: str,
+) -> None:
+    viz = _discover_visualizations(results_dir)
+    # ---- HTML ----
+    parts = [
+        "<!DOCTYPE html>",
+        "<html lang='en'><head><meta charset='UTF-8'>",
+        "<meta name='viewport' content='width=device-width, initial-scale=1.0'>",
+        f"<title>BrainStemX report - {html.escape(subject_id)}</title>",
+        f"<style>{_CSS}</style></head><body>",
+        "<h1>BrainStemX-Full results report</h1>",
+        f"<p class='meta'>Subject: <b>{html.escape(subject_id)}</b> "
+        f"&middot; Results: {html.escape(results_dir)}</p>",
+        "<p class='toc'>"
+        + " ".join(
+            f"<a href='#{html.escape(t.key)}'>{html.escape(t.title.split(' (')[0])}</a>"
+            for t in tables
+        )
+        + "</p>",
+    ]
+    for t in tables:
+        parts.append(t.html_fragment())
+    if viz:
+        parts.append("<h2 id='visualizations'>Visualizations</h2>")
+        parts.append("<div class='viz'>")
+        for rel, cap in viz:
+            parts.append(
+                f"<figure><img src='{html.escape(rel)}' alt='{html.escape(cap)}'>"
+                f"<figcaption>{html.escape(cap)}</figcaption></figure>"
+            )
+        parts.append("</div>")
+    parts.append("</body></html>")
+    with open(html_path, "w", encoding="utf-8") as fh:
+        fh.write("\n".join(parts) + "\n")
+
+    # ---- Markdown fallback ----
+    md = ["# BrainStemX-Full results report", "", f"Subject: **{subject_id}**", ""]
+    for t in tables:
+        md.append(f"## {t.title}")
+        md.append("")
+        if not t.populated:
+            md.append("_No data for this section (inputs absent for this run)._")
+            md.append("")
+            continue
+        md.append("| " + " | ".join(t.columns) + " |")
+        md.append("| " + " | ".join("---" for _ in t.columns) + " |")
+        for row in t.rows:
+            md.append("| " + " | ".join(str(c) for c in row) + " |")
+        md.append("")
+    if viz:
+        md.append("## Visualizations")
+        md.append("")
+        for rel, cap in viz:
+            md.append(f"- {cap}: `{rel}`")
+        md.append("")
+    with open(md_path, "w", encoding="utf-8") as fh:
+        fh.write("\n".join(md) + "\n")
+
+
+# --------------------------------------------------------------------------- #
+# Main
+# --------------------------------------------------------------------------- #
+
+
+def main(argv: Optional[Sequence[str]] = None) -> int:
+    ap = argparse.ArgumentParser(description="Aggregate BrainStemX results.")
+    ap.add_argument("--results-dir", required=True)
+    ap.add_argument("--out-dir", required=True)
+    ap.add_argument("--subject-id", default="")
+    ap.add_argument("--seg-volumes", default="", help="segmentation volume sidecar TSV")
+    ap.add_argument("--cross-modal-subdir", default="cross_modal")
+    ap.add_argument(
+        "--report-html",
+        default="",
+        help="top-level HTML report path (default <results>/reports/brainstemx_report.html)",
+    )
+    ap.add_argument("--report-md", default="")
+    args = ap.parse_args(argv)
+
+    os.makedirs(args.out_dir, exist_ok=True)
+
+    tables = [
+        build_hyperintensity_per_region(args.results_dir),
+        build_wmh_tool_volumes(args.results_dir),
+        build_segmentation_volumes(args.results_dir, args.seg_volumes),
+        build_cross_modal(args.results_dir, args.cross_modal_subdir),
+        build_freesurfer_morphometry(args.results_dir),
+    ]
+    populated = {t.key: t.populated for t in tables}
+    manifest = build_run_manifest(args.results_dir, args.subject_id, populated)
+    tables.append(manifest)
+
+    for t in tables:
+        t.write_tsv(os.path.join(args.out_dir, f"{t.key}.tsv"))
+        t.write_html(os.path.join(args.out_dir, f"{t.key}.html"))
+
+    with open(os.path.join(args.out_dir, "manifest.json"), "w", encoding="utf-8") as fh:
+        json.dump(
+            {
+                "subject_id": args.subject_id,
+                "results_dir": args.results_dir,
+                "sections": {t.key: t.populated for t in tables},
+            },
+            fh,
+            indent=2,
+        )
+
+    reports_dir = os.path.join(args.results_dir, "reports")
+    os.makedirs(reports_dir, exist_ok=True)
+    html_path = args.report_html or os.path.join(reports_dir, "brainstemx_report.html")
+    md_path = args.report_md or os.path.join(reports_dir, "brainstemx_report.md")
+    write_top_level_report(args.results_dir, args.subject_id, tables, html_path, md_path)
+
+    n_pop = sum(1 for t in tables if t.populated)
+    print(f"reporting_tables: wrote {len(tables)} tables ({n_pop} populated)")
+    print(f"reporting_tables: report_html={html_path}")
+    print(f"reporting_tables: report_md={md_path}")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/src/modules/visualization.sh
+++ b/src/modules/visualization.sh
@@ -628,10 +628,234 @@ generate_html_report() {
     return 0
 }
 
+# ---------------------------------------------------------------------------
+# _viz_find_base_image <modality> <subject_dir>
+#   Find a representative base image for overlays. Prefers a registered/common
+#   space volume, then standardized, then brain-extracted, then bias-corrected.
+#   Echoes path or empty.
+# ---------------------------------------------------------------------------
+_viz_find_base_image() {
+    local modality="$1"
+    local subject_dir="$2"
+    local f=""
+    if [ "$modality" = "FLAIR" ] && [ -f "${subject_dir}/registered/t1_to_flairWarped.nii.gz" ]; then
+        f="${subject_dir}/registered/t1_to_flairWarped.nii.gz"
+    fi
+    if [ -z "$f" ] && [ -d "${subject_dir}/standardized" ]; then
+        f=$(find "${subject_dir}/standardized" -iname "*${modality}*_std.nii.gz" ! -iname "*intensity*" 2>/dev/null | head -1)
+    fi
+    if [ -z "$f" ] && [ -d "${subject_dir}/brain_extraction" ]; then
+        f=$(find "${subject_dir}/brain_extraction" -iname "*${modality}*brain.nii.gz" 2>/dev/null | head -1)
+    fi
+    if [ -z "$f" ] && [ -d "${subject_dir}/bias_corrected" ]; then
+        f=$(find "${subject_dir}/bias_corrected" -iname "*${modality}*.nii.gz" ! -iname "*Mask*" 2>/dev/null | head -1)
+    fi
+    echo "$f"
+}
+
+# ---------------------------------------------------------------------------
+# _viz_snapshot <base> <overlay> <out_png> [cmap]
+#   Resample the overlay onto the base grid if dims differ, then write a
+#   tri-planar PNG via FSL slicer. GRACEFUL: returns non-zero (no crash) on any
+#   failure (e.g. slicer absent).
+# ---------------------------------------------------------------------------
+_viz_snapshot() {
+    local base="$1" overlay="$2" out_png="$3" cmap="${4:-red}"
+    [ -n "$base" ] && [ -f "$base" ] || return 1
+    command -v slicer >/dev/null 2>&1 || return 1
+    if [ -n "$overlay" ] && [ -f "$overlay" ]; then
+        local ov="$overlay"
+        if command -v fslval >/dev/null 2>&1; then
+            local bd od
+            bd=$(fslval "$base" dim1 2>/dev/null)
+            od=$(fslval "$overlay" dim1 2>/dev/null)
+            if [ -n "$bd" ] && [ -n "$od" ] && [ "$bd" != "$od" ] && command -v flirt >/dev/null 2>&1; then
+                ov="${out_png%.png}_ov_resampled.nii.gz"
+                flirt -in "$overlay" -ref "$base" -out "$ov" -applyxfm -usesqform -interp nearestneighbour >/dev/null 2>&1 || ov="$overlay"
+            fi
+        fi
+        local ov_bin="${out_png%.png}_ov_bin.nii.gz"
+        fslmaths "$ov" -bin "$ov_bin" >/dev/null 2>&1 || cp "$ov" "$ov_bin"
+        slicer "$base" "$ov_bin" -a "$out_png" >/dev/null 2>&1 || { rm -f "$ov_bin" 2>/dev/null; return 1; }
+        rm -f "$ov_bin" 2>/dev/null
+        [ "$ov" != "$overlay" ] && rm -f "$ov" 2>/dev/null
+    else
+        slicer "$base" -a "$out_png" >/dev/null 2>&1 || return 1
+    fi
+    [ -f "$out_png" ]
+}
+
+# ---------------------------------------------------------------------------
+# generate_segmentation_overlays <subject_id> <subject_dir>
+#   Per-method segmentation overlays on T1: HO gross brainstem + one
+#   representative overlay per detailed_brainstem source (FS substructures,
+#   multi-atlas nuclei). Writes PNGs to visualizations/. GRACEFUL: skips any
+#   source whose masks are absent.
+# ---------------------------------------------------------------------------
+generate_segmentation_overlays() {
+    local subject_id="$1"
+    local subject_dir="$2"
+    local viz_dir="${subject_dir}/visualizations"
+    mkdir -p "$viz_dir"
+
+    local t1
+    t1=$(_viz_find_base_image "T1" "$subject_dir")
+    if [ -z "$t1" ] || [ ! -f "$t1" ]; then
+        log_message "Viz: no T1 base image found - skipping segmentation overlays"
+        return 0
+    fi
+
+    local ho
+    ho=$(find "${subject_dir}/segmentation/brainstem" -name "*_brainstem.nii.gz" 2>/dev/null | head -1)
+    if [ -n "$ho" ] && [ -f "$ho" ]; then
+        _viz_snapshot "$t1" "$ho" "${viz_dir}/seg_harvard_oxford_brainstem.png" && \
+            log_message "Viz: seg overlay (HO gross brainstem)"
+    fi
+
+    local detailed="${subject_dir}/segmentation/detailed_brainstem"
+    if [ -d "$detailed" ]; then
+        local src f
+        for src in freesurfer bianciardi cit168 aal3; do
+            f=""
+            case "$src" in
+                freesurfer) f=$(find "$detailed" -name "*_pons.nii.gz" ! -name "bianciardi_*" ! -name "cit168_*" ! -name "aal3_*" 2>/dev/null | head -1) ;;
+                *)          f=$(find "$detailed" -name "${src}_*.nii.gz" ! -name "*intensity*" 2>/dev/null | head -1) ;;
+            esac
+            if [ -n "$f" ] && [ -f "$f" ]; then
+                _viz_snapshot "$t1" "$f" "${viz_dir}/seg_${src}.png" && \
+                    log_message "Viz: seg overlay (${src})"
+            fi
+        done
+    fi
+    return 0
+}
+
+# ---------------------------------------------------------------------------
+# generate_hyperintensity_overlays <subject_id> <subject_dir> [mask]
+#   Hyperintensity cluster overlay on FLAIR. Uses the supplied lesion mask or
+#   discovers the primary engine's mask. Writes a PNG to visualizations/.
+# ---------------------------------------------------------------------------
+generate_hyperintensity_overlays() {
+    local subject_id="$1"
+    local subject_dir="$2"
+    local mask="${3:-}"
+    local viz_dir="${subject_dir}/visualizations"
+    mkdir -p "$viz_dir"
+
+    local flair
+    flair=$(_viz_find_base_image "FLAIR" "$subject_dir")
+    if [ -z "$flair" ] || [ ! -f "$flair" ]; then
+        log_message "Viz: no FLAIR base image - skipping hyperintensity overlay"
+        return 0
+    fi
+
+    if [ -z "$mask" ] || [ ! -f "$mask" ]; then
+        mask=$(find "${subject_dir}/hyperintensities" -name "*_threshATLAS_GMM_bin_fpfiltered.nii.gz" 2>/dev/null | head -1)
+        [ -z "$mask" ] && mask=$(find "${subject_dir}/hyperintensities" -name "*_threshATLAS_GMM_bin.nii.gz" 2>/dev/null | head -1)
+        [ -z "$mask" ] && mask=$(find "${subject_dir}/hyperintensities" -name "*_bin.nii.gz" 2>/dev/null | head -1)
+    fi
+
+    if [ -n "$mask" ] && [ -f "$mask" ]; then
+        _viz_snapshot "$flair" "$mask" "${viz_dir}/hyperintensities_on_flair.png" && \
+            log_message "Viz: hyperintensity clusters on FLAIR"
+    else
+        log_message "Viz: no hyperintensity mask found - skipping FLAIR overlay"
+    fi
+    return 0
+}
+
+# ---------------------------------------------------------------------------
+# generate_multimodal_montage <subject_id> <subject_dir> [lesion_mask]
+#   Multi-modal montage: the lesion mask overlaid on FLAIR/DWI/SWI/T2 (each
+#   co-registered modality that is present). Writes one PNG per available
+#   modality plus the FLAIR reference. GRACEFUL: skips absent modalities.
+# ---------------------------------------------------------------------------
+generate_multimodal_montage() {
+    local subject_id="$1"
+    local subject_dir="$2"
+    local mask="${3:-}"
+    local viz_dir="${subject_dir}/visualizations"
+    mkdir -p "$viz_dir"
+
+    if [ -z "$mask" ] || [ ! -f "$mask" ]; then
+        mask=$(find "${subject_dir}/hyperintensities" -name "*_threshATLAS_GMM_bin*.nii.gz" 2>/dev/null | head -1)
+    fi
+
+    local cm_dir="${subject_dir}/registered/${CONTRAST_MATCHED_SUBDIR:-contrast_matched}"
+    local produced=0
+    local flair
+    flair=$(_viz_find_base_image "FLAIR" "$subject_dir")
+    if [ -n "$flair" ] && [ -f "$flair" ]; then
+        _viz_snapshot "$flair" "$mask" "${viz_dir}/montage_FLAIR.png" && produced=$((produced + 1))
+    fi
+
+    if [ -d "$cm_dir" ]; then
+        local reg_dir="${subject_dir}/registered"
+        local mod found
+        for mod in DWI SWI T2; do
+            found=""
+            # Prefer the canonical cross-modal discovery helper so the montage
+            # uses the SAME modality keyword families (DWI trace/b1000, SWI/SWAN/
+            # venobold, etc.) and ADC exclusion as cross_modal_analysis.sh — a
+            # literal *DWI*/*SWI* glob would miss trace/SWAN-named volumes that
+            # the cross-modal table nonetheless uses.
+            if declare -f _cross_modal_find_coregistered >/dev/null 2>&1; then
+                found=$(_cross_modal_find_coregistered "$mod" "$reg_dir" 2>/dev/null || true)
+            fi
+            # Fallback glob (when the cross-modal module is not loaded).
+            if [ -z "$found" ]; then
+                found=$(find "$cm_dir" -maxdepth 1 -iname "*${mod}*_to_flairWarped.nii.gz" ! -iname "*FLAIR*to_flair*" 2>/dev/null | head -1)
+                [ -z "$found" ] && found=$(find "$cm_dir" -maxdepth 1 -iname "*${mod}*Warped.nii.gz" ! -iname "*FLAIR*" 2>/dev/null | head -1)
+            fi
+            if [ -n "$found" ] && [ -f "$found" ]; then
+                _viz_snapshot "$found" "$mask" "${viz_dir}/montage_${mod}.png" && {
+                    produced=$((produced + 1))
+                    log_message "Viz: montage panel (${mod})"
+                }
+            fi
+        done
+    fi
+    log_message "Viz: multi-modal montage panels produced=$produced"
+    return 0
+}
+
+# ---------------------------------------------------------------------------
+# generate_report_visualizations <subject_id> <subject_dir> [lesion_mask]
+#   Convenience wrapper: build the full set of report visualizations into
+#   visualizations/. Each sub-step is independently gated/graceful.
+# ---------------------------------------------------------------------------
+generate_report_visualizations() {
+    local subject_id="$1"
+    local subject_dir="$2"
+    local mask="${3:-}"
+
+    if [ "${SKIP_VISUALIZATION:-false}" = "true" ]; then
+        log_message "Report visualizations skipped (SKIP_VISUALIZATION=true)"
+        return 0
+    fi
+
+    log_formatted "INFO" "===== REPORT VISUALIZATIONS ====="
+    mkdir -p "${subject_dir}/visualizations"
+    generate_segmentation_overlays "$subject_id" "$subject_dir" || \
+        log_formatted "WARNING" "Viz: segmentation overlays reported a non-fatal failure"
+    generate_hyperintensity_overlays "$subject_id" "$subject_dir" "$mask" || \
+        log_formatted "WARNING" "Viz: hyperintensity overlay reported a non-fatal failure"
+    generate_multimodal_montage "$subject_id" "$subject_dir" "$mask" || \
+        log_formatted "WARNING" "Viz: multi-modal montage reported a non-fatal failure"
+    log_message "Report visualizations written to: ${subject_dir}/visualizations"
+    return 0
+}
+
 # Export functions
 export -f generate_qc_visualizations
 export -f create_multi_threshold_overlays
 export -f generate_html_report
+export -f _viz_find_base_image
+export -f _viz_snapshot
+export -f generate_segmentation_overlays
+export -f generate_hyperintensity_overlays
+export -f generate_multimodal_montage
+export -f generate_report_visualizations
 
 # Function to launch visual QA in freeview without blocking pipeline execution
 launch_visual_qa() {

--- a/src/pipeline.sh
+++ b/src/pipeline.sh
@@ -99,6 +99,7 @@ source "${PIPELINE_DIR}/modules/multi_atlas.sh"
 source "${PIPELINE_DIR}/modules/segmentation_transformation_extraction.sh"
 source "${PIPELINE_DIR}/modules/analysis.sh"
 source "${PIPELINE_DIR}/modules/visualization.sh"
+source "${PIPELINE_DIR}/modules/reporting.sh"
 source "${PIPELINE_DIR}/modules/qa.sh"
 source "${PIPELINE_DIR}/modules/scan_selection.sh"
 source "${PIPELINE_DIR}/modules/reference_space_selection.sh"
@@ -1553,10 +1554,17 @@ run_pipeline() {
       log_message "  Pons mask: ${pons_mask:-'NOT FOUND'}"
       log_message "Skipping advanced visualization generation"
     fi
+    # Report visualizations (per-method segmentation overlays, hyperintensity
+    # clusters on FLAIR, multi-modal montage) written to visualizations/. Each
+    # sub-step is independently gated/graceful; the wrapper never aborts.
+    if declare -f generate_report_visualizations >/dev/null 2>&1; then
+      generate_report_visualizations "$subject_id" "$RESULTS_DIR" "${hyperintensity_mask:-}" || \
+        log_formatted "WARNING" "generate_report_visualizations reported a non-fatal failure"
+    fi
   else
     log_message 'Skipping Step 7.5 (Advanced Visualization) as requested'
   fi  # End of Advanced Visualization (Step 7.5)
-  
+
   # Step 8: Track pipeline progress
   if [ $START_STAGE -le 8 ]; then
     log_message "Step 8: Tracking pipeline progress"
@@ -1564,7 +1572,23 @@ run_pipeline() {
   else
     log_message 'Skipping Step 8 (Pipeline progress tracking) as requested'
   fi
-  
+
+  # Step 8.5: Reporting (aggregation + summary tables + top-level report).
+  # FINAL stage: discovers every artefact this run produced and aggregates it
+  # into CSV/TSV + HTML summary tables (reports/tables/) and a single top-level
+  # report (reports/brainstemx_report.html + .md). Fully gated/graceful and
+  # idempotent: a minimal T1+FLAIR run still produces a valid (smaller) report,
+  # absent sections are skipped, and re-running overwrites the same outputs.
+  if [ $START_STAGE -le 8 ]; then
+    if declare -f generate_summary_report >/dev/null 2>&1; then
+      log_message "Step 8.5: Reporting (summary tables + top-level report)"
+      generate_summary_report "$subject_id" "$RESULTS_DIR" || \
+        log_formatted "WARNING" "generate_summary_report reported a non-fatal failure"
+    fi
+  else
+    log_message 'Skipping Step 8.5 (Reporting) as requested'
+  fi
+
   log_message "Pipeline completed successfully for subject $subject_id"
   return 0
 }

--- a/tests/test_reporting_tables.py
+++ b/tests/test_reporting_tables.py
@@ -1,0 +1,288 @@
+#!/usr/bin/env python3
+"""Unit tests for reporting_tables.py (the summary-table aggregator).
+
+Builds a SYNTHETIC results dir with a couple of methods/modalities present and
+confirms the tables + top-level report render, and that absent sections are
+skipped cleanly. No FSL / nibabel / numpy required (the aggregator is stdlib
+only; volume numbers are supplied via the sidecars the bash layer would write).
+
+Run:
+    uv run pytest tests/test_reporting_tables.py -v
+    python3 tests/test_reporting_tables.py            # standalone
+"""
+
+import csv
+import json
+import os
+import sys
+
+import pytest
+
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), "..", "src", "modules"))
+
+import reporting_tables as rt  # noqa: E402
+
+
+# --------------------------------------------------------------------------- #
+# Synthetic results dir fixtures
+# --------------------------------------------------------------------------- #
+
+
+def _write(path, text):
+    os.makedirs(os.path.dirname(path), exist_ok=True)
+    with open(path, "w", encoding="utf-8") as fh:
+        fh.write(text)
+
+
+@pytest.fixture
+def full_results(tmp_path):
+    """A results dir with hyperintensity, WMH, seg, cross-modal, and FS inputs."""
+    r = str(tmp_path / "results")
+    # per-region GMM provenance + stats sidecar
+    _write(
+        os.path.join(r, "per_region_analysis", "region_provenance.tsv"),
+        "region_tag\tregion_base\tsource\tmask_path\n"
+        "freesurfer_pons\tpons\tfreesurfer\t/x/pons.nii.gz\n"
+        "bianciardi_LC\tLC\tbianciardi\t/x/lc.nii.gz\n",
+    )
+    _write(
+        os.path.join(r, "per_region_analysis", "region_stats.tsv"),
+        "region_tag\tvolume_mm3\tn_voxels\tcluster_count\tmean_z\tpeak_z\n"
+        "freesurfer_pons\t123.0\t123\t2\t1.81\t3.42\n"
+        "bianciardi_LC\t8.0\t8\t1\t2.10\t2.55\n",
+    )
+    # WMH tool summaries (BIANCA + SHIVA)
+    _write(
+        os.path.join(r, "analysis", "wmh", "bianca", "bianca_wmh_summary.txt"),
+        "tool=bianca\nwhole_brain_wmh_mm3=2500.0\n"
+        "whole_brain_wmh_clusters=12\nbrainstem_wmh_mm3=40.0\n"
+        "brainstem_wmh_clusters=2\n",
+    )
+    _write(
+        os.path.join(r, "analysis", "wmh", "shiva", "shiva_wmh_summary.txt"),
+        "tool=shiva_wmh\nwhole_brain_wmh_mm3=1800.5\n"
+        "whole_brain_wmh_clusters=30\nbrainstem_wmh_mm3=12.0\n"
+        "brainstem_wmh_clusters=1\n",
+    )
+    # cross-modal table
+    _write(
+        os.path.join(r, "analysis", "cross_modal", "cross_modal_clusters.csv"),
+        "cluster_id,n_voxels,cog_x,cog_y,cog_z,flair_mean,flair_z,"
+        "DWI_z,corroboration,n_corroborating\n"
+        "1,50,10,11,12,300,2.1,1.4,RESTRICTION,1\n"
+        "2,8,20,21,22,250,1.2,0.1,NONE,0\n",
+    )
+    # FreeSurfer aseg.stats with measures + a couple of structures
+    _write(
+        os.path.join(r, "freesurfer", "harvest", "stats", "aseg.stats"),
+        "# Measure EstimatedTotalIntraCranialVol, eTIV, "
+        "Estimated Total Intracranial Volume, 1500000.0, mm^3\n"
+        "# Measure BrainSegVol, BrainSegVol, Brain Segmentation Volume, "
+        "1200000.0, mm^3\n"
+        "# ColHeaders Index SegId NVoxels Volume_mm3 StructName\n"
+        "  1  16  18000  18000.0  Brain-Stem\n"
+        "  2  10   7000   7000.0  Left-Thalamus\n"
+        "  3   2  90000  90000.0  Left-Cerebral-White-Matter\n",
+    )
+    # segmentation masks (existence drives the run manifest)
+    os.makedirs(os.path.join(r, "segmentation", "brainstem"), exist_ok=True)
+    _write(os.path.join(r, "segmentation", "brainstem", "sub_brainstem.nii.gz"), "x")
+    _write(os.path.join(r, "segmentation", "detailed_brainstem", "sub_pons.nii.gz"), "x")
+    _write(
+        os.path.join(r, "segmentation", "detailed_brainstem", "bianciardi_LC_label5.nii.gz"),
+        "x",
+    )
+    # co-registered DWI (modality present in manifest)
+    _write(
+        os.path.join(r, "registered", "contrast_matched", "EPI_DWI_to_flairWarped.nii.gz"),
+        "x",
+    )
+    # segmentation volume sidecar (the bash layer would compute this via fslstats)
+    seg_sidecar = str(tmp_path / "seg_vol.tsv")
+    _write(
+        seg_sidecar,
+        "region\tsource\tvolume_mm3\tn_voxels\n"
+        "sub_brainstem\tharvard_oxford\t21000.0\t21000\n"
+        "pons\tfreesurfer\t4200.0\t4200\n"
+        "LC_label5\tbianciardi\t9.0\t9\n",
+    )
+    return r, seg_sidecar
+
+
+# --------------------------------------------------------------------------- #
+# Tests
+# --------------------------------------------------------------------------- #
+
+
+def _read_tsv(path):
+    with open(path, newline="", encoding="utf-8") as fh:
+        return list(csv.reader(fh, delimiter="\t"))
+
+
+def test_full_run_renders_all_tables(tmp_path, full_results):
+    results_dir, seg_sidecar = full_results
+    out_dir = str(tmp_path / "tables")
+    rc = rt.main([
+        "--results-dir", results_dir,
+        "--out-dir", out_dir,
+        "--subject-id", "sub",
+        "--seg-volumes", seg_sidecar,
+    ])
+    assert rc == 0
+
+    # All per-table CSV/TSV + HTML exist.
+    for key in (
+        "hyperintensity_per_region",
+        "wmh_tool_volumes",
+        "segmentation_volumes",
+        "cross_modal",
+        "freesurfer_morphometry",
+        "run_manifest",
+    ):
+        assert os.path.isfile(os.path.join(out_dir, f"{key}.tsv"))
+        assert os.path.isfile(os.path.join(out_dir, f"{key}.html"))
+
+    # Hyperintensity per region: two rows, sorted by source then region.
+    rows = _read_tsv(os.path.join(out_dir, "hyperintensity_per_region.tsv"))
+    assert rows[0] == ["region", "source", "cluster_count", "volume_mm3",
+                       "mean_z", "peak_z"]
+    body = rows[1:]
+    assert len(body) == 2
+    # bianciardi sorts before freesurfer
+    assert body[0][0] == "LC" and body[0][1] == "bianciardi"
+    assert body[1][0] == "pons" and body[1][1] == "freesurfer"
+    assert body[1][2] == "2" and body[1][3] == "123"  # cluster_count, volume
+
+    # WMH volumes: one row per tool present.
+    wmh = _read_tsv(os.path.join(out_dir, "wmh_tool_volumes.tsv"))
+    tools = {row[0] for row in wmh[1:]}
+    assert tools == {"BIANCA", "SHIVA"}
+
+    # Cross-modal passthrough retains the DWI_z column + corroboration.
+    cm = _read_tsv(os.path.join(out_dir, "cross_modal.tsv"))
+    assert "corroboration" in cm[0]
+    assert "DWI_z" in cm[0]
+    assert any("RESTRICTION" in row for row in cm[1:])
+
+    # FreeSurfer morphometry includes eTIV and Brain-Stem.
+    fs = _read_tsv(os.path.join(out_dir, "freesurfer_morphometry.tsv"))
+    fs_names = {row[0] for row in fs[1:]}
+    assert "EstimatedTotalIntraCranialVol" in fs_names
+    assert "Brain-Stem" in fs_names
+
+    # manifest.json marks the populated sections.
+    with open(os.path.join(out_dir, "manifest.json"), encoding="utf-8") as fh:
+        manifest = json.load(fh)
+    sections = manifest["sections"]
+    assert sections["hyperintensity_per_region"] is True
+    assert sections["wmh_tool_volumes"] is True
+    assert sections["cross_modal"] is True
+    assert sections["freesurfer_morphometry"] is True
+
+    # Top-level HTML + markdown reports were written.
+    assert os.path.isfile(os.path.join(results_dir, "reports", "brainstemx_report.html"))
+    assert os.path.isfile(os.path.join(results_dir, "reports", "brainstemx_report.md"))
+    with open(os.path.join(results_dir, "reports", "brainstemx_report.html"),
+              encoding="utf-8") as fh:
+        html = fh.read()
+    assert "BrainStemX-Full results report" in html
+    assert "RESTRICTION" in html  # cross-modal embedded
+
+
+def test_minimal_run_skips_absent_sections(tmp_path):
+    """Minimal T1+FLAIR-style run: only a hyperintensity table; rest absent."""
+    r = str(tmp_path / "results")
+    _write(
+        os.path.join(r, "per_region_analysis", "region_provenance.tsv"),
+        "region_tag\tregion_base\tsource\tmask_path\n"
+        "freesurfer_pons\tpons\tfreesurfer\t/x/pons.nii.gz\n",
+    )
+    os.makedirs(os.path.join(r, "segmentation", "brainstem"), exist_ok=True)
+    out_dir = str(tmp_path / "tables")
+    rc = rt.main([
+        "--results-dir", r, "--out-dir", out_dir, "--subject-id", "sub",
+    ])
+    assert rc == 0
+
+    with open(os.path.join(out_dir, "manifest.json"), encoding="utf-8") as fh:
+        sections = json.load(fh)["sections"]
+    # Hyperintensity present (provenance exists, even without stats sidecar).
+    assert sections["hyperintensity_per_region"] is True
+    # These have no inputs -> empty/absent.
+    assert sections["wmh_tool_volumes"] is False
+    assert sections["cross_modal"] is False
+    assert sections["freesurfer_morphometry"] is False
+    assert sections["segmentation_volumes"] is False
+
+    # Empty sections still produce a (header-only) TSV and an "absent" HTML note.
+    wmh = _read_tsv(os.path.join(out_dir, "wmh_tool_volumes.tsv"))
+    assert wmh[0][0] == "tool"
+    assert len(wmh) == 1
+    with open(os.path.join(out_dir, "wmh_tool_volumes.html"), encoding="utf-8") as fh:
+        assert "No data for this section" in fh.read()
+
+    # Top-level report still renders.
+    assert os.path.isfile(os.path.join(r, "reports", "brainstemx_report.html"))
+
+
+def test_html_escaping(tmp_path):
+    """A cell with HTML-special chars is escaped in the fragment."""
+    t = rt.Table("k", "Title", ["a", "b"])
+    t.add(["<x>", "a&b"])
+    frag = t.html_fragment()
+    assert "&lt;x&gt;" in frag
+    assert "a&amp;b" in frag
+
+
+def test_fmt_num_handles_nan_inf():
+    """_fmt_num must NOT raise on nan/inf (fslstats -M over empty region)."""
+    assert rt._fmt_num("nan") == "nan"
+    assert rt._fmt_num("inf") == "inf"
+    assert rt._fmt_num(float("nan")) == str(float("nan"))
+    assert rt._fmt_num(float("inf")) == str(float("inf"))
+    # sanity: normal values still format
+    assert rt._fmt_num("123.0") == "123"
+    assert rt._fmt_num("1.234", 2) == "1.23"
+
+
+def test_nan_meanz_does_not_wipe_report(tmp_path):
+    """A nan in region_stats.tsv must not abort the whole aggregation."""
+    r = str(tmp_path / "results")
+    _write(
+        os.path.join(r, "per_region_analysis", "region_provenance.tsv"),
+        "region_tag\tregion_base\tsource\tmask_path\n"
+        "freesurfer_pons\tpons\tfreesurfer\t/x/pons.nii.gz\n",
+    )
+    _write(
+        os.path.join(r, "per_region_analysis", "region_stats.tsv"),
+        "region_tag\tvolume_mm3\tn_voxels\tcluster_count\tmean_z\tpeak_z\n"
+        "freesurfer_pons\t123.0\t123\t2\tnan\tnan\n",
+    )
+    out_dir = str(tmp_path / "tables")
+    rc = rt.main(["--results-dir", r, "--out-dir", out_dir, "--subject-id", "sub"])
+    assert rc == 0
+    # The per-region table + the report were still written.
+    assert os.path.isfile(os.path.join(out_dir, "hyperintensity_per_region.tsv"))
+    assert os.path.isfile(os.path.join(r, "reports", "brainstemx_report.html"))
+    rows = _read_tsv(os.path.join(out_dir, "hyperintensity_per_region.tsv"))
+    assert rows[1][0] == "pons"  # row present despite the nan
+
+
+def test_freesurfer_measure_without_unit_column(tmp_path):
+    """A 4-field '# Measure' line (no unit col) must yield the NUMBER, not text."""
+    r = str(tmp_path / "results")
+    _write(
+        os.path.join(r, "freesurfer", "harvest", "stats", "aseg.stats"),
+        # No trailing unit column -> only 4 comma fields.
+        "# Measure BrainSegVol, BrainSegVol, Brain Segmentation Volume, 1100000.0\n"
+        "# ColHeaders Index SegId NVoxels Volume_mm3 StructName\n"
+        "  1  16  18000  18000.0  Brain-Stem\n",
+    )
+    t = rt.build_freesurfer_morphometry(r)
+    rowmap = {row[0]: row[1] for row in t.rows}
+    assert rowmap["BrainSegVol"] == "1100000"  # the number, not the description
+    assert "Brain Segmentation Volume" not in rowmap.values()
+
+
+if __name__ == "__main__":
+    sys.exit(pytest.main([__file__, "-v"]))

--- a/tests/test_reporting_unit.sh
+++ b/tests/test_reporting_unit.sh
@@ -1,0 +1,183 @@
+#!/usr/bin/env bash
+#
+# test_reporting_unit.sh - Unit tests for the reporting / aggregation layer:
+#   - reporting.sh module load + include guard + function definitions
+#   - _reporting_source_for_mask provenance classification
+#   - build_segmentation_volume_sidecar discovery + fslstats-driven volume rows
+#   - generate_summary_report end-to-end on a synthetic results dir (tables +
+#     top-level HTML/MD render; absent sections skipped cleanly)
+#   - visualization.sh new report-viz functions are defined and graceful
+#
+# Pure-logic / filesystem tests; FSL tools are mocked. The end-to-end report
+# build uses whichever python is on PATH (the aggregator is stdlib only).
+#
+
+set -u
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+source "$SCRIPT_DIR/test_helpers.sh"
+
+init_test_suite "Reporting / aggregation Unit Tests"
+setup_test_environment
+
+create_mock_fslmaths >/dev/null 2>&1 || true
+create_mock_fslstats >/dev/null 2>&1 || true
+create_mock_fslinfo  >/dev/null 2>&1 || true
+
+load_environment_module
+set +e
+
+source "$PROJECT_ROOT/config/default_config.sh" 2>/dev/null || true
+source "$PROJECT_ROOT/src/modules/reporting.sh" 2>/dev/null || true
+source "$PROJECT_ROOT/src/modules/visualization.sh" 2>/dev/null || true
+
+# ══════════════════════════════════════════════════════════════════════════════
+# 1. Config + module load + guards
+# ══════════════════════════════════════════════════════════════════════════════
+begin_test_group "1. Config defaults + module load + guards"
+
+assert_equals "true" "${REPORTING_ENABLED:-}" "REPORTING_ENABLED defaults true"
+
+assert_function_exists "generate_summary_report"          "generate_summary_report defined"
+assert_function_exists "build_segmentation_volume_sidecar" "build_segmentation_volume_sidecar defined"
+assert_function_exists "build_per_region_stats_sidecar"    "build_per_region_stats_sidecar defined"
+assert_function_exists "_reporting_source_for_mask"        "_reporting_source_for_mask defined"
+assert_function_exists "_reporting_mask_volume"            "_reporting_mask_volume defined"
+
+_before="${_REPORTING_LOADED:-}"
+source "$PROJECT_ROOT/src/modules/reporting.sh" 2>/dev/null || true
+assert_equals "$_before" "${_REPORTING_LOADED:-}" "reporting double-source is a no-op (guard holds)"
+
+# ══════════════════════════════════════════════════════════════════════════════
+# 2. Provenance classification from filename
+# ══════════════════════════════════════════════════════════════════════════════
+begin_test_group "2. _reporting_source_for_mask"
+
+assert_equals "bianciardi" "$(_reporting_source_for_mask /x/bianciardi_LC_label5.nii.gz)" "bianciardi_ -> bianciardi"
+assert_equals "cit168"     "$(_reporting_source_for_mask /x/cit168_Pu_label1.nii.gz)"     "cit168_ -> cit168"
+assert_equals "aal3"       "$(_reporting_source_for_mask /x/aal3_Precentral_R.nii.gz)"     "aal3_ -> aal3"
+assert_equals "synthseg"   "$(_reporting_source_for_mask /x/synthseg_seg.nii.gz)"          "synthseg_ -> synthseg"
+assert_equals "aseg"       "$(_reporting_source_for_mask /x/aseg_csf.nii.gz)"              "aseg_ -> aseg"
+assert_equals "freesurfer" "$(_reporting_source_for_mask /x/sub_pons.nii.gz)"             "no prefix -> freesurfer"
+
+# ══════════════════════════════════════════════════════════════════════════════
+# 3. Segmentation volume sidecar discovery
+# ══════════════════════════════════════════════════════════════════════════════
+begin_test_group "3. build_segmentation_volume_sidecar"
+
+RD="$TEMP_TEST_DIR/seg_results"
+mkdir -p "$RD/segmentation/brainstem" "$RD/segmentation/detailed_brainstem"
+touch "$RD/segmentation/brainstem/sub_brainstem.nii.gz"
+touch "$RD/segmentation/detailed_brainstem/sub_pons.nii.gz"
+touch "$RD/segmentation/detailed_brainstem/bianciardi_LC_label5.nii.gz"
+# decoys that must be excluded
+touch "$RD/segmentation/detailed_brainstem/sub_pons_intensity.nii.gz"
+touch "$RD/segmentation/detailed_brainstem/sub_brainstemSsLabels.nii.gz"
+
+SIDE="$TEMP_TEST_DIR/seg_vol.tsv"
+build_segmentation_volume_sidecar "$RD" "$SIDE" >/dev/null 2>&1
+
+assert_file_exists "$SIDE" "sidecar written"
+assert_contains "$(cat "$SIDE")" "region	source	volume_mm3	n_voxels" "sidecar has header"
+assert_contains "$(cat "$SIDE")" "harvard_oxford" "HO gross row present"
+assert_contains "$(cat "$SIDE")" "bianciardi" "bianciardi nucleus row present"
+assert_not_contains "$(cat "$SIDE")" "intensity" "intensity decoy excluded"
+assert_not_contains "$(cat "$SIDE")" "SsLabels" "SsLabels decoy excluded"
+# region name has source prefix stripped
+assert_contains "$(cat "$SIDE")" "LC_label5	bianciardi" "bianciardi prefix stripped from region"
+
+# ══════════════════════════════════════════════════════════════════════════════
+# 4. End-to-end report build (synthetic results dir, two methods present)
+# ══════════════════════════════════════════════════════════════════════════════
+begin_test_group "4. generate_summary_report end-to-end"
+
+ER="$TEMP_TEST_DIR/e2e_results"
+mkdir -p "$ER/per_region_analysis" \
+         "$ER/analysis/wmh/bianca" \
+         "$ER/analysis/cross_modal" \
+         "$ER/segmentation/brainstem" \
+         "$ER/segmentation/detailed_brainstem"
+
+printf 'region_tag\tregion_base\tsource\tmask_path\n%s\n' \
+  "freesurfer_pons	pons	freesurfer	/x/pons.nii.gz" \
+  > "$ER/per_region_analysis/region_provenance.tsv"
+
+cat > "$ER/analysis/wmh/bianca/bianca_wmh_summary.txt" <<'EOF'
+tool=bianca
+whole_brain_wmh_mm3=2500.0
+whole_brain_wmh_clusters=12
+brainstem_wmh_mm3=40.0
+brainstem_wmh_clusters=2
+EOF
+
+cat > "$ER/analysis/cross_modal/cross_modal_clusters.csv" <<'EOF'
+cluster_id,n_voxels,flair_z,DWI_z,corroboration,n_corroborating
+1,50,2.1,1.4,RESTRICTION,1
+EOF
+
+touch "$ER/segmentation/brainstem/sub_brainstem.nii.gz"
+touch "$ER/segmentation/detailed_brainstem/sub_pons.nii.gz"
+
+if _reporting_python >/dev/null 2>&1; then
+    generate_summary_report "subE2E" "$ER" >/dev/null 2>&1
+
+    assert_file_exists "$ER/reports/tables/hyperintensity_per_region.tsv" "per-region TSV written"
+    assert_file_exists "$ER/reports/tables/hyperintensity_per_region.html" "per-region HTML written"
+    assert_file_exists "$ER/reports/tables/wmh_tool_volumes.tsv" "WMH TSV written"
+    assert_file_exists "$ER/reports/tables/cross_modal.tsv" "cross-modal TSV written"
+    assert_file_exists "$ER/reports/tables/run_manifest.tsv" "run manifest TSV written"
+    assert_file_exists "$ER/reports/tables/manifest.json" "manifest.json written"
+    assert_file_exists "$ER/reports/brainstemx_report.html" "top-level HTML report written"
+    assert_file_exists "$ER/reports/brainstemx_report.md" "markdown fallback written"
+
+    assert_contains "$(cat "$ER/reports/tables/wmh_tool_volumes.tsv")" "BIANCA" "BIANCA row in WMH table"
+    assert_contains "$(cat "$ER/reports/tables/cross_modal.tsv")" "RESTRICTION" "cross-modal corroboration preserved"
+    assert_contains "$(cat "$ER/reports/brainstemx_report.html")" "BrainStemX-Full results report" "report has title"
+    # absent section (no FS stats) skipped cleanly
+    assert_contains "$(cat "$ER/reports/tables/freesurfer_morphometry.html")" "No data for this section" "absent FS section skipped"
+else
+    echo "  SKIP: no python available for end-to-end aggregation"
+fi
+
+# ══════════════════════════════════════════════════════════════════════════════
+# 4b. WMH summary backfill (BIANCA leaves a mask but no summary)
+# ══════════════════════════════════════════════════════════════════════════════
+begin_test_group "4b. backfill_wmh_summaries"
+
+assert_function_exists "backfill_wmh_summaries" "backfill_wmh_summaries defined"
+
+BF="$TEMP_TEST_DIR/backfill_results"
+mkdir -p "$BF/analysis/wmh/bianca"
+touch "$BF/analysis/wmh/bianca/bianca_wmh_thr0.9_bin.nii.gz"
+touch "$BF/analysis/wmh/bianca/bianca_wmh_brainstem.nii.gz"
+backfill_wmh_summaries "$BF" >/dev/null 2>&1
+assert_file_exists "$BF/analysis/wmh/bianca/bianca_wmh_summary.txt" "BIANCA summary synthesized from mask"
+assert_contains "$(cat "$BF/analysis/wmh/bianca/bianca_wmh_summary.txt" 2>/dev/null)" "whole_brain_wmh_mm3=" "synthesized summary has whole-brain volume"
+
+# Idempotent: an existing summary is NOT clobbered.
+echo "tool=bianca
+whole_brain_wmh_mm3=999.0" > "$BF/analysis/wmh/bianca/bianca_wmh_summary.txt"
+backfill_wmh_summaries "$BF" >/dev/null 2>&1
+assert_contains "$(cat "$BF/analysis/wmh/bianca/bianca_wmh_summary.txt")" "999.0" "existing summary preserved (idempotent)"
+
+# ══════════════════════════════════════════════════════════════════════════════
+# 5. Visualization report functions defined + graceful with no inputs
+# ══════════════════════════════════════════════════════════════════════════════
+begin_test_group "5. report visualization functions"
+
+assert_function_exists "generate_report_visualizations"   "generate_report_visualizations defined"
+assert_function_exists "generate_segmentation_overlays"   "generate_segmentation_overlays defined"
+assert_function_exists "generate_hyperintensity_overlays" "generate_hyperintensity_overlays defined"
+assert_function_exists "generate_multimodal_montage"      "generate_multimodal_montage defined"
+assert_function_exists "_viz_find_base_image"             "_viz_find_base_image defined"
+
+VR="$TEMP_TEST_DIR/viz_results"
+mkdir -p "$VR"
+generate_report_visualizations "subViz" "$VR" "" >/dev/null 2>&1
+assert_exit_code 0 $? "generate_report_visualizations graceful with no inputs"
+assert_dir_exists "$VR/visualizations" "visualizations dir created"
+
+print_test_summary
+RESULT=$?
+cleanup_test_environment
+exit $RESULT


### PR DESCRIPTION
The aggregation/reporting layer over all the now-merged capabilities (segmentation paths, hyperintensity GMM, optional WMH tools, multi-modal cross-modal corroboration, FreeSurfer harvest).

## Canonical output tree
Documented in `docs/output_structure.md` + `CLAUDE.md`. The reporting layer **discovers** outputs wherever modules wrote them (no risky path churn); `create_directories` creates the canonical dirs up front:

```
<RESULTS_DIR>/
├── segmentation/{brainstem,detailed_brainstem,...}
├── freesurfer/harvest/{stats,csf_masks,synthseg,subregions}
├── hyperintensities/  per_region_analysis/
├── analysis/{wmh/<tool>,cross_modal}/
├── registered/{,contrast_matched/}
├── visualizations/                       # NEW report viz
└── reports/
    ├── tables/  (*.tsv + *.html + manifest.json)   # NEW
    ├── brainstemx_report.html                       # NEW
    └── brainstemx_report.md                         # NEW
```

## Summary tables (CSV/TSV **and** HTML, under `reports/tables/`)
- **hyperintensity_per_region** — region × source: cluster count, volume mm³, mean/peak z (from per-region GMM + `region_provenance.tsv`; z sampled from the region z-score image, not the binary GMM mask).
- **wmh_tool_volumes** — one row per enabled tool (BIANCA/LST-AI/SAMSEG/segcsvd/SHIVA/MARS/WMH-SynthSeg): total + brainstem-restricted volume + clusters from each tool's `*_summary.txt`. BIANCA (which writes no summary) gets a synthesized one so it is never silently omitted.
- **segmentation_volumes** — HO gross, FS substructures, multi-atlas nuclei, SynthSeg/aseg, thalamic/hypothalamic (discovered masks → `fslstats` sidecar).
- **cross_modal** — the per-cluster corroboration table from `analysis/cross_modal/`.
- **freesurfer_morphometry** — aseg volumes + eTIV from `freesurfer/harvest/stats/aseg.stats`.
- **run_manifest** — which segmentation paths, WMH tools, modalities, and tables actually ran.

Heavy parsing/rendering is in the stdlib-only `reporting_tables.py` (run via `uv`); the bash `reporting.sh` owns only the FSL-dependent mask discovery + volume sidecars (`safe_fslmaths`/`fslstats` convention).

## Visualizations (`visualization.sh` → `visualizations/`)
- Per-method **segmentation overlays** on T1 (HO + each detailed_brainstem source).
- **Hyperintensity clusters on FLAIR**.
- **Multi-modal montage** (lesion on FLAIR/DWI/SWI/T2), reusing the canonical `_cross_modal_find_coregistered` discovery so trace/SWAN-named volumes aren't missed.

## Top-level report
`reports/brainstemx_report.html` (+ `.md` fallback): one-stop dashboard embedding every populated table, the run manifest, and discovered visualizations.

## Graceful minimal-run behavior
The reporting stage (Step 8.5) is gated/graceful/idempotent: a minimal T1+FLAIR run still produces a valid (smaller) report; sections without inputs render "No data for this section" and are marked `absent` in the manifest. Governed by `REPORTING_ENABLED` (default true); report viz honours `SKIP_VISUALIZATION`.

## Tests / verification
- `tests/test_reporting_tables.py` (6 tests): synthetic inputs → expected CSV/HTML, absent-section skipping, NaN/Inf robustness (a nan no longer wipes the whole report), short FS-measure-line parsing.
- `tests/test_reporting_unit.sh` (43 tests): module load/guards, provenance classification, segmentation sidecar discovery, end-to-end report build, WMH backfill idempotency, viz functions.
- All pass: `bash -n` + `shellcheck --severity=error` clean; core suites (environment 100/100, pipeline_control 98/98, import 29/29, cross_modal 34/34); `pipeline.sh --help` smoke; full `uv run pytest tests/` 33 passed.

Findings from `/code-review` (xhigh) were addressed: `_fmt_num` NaN/Inf guard, z sampled from the z-score image (not the binary mask), `find \( -o \)` precedence + deterministic ordering, robust `# Measure` numeric extraction, 4D `fslstats -V` summing, forced-comma cross-modal parsing, montage reuse of the canonical modality discovery, and the BIANCA summary backfill.

🤖 Generated with [Claude Code](https://claude.com/claude-code)