### PR TITLE
Docs review: align narrative docs with the full merged pipeline (parallel seg, FS harvest+ML, multi-modality, reporting)

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,13 +6,17 @@ An end-to-end neuroimaging pipeline for analyzing T2/FLAIR hyperintensity and T1
 
 ## Key Features
 
-- **Multi-modal integration** across T1/T2/FLAIR/SWI/DWI sequences
-- **Zero-shot cluster analysis** identifies signal anomalies without manual segmentation
+- **Multi-modal integration** across T1/FLAIR plus SWI / DWI-trace / ADC / T2 (modality-aware selection), with **cross-modal corroboration** of every primary FLAIR cluster (DWI restriction → acute, SWI → hemorrhage, T2 → corroborates)
+- **Contrast-matched cascaded registration** (`T1 → FLAIR → {DWI, T2, SWI}`, default on, graceful) anchors each secondary modality to its nearest same-contrast 3D structural, with composed forward+inverse transforms
+- **Zero-shot cluster analysis** identifies signal anomalies without manual segmentation — per-region GMM with FreeSurfer-CSF-aware CSF/partial-volume exclusion is the PRIMARY detector
+- **Parallel multi-method brainstem segmentation** (default `BRAINSTEM_SEGMENTATION_METHOD=all`): Harvard-Oxford gross extent + FreeSurfer substructures + multi-atlas nuclei + SynthSeg+ run concurrently, union-fed and provenance-tagged (per-method `SEG_RUN_*` toggles)
+- **Full FreeSurfer recon harvest** (aseg/wmparc/aparc stats, eTIV, optional thalamic/hypothalamic/hippo-amygdala subregions) plus extra ML methods (SynthSeg+, SynthSR, sclimbic)
 - **8-stage resumable pipeline** with intelligent checkpoint detection
-- **DICOM backtrace capability** for clinical validation in native scanner format
+- **Canonical results tree + reporting layer** — per-method/cluster/multi-modal visualizations, CSV/HTML summary tables, and a top-level `reports/brainstemx_report.html` dashboard
+- **DICOM backtrace capability** for clinical validation in native scanner format (cluster→source mapping is currently gated off pending a rewrite — `RUN_DICOM_MAPPING=false`)
 - **Adaptive processing** handles both high-end research and routine clinical protocols
 - **Optional multi-atlas brainstem nuclei labeling** (Bianciardi/CIT168/AAL3) warped into subject space
-- **Optional supervised/DL WMH modules** (BIANCA, LST-AI/SAMSEG, segcsvdWMH, SHIVA-WMH, MARS-WMH, WMH-SynthSeg) — default OFF
+- **Optional supervised/DL WMH modules** (BIANCA, LST-AI/SAMSEG, segcsvdWMH, SHIVA-WMH, MARS-WMH, WMH-SynthSeg) — exploratory; none validated in the brainstem
 
 ## Quick Start
 
@@ -56,21 +60,25 @@ source ~/.bash_profile && src/pipeline.sh -i ../DiCOM -o ../mri_results -s patie
 
 The pipeline consists of 8 resumable stages:
 
-1. **import** - DICOM import and conversion
-2. **preprocess** - Modality-aware denoising (Rician NLM for T1/T2/FLAIR, MP-PCA for DWI) + N4 bias correction
+1. **import** - DICOM import and conversion (all series kept; no modality filtering)
+2. **preprocess** - Modality-aware denoising (Rician NLM for T1/T2/FLAIR, MP-PCA for DWI) + N4 bias correction (field-strength `-b`; gentler lesion-aware FLAIR)
 3. **brain_extraction** - SynthStrip primary (ANTs/BET fallback) + robustfov + posterior-fossa QC, plus standardization
-4. **registration** - Multi-stage ANTs alignment to standard space (cross-modality SyN uses Mutual Information)
-5. **segmentation** - Brainstem/pons segmentation — FreeSurfer substructures (default) or Harvard-Oxford gross extent (thr25), with an optional multi-atlas warp (Bianciardi/CIT168/AAL3); selectable via `BRAINSTEM_SEGMENTATION_METHOD`
-6. **analysis** - Hyperintensity detection and clustering
-7. **visualization** - Generate reports and visualizations
+4. **registration** - Multi-stage ANTs alignment (cross-modality SyN uses Mutual Information) + the contrast-matched cascade routing any present SWI/DWI/ADC/T2 into the common analysis space
+5. **segmentation** - Parallel multi-method brainstem segmentation (default `BRAINSTEM_SEGMENTATION_METHOD=all`): Harvard-Oxford gross extent (thr25) + FreeSurfer substructures + multi-atlas nuclei (Bianciardi/CIT168/AAL3) + SynthSeg+, union-fed; also `freesurfer` / `atlas` / `multi_atlas` single-method values
+6. **analysis** - Per-region GMM hyperintensity detection with CSF/PV exclusion + cross-modal corroboration of each cluster
+7. **visualization** - Generate QC + report visualizations
 8. **tracking** - Pipeline progress validation
+
+A final **reporting** step (Step 8.5) then aggregates everything into CSV/HTML summary tables and the top-level `reports/brainstemx_report.html` dashboard.
 
 Use `-t STAGE` to resume from any stage (e.g., `-t 4` or `-t registration`).
 
 ## Documentation
 
 - **[Technical Overview](docs/TECHNICAL_OVERVIEW.md)** - Comprehensive technical documentation
+- **[Output Structure](docs/output_structure.md)** - Canonical results tree, summary tables, and the top-level report
 - **[Multi-Atlas Integration](docs/multi_atlas_integration_spec.md)** - Optional Bianciardi/CIT168/AAL3 brainstem labeling
+- **[FreeSurfer Brainstem Substructures](docs/brainstem_freesurfer_segmentation_spec.md)** - Iglesias 2015 `segmentBS` parcels (replaces Talairach)
 - **[Scan Selection](docs/README_scan_selection.md)** - Details on intelligent scan selection
 - **[Reference Space Selection](docs/README_reference_space_selection.md)** - Reference space optimization
 - **[Synthetic Test Data](docs/synthetic_test_data.md)** - Generating synthetic phantoms for testing
@@ -85,7 +93,7 @@ Active development as of June 2026. While functional, improvements are ongoing. 
 This pipeline leverages established neuroimaging tools:
 - **ANTs** - Advanced Normalizations Tools
 - **FSL** - FMRIB Software Library
-- **FreeSurfer** - Brainstem substructure segmentation (Iglesias 2015 `segmentBS`) + 3D visualization
+- **FreeSurfer** - Brainstem substructure segmentation (Iglesias 2015 `segmentBS`), full recon harvest (aseg/wmparc/aparc stats, eTIV, subregions), ML methods (SynthSeg+, SynthSR, sclimbic), and 3D visualization
 - **Harvard-Oxford Atlas** - Gross brainstem extent mask
 - **MNI152 Templates** - Registration targets
 

--- a/docs/README.md
+++ b/docs/README.md
@@ -28,17 +28,35 @@ For a minimal pure-python implemention with synthetic data generation, LLM repor
 - Updated Juelich pons segmentation: applied same interpolation fix, yielding anatomically reasonable voxel counts.
 - Integrated FLAIR enhancement: generated separate FLAIR intensity masks for segmentation quality analysis.
 
-## Multi-Atlas Labeling & Optional Modules
+## Parallel Multi-Method Segmentation, Multi-Atlas Labeling & Optional Modules
 
-Beyond the default FreeSurfer/Harvard-Oxford path, the pipeline now ships several **opt-in** segmentation and lesion-detection back-ends:
+The default brainstem-segmentation mode is now **`BRAINSTEM_SEGMENTATION_METHOD=all`**: every enabled path runs as a **concurrent parallel path** and downstream per-region detection analyses the **union** of all masks they produce. The fast paths (Harvard-Oxford gross extent + multi-atlas warp, minutes) run side-by-side with the multi-hour FreeSurfer recon-all; each path is independent and **non-fatal** (a failed/skipped path logs a WARNING and never kills the others or the pipeline), and the shared MNI→subject SyN transform is computed once up front and reused. Per-path toggles `SEG_RUN_HARVARD_OXFORD` / `SEG_RUN_MULTI_ATLAS` / `SEG_RUN_FREESURFER` / `SEG_RUN_SYNTHSEG` (all default ON) drop individual paths — e.g. `SEG_RUN_FREESURFER=false` keeps the fast HO + multi-atlas paths and skips recon-all. The single-method values (`freesurfer`, `atlas`/`harvard_oxford`, `multi_atlas`/`bianciardi`) remain mutually exclusive and behave exactly as before. Each path's masks are provenance-tagged (`per_region_analysis/region_provenance.tsv`) so the reporting layer can attribute every region to its source method.
 
 - **Multi-atlas brainstem labeling** (`BRAINSTEM_SEGMENTATION_METHOD=multi_atlas`/`bianciardi`, `multi_atlas.sh`) — warps the **Bianciardi BrainstemNavigator v1.0** (nucleus-level), **CIT168** subcortical, and (off-by-default) **AAL3** atlases into subject T1 space via one shared SyN→MNI registration plus label-aware `GenericLabel` interpolation, producing per-region masks the existing per-region GMM detection consumes directly. See [docs/multi_atlas_integration_spec.md](multi_atlas_integration_spec.md).
+- **FreeSurfer full-recon harvest + ML methods** (`freesurfer_harvest.sh`) — recon-all is paid for **once**; the harvest then extracts the rest of its output (aseg/wmparc/aparc + `aparc.a2009s` stats, eTIV, optional thalamic / hypothalamic / hippo-amygdala subregions) with **no second recon**. Aseg/SynthSeg CSF + 4th-ventricle masks feed the FP-exclusion path. Fast contrast/resolution-agnostic ML methods run directly on a clinical/2D T1 with no recon: **SynthSeg+** (`mri_synthseg --robust`, default on), **SynthSR** (`mri_synthsr`, optional 1 mm T1 synthesis pre-step), and **sclimbic** (`mri_sclimbic_seg`, gated). Cheap harvests default ON; the multi-hour/extra-time pieces default OFF.
 - **Atlas-availability check** — a startup `check_atlas_availability` step reports which atlases are present under `$FSLDIR/data/atlases` and warns if the selected method needs a missing one; absence is **non-fatal** (the pipeline degrades to the Harvard-Oxford gross mask).
-- **Optional supervised / deep-learning WMH modules (all default-OFF)**, each intersected with the brainstem mask: FSL **BIANCA** (`wmh_bianca.sh`), **LST-AI + FreeSurfer SAMSEG** (`wmh_lst_samseg.sh`), **WMH-SynthSeg** (`wmh_synthseg.sh`), **segcsvdWMH** (`wmh_segcsvd.sh`), **SHIVA-WMH** (`wmh_shiva.sh`), and **MARS-WMH** (`wmh_mars.sh`).
-- **AANSegment** (`brainstem_aanseg.sh`) — **exploratory** FreeSurfer arousal-network nuclei segmentation (≤1 mm input only; large-lesion-sensitive; off by default).
-- **Post-detection false-positive filter** (`fp_filter.sh`) — config-gated FP suppression that operates *after* detection, complementing the CSF/partial-volume exclusion that runs *before* thresholding.
+- **Optional supervised / deep-learning WMH modules**, each intersected with the brainstem mask: FSL **BIANCA** (`wmh_bianca.sh`), **LST-AI + FreeSurfer SAMSEG** (`wmh_lst_samseg.sh`), **WMH-SynthSeg** (`wmh_synthseg.sh`), **segcsvdWMH** (`wmh_segcsvd.sh`), **SHIVA-WMH** (`wmh_shiva.sh`), and **MARS-WMH** (`wmh_mars.sh`). Each is self-gated — a no-op WARNING+skip until its tool/model/training data is present — so an enabled master switch is harmless until the tool is installed.
+- **AANSegment** (`brainstem_aanseg.sh`) — **exploratory** FreeSurfer arousal-network nuclei segmentation (≤1 mm input only; large-lesion-sensitive).
+- **Post-detection false-positive filter** (`fp_filter.sh`) — config-gated FP suppression that operates *after* detection, complementing the CSF/partial-volume exclusion that runs *before* thresholding. Lossy (removes true small lesions) — kept OFF by default for the brainstem.
 
-> ⚠️ **None of these is validated in the brainstem/pons.** All published WMH/lesion SOTA is supratentorial; the posterior fossa is repeatedly "under-evaluated", and Ryu et al. 2025 find DL segmentation "relatively poor" in the brainstem. Treat every optional module as exploratory, keep conservative pons QA with a human in the loop, and locally validate any tool before relying on it.
+> ⚠️ **None of the optional WMH/lesion modules is validated in the brainstem/pons.** All published WMH/lesion SOTA is supratentorial; the posterior fossa is repeatedly "under-evaluated", and Ryu et al. 2025 find DL segmentation "relatively poor" in the brainstem. Treat every optional module as exploratory, keep conservative pons QA with a human in the loop, and locally validate any tool before relying on it. These add-ons only **corroborate** — none alters the primary per-region-GMM FLAIR detection.
+
+## Multi-Modal Corroboration (SWI / DWI / T2 end-to-end)
+
+Beyond the T1/FLAIR backbone, the pipeline brings the **secondary** T2-weighted modalities — SWI magnitude, the DERIVED DWI **trace** + **ADC** (not raw 4D diffusion), and a true T2 — all the way through, **only when they are present** (a T1+FLAIR-only study is byte-identically unchanged; the toggles default ON precisely because they are no-ops in the absence of the relevant series).
+
+- **Contrast-matched cascaded registration** (`registration.sh:register_contrast_matched_cascade`, `CONTRAST_MATCHED_REGISTRATION=true`) anchors each T2-weighted secondary to its nearest same-contrast 3D structural rather than directly to T1: the cascade is `T1 ← FLAIR ← {T2, DWI, ADC, SWI}` (anchors set by `CONTRAST_ANCHOR_MAP`). Each secondary's transform is **composed** with the FLAIR→T1 transforms so it reaches T1/MNI in a single `antsApplyTransforms` application (no double interpolation); both the composed **forward and inverse** transform lists are persisted.
+- **Cross-modal corroboration** (`cross_modal_analysis.sh`, `CROSS_MODAL_ANALYSIS_ENABLED=true`) samples each co-registered secondary inside every PRIMARY FLAIR cluster ROI and flags **DWI restriction** (trace ↑ AND ADC ↓ → acute/ischemic), **SWI hypointensity** (→ hemorrhage/microbleed), and **T2 hyperintensity** (→ corroborates FLAIR). Each modality is z-scored within the brainstem ROI so the thresholds (`CROSS_MODAL_*_Z`) are scanner-independent. This is corroboration **on top of** the primary detection — it never re-detects lesions and never alters the primary mask. Outputs a per-cluster table + summary under `analysis/cross_modal/`.
+
+## Output & Reporting Layer
+
+A final **reporting** stage (Step 8.5, `reporting.sh`, after analysis/QA/viz) aggregates every merged capability over the **canonical results tree**. It **discovers** outputs wherever modules wrote them and emits, all gated/graceful/idempotent (a minimal T1+FLAIR run still produces a valid smaller report; absent sections render as "No data" and are recorded `absent` in the run manifest):
+
+- **Summary tables** under `reports/tables/`, each as **CSV/TSV + HTML**: `hyperintensity_per_region`, `wmh_tool_volumes`, `segmentation_volumes` (HO / FS / multi-atlas / SynthSeg-aseg / subregions), `cross_modal`, `freesurfer_morphometry` (aseg volumes + eTIV), and a `run_manifest`; plus a machine-readable `manifest.json`.
+- **Report visualizations** under `visualizations/` — per-method segmentation overlays, hyperintensity clusters on FLAIR, and a multi-modal montage (FLAIR/DWI/SWI/T2).
+- **Top-level report** `reports/brainstemx_report.html` (+ `.md` fallback) — a one-stop dashboard embedding all populated tables, the run manifest, and the discovered visualizations.
+
+Governed by `REPORTING_ENABLED` (default `true`); report visualizations honour `SKIP_VISUALIZATION`. Full tree + table schemas: [docs/output_structure.md](output_structure.md).
 
 ## Recent advances & roadmap (2024–2026)
 
@@ -88,7 +106,7 @@ This section situates BrainStem X against the 2024–2026 literature and records
   - DICOM backtrace JSON mapping results into original scanner coordinates for PACS validation
 
 ### Advanced Segmentation
-- **FreeSurfer brainstem substructures** (Iglesias 2015 `segmentBS`/`brainstemSsLabels`) for the detailed subdivision into midbrain / pons / medulla / SCP, selected via `BRAINSTEM_SEGMENTATION_METHOD` (default `freesurfer`, fallback `atlas`)
+- **FreeSurfer brainstem substructures** (Iglesias 2015 `segmentBS`/`brainstemSsLabels`) for the detailed subdivision into midbrain / pons / medulla / SCP, run by default (the `all` mode runs them alongside the other paths; also selectable as the single-method `BRAINSTEM_SEGMENTATION_METHOD=freesurfer`)
 - **Harvard-Oxford subcortical atlas** (index 7, tightened to `maxprob-thr25`) used only for the gross brainstem extent mask and as the FreeSurfer fallback
 - **Atlas-to-subject transformation** preserving native resolution by bringing the MNI HO atlas to subject space; FreeSurfer segments the subject's own T1 directly
 - **Subject-specific brainstem refinement** using tissue segmentation to address shape variance in pathological cases
@@ -152,7 +170,8 @@ This section situates BrainStem X against the 2024–2026 literature and records
 
 #### Advanced Segmentation (segmentation.sh)
 - **Harvard-Oxford gross brainstem extent** using subcortical index 7, tightened to `maxprob-thr25`, as the extent mask and the fallback
-- **FreeSurfer brainstem substructures** (Iglesias 2015 `segmentBS`/`brainstemSsLabels`) for the detailed subdivision into midbrain / pons / medulla / SCP, selected via `BRAINSTEM_SEGMENTATION_METHOD` (default `freesurfer`, fallback `atlas`) and gated by an FS↔HO agreement (Dice + leakage) QC check
+- **FreeSurfer brainstem substructures** (Iglesias 2015 `segmentBS`/`brainstemSsLabels`) for the detailed subdivision into midbrain / pons / medulla / SCP, gated by an FS↔HO agreement (Dice + leakage) QC check
+- **Parallel multi-method mode** (default `BRAINSTEM_SEGMENTATION_METHOD=all`) runs the HO, FreeSurfer-substructure, multi-atlas, and SynthSeg+ paths concurrently and feeds their union to per-region detection; per-path `SEG_RUN_*` toggles. Single-method values (`freesurfer`, `atlas`/`harvard_oxford`, `multi_atlas`/`bianciardi`) remain available and mutually exclusive
 - **Atlas-to-subject transformation** preserving native resolution by bringing the MNI HO atlas to subject space; FreeSurfer segments the subject's own T1 directly
 - **Subject-specific refinement** using tissue segmentation (Atropos/FAST) to address shape variance in hydrocephalus & Chiari cases
 - **FLAIR enhancement integration** creating both T1 and FLAIR intensity versions for multi-modal analysis
@@ -168,7 +187,8 @@ This section situates BrainStem X against the 2024–2026 literature and records
 - **Connectivity weighting** for refined detection using 3D morphological operations (fslmaths)
 - **Multi-threshold hyperintensity detection** with configurable standard deviation multipliers and minimum cluster size filtering
 - **Cross-modality validation** analyzes both FLAIR hyperintensities and T1 hypointensities with statistical correlation
-- **Optional supervised / DL WMH modules** (all default-off), each intersecting results with the brainstem mask: FSL BIANCA (`wmh_bianca.sh`), LST-AI + FreeSurfer SAMSEG (`wmh_lst_samseg.sh`), WMH-SynthSeg (`wmh_synthseg.sh`), segcsvdWMH (`wmh_segcsvd.sh`), SHIVA-WMH (`wmh_shiva.sh`), MARS-WMH (`wmh_mars.sh`); plus a post-detection false-positive filter (`fp_filter.sh`)
+- **Cross-modal corroboration** (`cross_modal_analysis.sh`, default on/graceful) annotates each primary FLAIR cluster with co-registered SWI/DWI-trace/ADC/T2 evidence (DWI restriction → acute, SWI → hemorrhage, T2 → corroborates), without altering the primary mask
+- **Optional supervised / DL WMH modules** (each self-gated — no-op until its tool/model/training data is present), each intersecting results with the brainstem mask: FSL BIANCA (`wmh_bianca.sh`), LST-AI + FreeSurfer SAMSEG (`wmh_lst_samseg.sh`), WMH-SynthSeg (`wmh_synthseg.sh`), segcsvdWMH (`wmh_segcsvd.sh`), SHIVA-WMH (`wmh_shiva.sh`), MARS-WMH (`wmh_mars.sh`); plus a post-detection false-positive filter (`fp_filter.sh`, off by default)
 
 #### Advanced Visualization & QA (visualization.sh, qa.sh)
 - **Interactive 3D rendering** creates volume renderings of hyperintensity clusters with customizable opacity and color mapping
@@ -179,7 +199,7 @@ This section situates BrainStem X against the 2024–2026 literature and records
 #### DICOM Integration & Clinical Validation (dicom_analysis.sh, dicom_cluster_mapping.sh)
 - **Vendor-agnostic DICOM metadata extraction** analyzes scanner parameters, acquisition settings, and sequence characteristics for optimal processing
 - **Clinical coordinate backtrace** maps processed results back to original DICOM coordinate system for PACS viewer compatibility
-- **Comprehensive cluster-to-DICOM mapping** creates coordinate lookup tables enabling medical imaging viewer navigation to identified clusters
+- **Cluster-to-DICOM mapping** (`dicom_cluster_mapping.sh`) creates coordinate lookup tables enabling medical imaging viewer navigation to identified clusters — **currently gated off** (`RUN_DICOM_MAPPING=false`) pending a rewrite; a normal run skips it
 - **Scanner-specific optimization** automatically detects Siemens, Philips, and GE scanners and applies vendor-specific processing parameters
 
 #### Intelligent Reference Space Selection (reference_space_selection.sh)
@@ -215,7 +235,7 @@ The segmentation module implements a **two-tier approach** (gross extent + subst
 
 2. **FreeSurfer Brainstem Substructures (Detailed Subdivision)**
    - Iglesias 2015 `segmentBS`/`brainstemSsLabels` → midbrain / pons / medulla / SCP masks in subject space (FreeSurfer segments the subject's own T1, no warp)
-   - Selected via `BRAINSTEM_SEGMENTATION_METHOD` (default `freesurfer`; `atlas`/`harvard_oxford` = gross mask only)
+   - Run by default: the default `BRAINSTEM_SEGMENTATION_METHOD=all` mode runs this path concurrently with the HO / multi-atlas / SynthSeg+ paths (toggle with `SEG_RUN_FREESURFER`); also selectable as the single-method value `freesurfer` (`atlas`/`harvard_oxford` = gross mask only)
    - Gated by an FS↔HO agreement check (Dice + leakage); on disagreement or missing FreeSurfer/license, falls back to the HO gross mask and flags low confidence
    - Talairach has been removed entirely (single 1988 post-mortem brain; largest MNI-mapping error inferiorly/posteriorly — worst exactly in the brainstem)
 
@@ -251,10 +271,10 @@ The analysis module implements **region-based hyperintensity detection**:
    - Minimum cluster size filtering (configurable via `MIN_HYPERINTENSITY_SIZE`)
    - Morphological closing operations to eliminate noise
 
-5. **Optional Supervised / DL WMH Modules** (all default-off)
+5. **Optional Supervised / DL WMH Modules** (each self-gated; no-op until its tool/model/training data is present)
    - Each intersects results with the brainstem mask: FSL BIANCA (`wmh_bianca.sh`), LST-AI + FreeSurfer SAMSEG (`wmh_lst_samseg.sh`), WMH-SynthSeg (`wmh_synthseg.sh`), segcsvdWMH (`wmh_segcsvd.sh`), SHIVA-WMH (`wmh_shiva.sh`), MARS-WMH (`wmh_mars.sh`)
-   - A post-detection false-positive filter (`fp_filter.sh`) can be applied afterward (config-gated)
-   - **None is validated in the brainstem** — keep conservative pons QA / human-in-the-loop
+   - A post-detection false-positive filter (`fp_filter.sh`) can be applied afterward (config-gated; off by default — lossy for small lesions)
+   - **None is validated in the brainstem** — keep conservative pons QA / human-in-the-loop; these corroborate, they never alter the primary detection
 
 #### QA Module (qa.sh)
 The QA module performs **20+ comprehensive validation checks**:
@@ -370,8 +390,9 @@ The pipeline implements a sophisticated 8-stage processing workflow with intelli
 - **Enhanced registration validation** comprehensive metrics including cross-correlation, mutual information, normalized CC
 
 #### Stage 5: Brainstem Segmentation
+- **Parallel multi-method segmentation** (default `BRAINSTEM_SEGMENTATION_METHOD=all`): Harvard-Oxford gross extent + FreeSurfer substructures + multi-atlas nuclei + SynthSeg+ run as concurrent, independent, non-fatal paths whose masks are union-fed to per-region detection and provenance-tagged; per-path `SEG_RUN_*` toggles. Single-method values (`freesurfer`, `atlas`/`harvard_oxford`, `multi_atlas`/`bianciardi`) remain available
 - **Harvard-Oxford gross extent** subcortical atlas (index 7, `maxprob-thr25`) for the brainstem boundary mask and as the fallback
-- **FreeSurfer brainstem substructures** (Iglesias 2015 `segmentBS`) for midbrain / pons / medulla / SCP, selected via `BRAINSTEM_SEGMENTATION_METHOD` (default `freesurfer`, fallback `atlas`) and gated by an FS↔HO agreement QC check
+- **FreeSurfer brainstem substructures** (Iglesias 2015 `segmentBS`) for midbrain / pons / medulla / SCP, gated by an FS↔HO agreement QC check; plus the full FreeSurfer recon harvest (aseg/wmparc/aparc stats, eTIV, optional subregions) and ML methods (SynthSeg+, SynthSR, sclimbic) from the same recon
 - **Subject-specific refinement** using tissue segmentation to address shape variance in pathological cases
 - **Native space preservation** maintains segmentation accuracy in subject's original high-resolution space
 - **FLAIR integration** creates both T1 and FLAIR intensity versions for comprehensive analysis
@@ -382,13 +403,15 @@ The pipeline implements a sophisticated 8-stage processing workflow with intelli
 - **CSF / partial-volume exclusion** using the FSL FAST CSF PVE map before thresholding
 - **Multi-threshold detection** configurable SD multipliers with minimum cluster size filtering
 - **Cross-modality validation** analyzes hyperintensity patterns across T1/T2/FLAIR with statistical correlation
-- **Optional supervised / DL WMH** BIANCA, LST-AI + SAMSEG, WMH-SynthSeg, segcsvdWMH, SHIVA-WMH, MARS-WMH modules (all default-off), intersected with the brainstem mask; optional `fp_filter.sh` post-detection FP suppression
+- **Cross-modal corroboration** samples each co-registered secondary (SWI/DWI-trace/ADC/T2) inside every primary FLAIR cluster and flags DWI restriction (→ acute), SWI hypointensity (→ hemorrhage), and T2 hyperintensity (→ corroborates) — on top of, never altering, the primary detection
+- **Optional supervised / DL WMH** BIANCA, LST-AI + SAMSEG, WMH-SynthSeg, segcsvdWMH, SHIVA-WMH, MARS-WMH modules (each self-gated, no-op until its tool/data is present), intersected with the brainstem mask; optional `fp_filter.sh` post-detection FP suppression
 - **Native-to-standard space mapping** enables analysis in both subject native and standardized coordinates
-- **DICOM cluster backtrace** creates coordinate lookup tables for medical imaging viewer navigation
+- **DICOM cluster backtrace** — the cluster→DICOM-source mapping (`dicom_cluster_mapping.sh`) is currently **gated off** (`RUN_DICOM_MAPPING=false`) pending a rewrite, so a normal run skips it
 
 #### Stage 7: Advanced Visualization & Reporting
 - **3D volume rendering** with customizable opacity and color mapping for hyperintensity clusters
 - **Multi-threshold comparison** side-by-side visualizations across different detection thresholds
+- **Report visualizations** per-method segmentation overlays, hyperintensity-on-FLAIR, and a multi-modal montage (FLAIR/DWI/SWI/T2)
 - **Interactive QA interface** real-time FSLView integration for immediate visual feedback
 - **Comprehensive HTML reporting** with embedded visualizations and quantitative metrics
 
@@ -397,6 +420,11 @@ The pipeline implements a sophisticated 8-stage processing workflow with intelli
 - **Comprehensive QA reporting** 20+ validation checks including coordinate space consistency
 - **Batch processing summary** CSV reports with volume metrics and registration quality scores
 - **Error tracking and diagnostics** detailed logging for troubleshooting and quality assurance
+
+#### Stage 8.5: Aggregation & Reporting Layer
+- **Summary tables** under `reports/tables/` as CSV/TSV + HTML (per-region hyperintensity, WMH tool volumes, segmentation volumes, cross-modal, FreeSurfer morphometry, run manifest)
+- **Top-level dashboard** `reports/brainstemx_report.html` (+ `.md` fallback) embeds all populated tables and discovered visualizations; `manifest.json` records which sections were populated
+- **Discovers** outputs wherever modules wrote them; gated/graceful/idempotent (`REPORTING_ENABLED`). See [docs/output_structure.md](output_structure.md)
 
 **Complete Module Implementation:**
 - Core Pipeline → [`src/pipeline.sh`](src/pipeline.sh:1)
@@ -409,9 +437,14 @@ The pipeline implements a sophisticated 8-stage processing workflow with intelli
 - Preprocessing → [`src/modules/preprocess.sh`](src/modules/preprocess.sh:1)
 - Registration → [`src/modules/registration.sh`](src/modules/registration.sh:1)
 - Brainstem Segmentation (HO gross extent + FreeSurfer substructures) → [`src/modules/segmentation.sh`](src/modules/segmentation.sh:1), [`src/modules/brainstem_freesurfer.sh`](src/modules/brainstem_freesurfer.sh:1)
+- Multi-Atlas Labeling (Bianciardi/CIT168/AAL3) → [`src/modules/multi_atlas.sh`](src/modules/multi_atlas.sh:1)
+- FreeSurfer Recon Harvest + ML methods (SynthSeg+/SynthSR/sclimbic) → [`src/modules/freesurfer_harvest.sh`](src/modules/freesurfer_harvest.sh:1)
 - Comprehensive Analysis → [`src/modules/analysis.sh`](src/modules/analysis.sh:1), [`src/modules/gmm_threshold.py`](src/modules/gmm_threshold.py:1)
+- Cross-Modal Corroboration → [`src/modules/cross_modal_analysis.sh`](src/modules/cross_modal_analysis.sh:1), [`src/modules/cross_modal_sample.py`](src/modules/cross_modal_sample.py:1)
+- Optional WMH Modules (default add-ons) → [`src/modules/wmh_bianca.sh`](src/modules/wmh_bianca.sh:1), [`src/modules/wmh_lst_samseg.sh`](src/modules/wmh_lst_samseg.sh:1), [`src/modules/wmh_synthseg.sh`](src/modules/wmh_synthseg.sh:1), [`src/modules/wmh_segcsvd.sh`](src/modules/wmh_segcsvd.sh:1), [`src/modules/wmh_shiva.sh`](src/modules/wmh_shiva.sh:1), [`src/modules/wmh_mars.sh`](src/modules/wmh_mars.sh:1), [`src/modules/brainstem_aanseg.sh`](src/modules/brainstem_aanseg.sh:1), [`src/modules/fp_filter.sh`](src/modules/fp_filter.sh:1)
 - Enhanced Registration Validation → [`src/modules/enhanced_registration_validation.sh`](src/modules/enhanced_registration_validation.sh:1)
 - Advanced Visualization → [`src/modules/visualization.sh`](src/modules/visualization.sh:1)
+- Aggregation & Reporting Layer → [`src/modules/reporting.sh`](src/modules/reporting.sh:1), [`src/modules/reporting_tables.py`](src/modules/reporting_tables.py:1)
 - Quality Assurance → [`src/modules/qa.sh`](src/modules/qa.sh:1)
 - Parallel Processing → [`src/modules/fast_wrapper.sh`](src/modules/fast_wrapper.sh:1)
 

--- a/docs/README_scan_selection.md
+++ b/docs/README_scan_selection.md
@@ -4,7 +4,7 @@ This document describes the scan selection system that has been implemented in t
 
 ## Scan Selection Modes
 
-The pipeline now supports four different modes for selecting the best scan:
+The pipeline supports five different modes for selecting the best scan:
 
 ### 1. `original` Mode (Default for T1)
 
@@ -125,3 +125,14 @@ When analyzing brainstem lesions, prefer using scans like T2_SPACE_FLAIR_Sag_CS_
 - ORIGINAL acquisitions
 - Have consistent dimensions with the T1 reference
 - Avoid any unnecessary resampling or interpolation
+
+## Secondary-Modality Discovery (SWI / DWI-trace / ADC / T2)
+
+Beyond selecting the best T1 and FLAIR, scan selection is **modality-aware** for the
+secondary T2-weighted modalities the multi-modal path consumes. `scan_selection.sh::discover_secondary_modality_specs`
+walks `MULTIMODAL_SECONDARY_MODALITIES` (default `T2`, `SWI`, `DWI`, `ADC`) and, for
+each modality **present on disk**, picks the best scan — filtering out the
+T2-SPACE-FLAIR (which belongs to the FLAIR family, not T2) and disambiguating the
+DWI trace from the ADC map. The chosen secondaries flow into the contrast-matched
+registration cascade and per-cluster cross-modal corroboration. A study with only
+T1+FLAIR yields no secondary specs and the rest of the pipeline is unchanged.

--- a/docs/TECHNICAL_OVERVIEW.md
+++ b/docs/TECHNICAL_OVERVIEW.md
@@ -27,17 +27,37 @@ Brainstem regions can present clinically with very subtle variations below the c
 - Updated Juelich pons segmentation: applied same interpolation fix, yielding anatomically reasonable voxel counts
 - Integrated FLAIR enhancement: generated separate FLAIR intensity masks for segmentation quality analysis
 
-## Multi-Atlas Labeling, Optional Modules & Atlas Availability
+## Parallel Multi-Method Segmentation, Multi-Atlas Labeling, Optional Modules & Atlas Availability
 
-The default segmentation path is FreeSurfer substructures with a Harvard-Oxford gross-extent fallback. Several **opt-in** back-ends extend it:
+The default segmentation mode is **`BRAINSTEM_SEGMENTATION_METHOD=all`**: every enabled path runs as a **concurrent parallel path**, and downstream per-region detection analyses the **union** of the masks they produce. The fast paths (Harvard-Oxford gross extent + multi-atlas warp, minutes) run side-by-side with the multi-hour FreeSurfer recon-all; each path is **independent and non-fatal** (a failed/skipped path logs a WARNING and never kills the others or the pipeline), and the MNI→subject SyN transform is computed once up front and shared. Per-path toggles `SEG_RUN_HARVARD_OXFORD` / `SEG_RUN_MULTI_ATLAS` / `SEG_RUN_FREESURFER` / `SEG_RUN_SYNTHSEG` (all default ON) drop individual paths (e.g. `SEG_RUN_FREESURFER=false` keeps the fast paths and skips recon-all). The single-method values (`freesurfer`, `atlas`/`harvard_oxford`, `multi_atlas`/`bianciardi`) remain mutually exclusive and behave exactly as before; each path's masks are provenance-tagged (`per_region_analysis/region_provenance.tsv`).
+
+Several **opt-in** back-ends extend this:
 
 - **Multi-atlas brainstem labeling** (`multi_atlas.sh`, enabled via `BRAINSTEM_SEGMENTATION_METHOD=multi_atlas`/`bianciardi`) — warps the **Bianciardi BrainstemNavigator v1.0**, **CIT168**, and (off-by-default) **AAL3** atlases into subject T1 space through one shared SyN→MNI registration with label-aware `GenericLabel` interpolation. Bianciardi's *overlapping* probabilistic maps are combined by a streaming winner-take-all argmax into an int16 dseg **plus** an overlay set for the 12 reticular-formation nuclei that argmax would zero out. Per-region masks land where `analysis.sh:find_all_atlas_regions` discovers them, so per-region GMM detection consumes them unchanged. Full detail: [multi_atlas_integration_spec.md](multi_atlas_integration_spec.md).
+- **FreeSurfer full-recon harvest + ML methods** (`freesurfer_harvest.sh`) — recon-all is paid for **once**; the harvest then extracts the rest of its output with **no second recon**: aseg/wmparc/aparc + `aparc.a2009s` stats, eTIV, and (opt-in, extra-time) thalamic / hypothalamic / hippo-amygdala subregions. Aseg/SynthSeg CSF + 4th-ventricle masks feed the FP-exclusion path (`CSF_USE_FREESURFER_MASK`). Fast contrast/resolution-agnostic ML methods run on a clinical/2D T1 with no recon: **SynthSeg+** (`mri_synthseg --robust`, default on), **SynthSR** (`mri_synthsr`, optional 1 mm-T1 synthesis pre-step `USE_SYNTHSR`), and **sclimbic** (`mri_sclimbic_seg`, gated). Cheap harvests default ON; multi-hour/extra-time pieces default OFF.
 - **Atlas-availability check** (`check_atlas_availability` in `environment.sh`, invoked at startup) — reports presence/absence of each atlas under `$FSLDIR/data/atlases` (`ATLAS_DIR`) and warns if the selected method needs a missing one. Absence is **non-fatal**: the pipeline degrades to the Harvard-Oxford gross mask. Layout is overridable via `ATLAS_{BIANCIARDI,CIT168,AAL3,HARVARDOXFORD}_REL`.
-- **Optional supervised / deep-learning WMH modules (all default-OFF)**, each intersected with the brainstem mask: FSL **BIANCA** (`wmh_bianca.sh`), **LST-AI + FreeSurfer SAMSEG** (`wmh_lst_samseg.sh`), **WMH-SynthSeg** (`wmh_synthseg.sh`), **segcsvdWMH** (`wmh_segcsvd.sh`), **SHIVA-WMH** (`wmh_shiva.sh`), **MARS-WMH** (`wmh_mars.sh`).
-- **AANSegment** (`brainstem_aanseg.sh`) — **exploratory** FreeSurfer arousal-network nuclei segmentation; ≤1 mm input only, large-lesion-sensitive, off by default.
-- **Post-detection false-positive filter** (`fp_filter.sh`) — config-gated FP suppression operating *after* detection, complementing the CSF/partial-volume exclusion that runs *before* thresholding.
+- **Optional supervised / deep-learning WMH modules** (each self-gated — a no-op WARNING+skip until its tool/model/training data is present), each intersected with the brainstem mask: FSL **BIANCA** (`wmh_bianca.sh`), **LST-AI + FreeSurfer SAMSEG** (`wmh_lst_samseg.sh`), **WMH-SynthSeg** (`wmh_synthseg.sh`), **segcsvdWMH** (`wmh_segcsvd.sh`), **SHIVA-WMH** (`wmh_shiva.sh`), **MARS-WMH** (`wmh_mars.sh`).
+- **AANSegment** (`brainstem_aanseg.sh`) — **exploratory** FreeSurfer arousal-network nuclei segmentation; ≤1 mm input only, large-lesion-sensitive.
+- **Post-detection false-positive filter** (`fp_filter.sh`) — config-gated FP suppression operating *after* detection, complementing the CSF/partial-volume exclusion that runs *before* thresholding. Lossy (removes true small lesions) — OFF by default for the brainstem.
 
-> ⚠️ **None of these is validated in the brainstem/pons.** Published WMH/lesion SOTA is supratentorial; the posterior fossa is repeatedly "under-evaluated", and Ryu et al. 2025 report DL is "relatively poor" there. Treat optional modules as exploratory, keep conservative pons QA with a human in the loop, and locally validate before relying on any tool.
+> ⚠️ **None of the optional WMH/lesion modules is validated in the brainstem/pons.** Published WMH/lesion SOTA is supratentorial; the posterior fossa is repeatedly "under-evaluated", and Ryu et al. 2025 report DL is "relatively poor" there. Treat optional modules as exploratory, keep conservative pons QA with a human in the loop, and locally validate before relying on any tool. These add-ons only **corroborate** — none alters the primary per-region-GMM FLAIR detection.
+
+## Multi-Modal Corroboration (SWI / DWI / T2 end-to-end)
+
+Beyond the T1/FLAIR backbone, the pipeline brings the **secondary** T2-weighted modalities — SWI magnitude, the DERIVED DWI **trace** + **ADC** (not raw 4D diffusion), and a true T2 — all the way through, **only when they are present** (a T1+FLAIR-only study is byte-identically unchanged):
+
+- **Contrast-matched cascaded registration** (`registration.sh:register_contrast_matched_cascade`, `CONTRAST_MATCHED_REGISTRATION=true`, default on/graceful) anchors each T2-weighted secondary to its nearest same-contrast 3D structural rather than directly to T1 — the cascade is `T1 ← FLAIR ← {T2, DWI, ADC, SWI}` (anchors set by `CONTRAST_ANCHOR_MAP`). Each secondary's transform is **composed** with the FLAIR→T1 transforms so it reaches T1/MNI in a single `antsApplyTransforms` (no double interpolation); both the composed **forward and inverse** transform lists are persisted (the inverse is needed by the downstream DICOM cluster→source mapping when it is re-enabled).
+- **Cross-modal corroboration** (`cross_modal_analysis.sh` + `cross_modal_sample.py`, `CROSS_MODAL_ANALYSIS_ENABLED=true`) samples each co-registered secondary inside every PRIMARY FLAIR cluster ROI and flags **DWI restriction** (trace z ↑ AND ADC z ↓ → acute/ischemic), **SWI hypointensity** (→ hemorrhage/microbleed), and **T2 hyperintensity** (→ corroborates FLAIR). Each modality is z-scored within the brainstem ROI so thresholds (`CROSS_MODAL_*_Z`) are scanner-independent. This is corroboration **on top of** the primary detection — it never re-detects lesions and never alters the primary mask. Outputs a per-cluster table + summary under `analysis/cross_modal/`.
+
+## Output & Reporting Layer
+
+A final **reporting** stage (Step 8.5, `reporting.sh` + `reporting_tables.py`, after analysis/QA/viz) aggregates every merged capability over the **canonical results tree**. It **discovers** outputs wherever modules wrote them (it does not require fixed paths) and emits, all gated/graceful/idempotent:
+
+- **Summary tables** under `reports/tables/`, each as **CSV/TSV + HTML**: `hyperintensity_per_region`, `wmh_tool_volumes`, `segmentation_volumes` (HO / FS / multi-atlas / SynthSeg-aseg / subregions), `cross_modal`, `freesurfer_morphometry` (aseg volumes + eTIV), and a `run_manifest`; plus a machine-readable `manifest.json`.
+- **Report visualizations** under `visualizations/`: per-method segmentation overlays, hyperintensity clusters on FLAIR, and a multi-modal montage (FLAIR/DWI/SWI/T2).
+- **Top-level report** `reports/brainstemx_report.html` (+ `.md` fallback) — a one-stop dashboard embedding all populated tables, the run manifest, and the discovered visualizations.
+
+Heavy parsing/rendering lives in the stdlib-only `reporting_tables.py` (run via `uv`); the bash layer owns only the FSL-dependent volume sidecars. A minimal T1+FLAIR run still produces a valid smaller report; absent sections render as "No data". Governed by `REPORTING_ENABLED` (default `true`); report visualizations honour `SKIP_VISUALIZATION`. Full tree + table schemas: [output_structure.md](output_structure.md).
 
 ## Recent Advances & Roadmap (2024–2026)
 
@@ -142,8 +162,9 @@ This section situates BrainStem X against the 2024–2026 literature. Items mark
 ### Advanced Segmentation
 
 #### Brainstem Segmentation Approaches
-- **FreeSurfer brainstem substructures** (Iglesias 2015 `segmentBS`/`brainstemSsLabels`) for the detailed subdivision into midbrain / pons / medulla / SCP, selected via `BRAINSTEM_SEGMENTATION_METHOD` (default `freesurfer`)
-- **Harvard-Oxford subcortical atlas** (index 7, tightened to `maxprob-thr25`) used only for the gross brainstem extent mask — also the fallback when FreeSurfer/recon-all/license is unavailable (`BRAINSTEM_SEGMENTATION_METHOD=atlas`)
+- **Parallel multi-method mode** (`BRAINSTEM_SEGMENTATION_METHOD=all`, the **default**) runs the HO gross-extent, FreeSurfer-substructure, multi-atlas, and SynthSeg+ paths concurrently and feeds their union to per-region detection; per-path `SEG_RUN_*` toggles
+- **FreeSurfer brainstem substructures** (Iglesias 2015 `segmentBS`/`brainstemSsLabels`) for the detailed subdivision into midbrain / pons / medulla / SCP (single-method value `freesurfer`)
+- **Harvard-Oxford subcortical atlas** (index 7, tightened to `maxprob-thr25`) used for the gross brainstem extent mask — also the fallback when FreeSurfer/recon-all/license is unavailable (`BRAINSTEM_SEGMENTATION_METHOD=atlas`)
 - **Atlas-to-subject transformation** preserving native resolution by bringing the MNI HO atlas to subject space; FreeSurfer segments the subject's own T1 directly
 
 #### Subject-Specific Refinement
@@ -214,7 +235,8 @@ This section situates BrainStem X against the 2024–2026 literature. Items mark
 ### Advanced Segmentation (segmentation.sh)
 
 - **Harvard-Oxford gross brainstem extent** using subcortical index 7, tightened to `maxprob-thr25`, as the extent mask and the fallback when FreeSurfer is unavailable
-- **FreeSurfer brainstem substructures** (Iglesias 2015 `segmentBS`/`brainstemSsLabels`) for the detailed subdivision into midbrain / pons / medulla / SCP, selected via `BRAINSTEM_SEGMENTATION_METHOD` (default `freesurfer`, fallback `atlas`); gated by an FS↔HO agreement (Dice + leakage) QC check
+- **FreeSurfer brainstem substructures** (Iglesias 2015 `segmentBS`/`brainstemSsLabels`) for the detailed subdivision into midbrain / pons / medulla / SCP, gated by an FS↔HO agreement (Dice + leakage) QC check
+- **Parallel multi-method mode** (default `BRAINSTEM_SEGMENTATION_METHOD=all`) runs the HO, FreeSurfer-substructure, multi-atlas, and SynthSeg+ paths concurrently and union-feeds them to per-region detection; per-path `SEG_RUN_*` toggles. Single-method values (`freesurfer`, `atlas`/`harvard_oxford`, `multi_atlas`/`bianciardi`) remain available and mutually exclusive
 - **Atlas-to-subject transformation** preserving native resolution by bringing the MNI HO atlas to subject space; FreeSurfer segments the subject's own T1 directly
 - **Subject-specific refinement** using tissue segmentation (Atropos/FAST) to address shape variance in hydrocephalus & Chiari cases
 - **FLAIR enhancement integration** creating both T1 and FLAIR intensity versions for multi-modal analysis
@@ -230,7 +252,8 @@ This section situates BrainStem X against the 2024–2026 literature. Items mark
 - **Connectivity weighting** for refined detection using 3D morphological operations
 - **Multi-threshold hyperintensity detection** with configurable standard deviation multipliers and minimum cluster size filtering
 - **Cross-modality validation** analyzes both FLAIR hyperintensities and T1 hypointensities with statistical correlation
-- **Optional supervised / DL WMH modules** (all default-off), each intersecting results with the brainstem mask: FSL BIANCA (`wmh_bianca.sh`), LST-AI + FreeSurfer SAMSEG (`wmh_lst_samseg.sh`), WMH-SynthSeg (`wmh_synthseg.sh`), segcsvdWMH (`wmh_segcsvd.sh`), SHIVA-WMH (`wmh_shiva.sh`), MARS-WMH (`wmh_mars.sh`); plus a post-detection false-positive filter (`fp_filter.sh`)
+- **Cross-modal corroboration** (`cross_modal_analysis.sh`, default on/graceful) annotates each primary FLAIR cluster with co-registered SWI/DWI-trace/ADC/T2 evidence (DWI restriction → acute, SWI → hemorrhage, T2 → corroborates), without altering the primary mask
+- **Optional supervised / DL WMH modules** (each self-gated, no-op until its tool/data is present), each intersecting results with the brainstem mask: FSL BIANCA (`wmh_bianca.sh`), LST-AI + FreeSurfer SAMSEG (`wmh_lst_samseg.sh`), WMH-SynthSeg (`wmh_synthseg.sh`), segcsvdWMH (`wmh_segcsvd.sh`), SHIVA-WMH (`wmh_shiva.sh`), MARS-WMH (`wmh_mars.sh`); plus a post-detection false-positive filter (`fp_filter.sh`, off by default)
 
 ### Advanced Visualization & QA (visualization.sh, qa.sh)
 
@@ -311,8 +334,9 @@ This section situates BrainStem X against the 2024–2026 literature. Items mark
 - **Enhanced registration validation** comprehensive metrics including cross-correlation, mutual information, normalized CC
 
 ### Stage 5: Brainstem Segmentation
+- **Parallel multi-method segmentation** (default `BRAINSTEM_SEGMENTATION_METHOD=all`): HO gross extent + FreeSurfer substructures + multi-atlas nuclei + SynthSeg+ run as concurrent, independent, non-fatal paths whose masks are union-fed and provenance-tagged; per-path `SEG_RUN_*` toggles. Single-method values (`freesurfer`, `atlas`/`harvard_oxford`, `multi_atlas`/`bianciardi`) remain available
 - **Harvard-Oxford gross extent** subcortical atlas (index 7, `maxprob-thr25`) for the brainstem boundary mask and as the fallback
-- **FreeSurfer brainstem substructures** (Iglesias 2015 `segmentBS`) for midbrain / pons / medulla / SCP, selected via `BRAINSTEM_SEGMENTATION_METHOD` (default `freesurfer`, fallback `atlas`) and gated by an FS↔HO agreement QC check
+- **FreeSurfer brainstem substructures** (Iglesias 2015 `segmentBS`) for midbrain / pons / medulla / SCP, gated by an FS↔HO agreement QC check; plus the full FreeSurfer recon harvest (aseg/wmparc/aparc stats, eTIV, optional subregions) and ML methods (SynthSeg+, SynthSR, sclimbic)
 - **Subject-specific refinement** using tissue segmentation to address shape variance in pathological cases
 - **Native space preservation** maintains segmentation accuracy in subject's original high-resolution space
 - **FLAIR integration** creates both T1 and FLAIR intensity versions for comprehensive analysis
@@ -323,13 +347,15 @@ This section situates BrainStem X against the 2024–2026 literature. Items mark
 - **CSF / partial-volume exclusion** using the FSL FAST CSF PVE map before thresholding
 - **Multi-threshold detection** configurable SD multipliers (1.5-3.0) with minimum cluster size filtering
 - **Cross-modality validation** analyzes hyperintensity patterns across T1/T2/FLAIR with statistical correlation
-- **Optional supervised / DL WMH** BIANCA, LST-AI + SAMSEG, WMH-SynthSeg, segcsvdWMH, SHIVA-WMH, MARS-WMH modules (all default-off), intersected with the brainstem mask; optional `fp_filter.sh` post-detection FP suppression
+- **Cross-modal corroboration** samples each co-registered secondary (SWI/DWI-trace/ADC/T2) inside every primary FLAIR cluster and flags DWI restriction (→ acute), SWI hypointensity (→ hemorrhage), and T2 hyperintensity (→ corroborates) — on top of, never altering, the primary detection
+- **Optional supervised / DL WMH** BIANCA, LST-AI + SAMSEG, WMH-SynthSeg, segcsvdWMH, SHIVA-WMH, MARS-WMH modules (each self-gated, no-op until its tool/data is present), intersected with the brainstem mask; optional `fp_filter.sh` post-detection FP suppression (off by default)
 - **Native-to-standard space mapping** enables analysis in both subject native and standardized coordinates
-- **DICOM cluster backtrace** creates coordinate lookup tables for medical imaging viewer navigation
+- **DICOM cluster backtrace** — the cluster→DICOM-source mapping (`dicom_cluster_mapping.sh`) is currently **gated off** (`RUN_DICOM_MAPPING=false`) pending a rewrite; a normal run skips it
 
 ### Stage 7: Advanced Visualization & Reporting
 - **3D volume rendering** with customizable opacity and color mapping for hyperintensity clusters
 - **Multi-threshold comparison** side-by-side visualizations across different detection thresholds
+- **Report visualizations** per-method segmentation overlays, hyperintensity-on-FLAIR, and a multi-modal montage (FLAIR/DWI/SWI/T2)
 - **Interactive QA interface** real-time FSLView integration for immediate visual feedback
 - **Comprehensive HTML reporting** with embedded visualizations and quantitative metrics
 
@@ -338,6 +364,11 @@ This section situates BrainStem X against the 2024–2026 literature. Items mark
 - **Comprehensive QA reporting** 20+ validation checks including coordinate space consistency
 - **Batch processing summary** CSV reports with volume metrics and registration quality scores
 - **Error tracking and diagnostics** detailed logging for troubleshooting and quality assurance
+
+### Stage 8.5: Aggregation & Reporting Layer
+- **Summary tables** under `reports/tables/` as CSV/TSV + HTML (per-region hyperintensity, WMH tool volumes, segmentation volumes, cross-modal, FreeSurfer morphometry, run manifest)
+- **Top-level dashboard** `reports/brainstemx_report.html` (+ `.md` fallback) embeds all populated tables and discovered visualizations; `manifest.json` records which sections were populated
+- **Discovers** outputs wherever modules wrote them; gated/graceful/idempotent (`REPORTING_ENABLED`). See [output_structure.md](output_structure.md)
 
 ## Module Implementation Reference
 
@@ -351,9 +382,14 @@ This section situates BrainStem X against the 2024–2026 literature. Items mark
 - Preprocessing → [`src/modules/preprocess.sh`](../src/modules/preprocess.sh:1)
 - Registration → [`src/modules/registration.sh`](../src/modules/registration.sh:1)
 - Brainstem Segmentation (HO gross extent + FreeSurfer substructures) → [`src/modules/segmentation.sh`](../src/modules/segmentation.sh:1), [`src/modules/brainstem_freesurfer.sh`](../src/modules/brainstem_freesurfer.sh:1)
-- Comprehensive Analysis → [`src/modules/analysis.sh`](../src/modules/analysis.sh:1)
+- Multi-Atlas Labeling (Bianciardi/CIT168/AAL3) → [`src/modules/multi_atlas.sh`](../src/modules/multi_atlas.sh:1)
+- FreeSurfer Recon Harvest + ML methods (SynthSeg+/SynthSR/sclimbic) → [`src/modules/freesurfer_harvest.sh`](../src/modules/freesurfer_harvest.sh:1)
+- Comprehensive Analysis → [`src/modules/analysis.sh`](../src/modules/analysis.sh:1), [`src/modules/gmm_threshold.py`](../src/modules/gmm_threshold.py:1)
+- Cross-Modal Corroboration → [`src/modules/cross_modal_analysis.sh`](../src/modules/cross_modal_analysis.sh:1), [`src/modules/cross_modal_sample.py`](../src/modules/cross_modal_sample.py:1)
+- Optional WMH Modules → [`src/modules/wmh_bianca.sh`](../src/modules/wmh_bianca.sh:1), [`src/modules/wmh_lst_samseg.sh`](../src/modules/wmh_lst_samseg.sh:1), [`src/modules/wmh_synthseg.sh`](../src/modules/wmh_synthseg.sh:1), [`src/modules/wmh_segcsvd.sh`](../src/modules/wmh_segcsvd.sh:1), [`src/modules/wmh_shiva.sh`](../src/modules/wmh_shiva.sh:1), [`src/modules/wmh_mars.sh`](../src/modules/wmh_mars.sh:1), [`src/modules/brainstem_aanseg.sh`](../src/modules/brainstem_aanseg.sh:1), [`src/modules/fp_filter.sh`](../src/modules/fp_filter.sh:1)
 - Enhanced Registration Validation → [`src/modules/enhanced_registration_validation.sh`](../src/modules/enhanced_registration_validation.sh:1)
 - Advanced Visualization → [`src/modules/visualization.sh`](../src/modules/visualization.sh:1)
+- Aggregation & Reporting Layer → [`src/modules/reporting.sh`](../src/modules/reporting.sh:1), [`src/modules/reporting_tables.py`](../src/modules/reporting_tables.py:1)
 - Quality Assurance → [`src/modules/qa.sh`](../src/modules/qa.sh:1)
 - Parallel Processing → [`src/modules/fast_wrapper.sh`](../src/modules/fast_wrapper.sh:1)
 
@@ -420,7 +456,7 @@ The segmentation module implements a **two-tier approach** (gross extent + subst
 
 2. **FreeSurfer Brainstem Substructures (Detailed Subdivision)**
    - Iglesias 2015 `segmentBS`/`brainstemSsLabels` → midbrain / pons / medulla / SCP masks in subject space (FreeSurfer segments the subject's own T1, no warp)
-   - Selected via `BRAINSTEM_SEGMENTATION_METHOD` (default `freesurfer`; `atlas`/`harvard_oxford` = gross mask only)
+   - Run by default: the default `BRAINSTEM_SEGMENTATION_METHOD=all` mode runs this path concurrently with the HO / multi-atlas / SynthSeg+ paths (toggle with `SEG_RUN_FREESURFER`); also selectable as the single-method value `freesurfer` (`atlas`/`harvard_oxford` = gross mask only)
    - Gated by an FS↔HO agreement check (Dice + leakage); on disagreement or missing FreeSurfer/license, falls back to the HO gross mask and flags low confidence
    - Talairach has been removed entirely (single 1988 post-mortem brain; largest MNI-mapping error inferiorly/posteriorly — worst exactly in the brainstem)
 
@@ -454,10 +490,10 @@ The analysis module implements **region-based hyperintensity detection**:
    - Minimum cluster size filtering (configurable, default 27 voxels)
    - Morphological closing operations to eliminate noise
 
-5. **Optional Supervised / DL WMH Modules** (all default-off)
+5. **Optional Supervised / DL WMH Modules** (each self-gated; no-op until its tool/model/training data is present)
    - Each intersects results with the brainstem mask: FSL BIANCA (`wmh_bianca.sh`), LST-AI + FreeSurfer SAMSEG (`wmh_lst_samseg.sh`), WMH-SynthSeg (`wmh_synthseg.sh`), segcsvdWMH (`wmh_segcsvd.sh`), SHIVA-WMH (`wmh_shiva.sh`), MARS-WMH (`wmh_mars.sh`)
-   - A post-detection false-positive filter (`fp_filter.sh`) can be applied afterward (config-gated)
-   - **None is validated in the brainstem** — keep conservative pons QA / human-in-the-loop
+   - A post-detection false-positive filter (`fp_filter.sh`) can be applied afterward (config-gated; off by default — lossy for small lesions)
+   - **None is validated in the brainstem** — keep conservative pons QA / human-in-the-loop; these corroborate, they never alter the primary detection
 
 ## Quality Assurance Details
 

--- a/docs/dicom_cluster_mapping_implementation.md
+++ b/docs/dicom_cluster_mapping_implementation.md
@@ -1,5 +1,15 @@
 # DICOM Cluster Mapping Implementation
 
+> **Status (2026): GATED OFF pending a rewrite.** The cluster→DICOM-source mapping
+> stage is currently disabled by default — `RUN_DICOM_MAPPING=false` in
+> `config/default_config.sh`, and `pipeline.sh` skips the stage unless
+> `RUN_DICOM_MAPPING=true`. The module (`src/modules/dicom_cluster_mapping.sh`)
+> and the design below are retained for reference, but a normal run does **not**
+> produce the `dicom_cluster_mapping/` outputs described here. The contrast-matched
+> cascade now persists the composed **inverse** transforms this stage will need
+> when it is re-enabled. Treat the "ready for production" / "happens automatically
+> in Step 5" claims below as describing the *intended* (currently inactive) flow.
+
 ## Overview
 
 This document describes the implementation of cluster-to-DICOM coordinate mapping functionality for the brainstem MRI analysis pipeline. This feature addresses the architectural gap where hyperintense clusters detected in processed NIfTI space could not be mapped back to their source DICOM files for visualization in medical imaging viewers.

--- a/docs/multi_atlas_integration_spec.md
+++ b/docs/multi_atlas_integration_spec.md
@@ -174,12 +174,15 @@ enabled atlas:
 
 ## Dispatch hook
 
-`config/default_config.sh` documents two new `BRAINSTEM_SEGMENTATION_METHOD`
-values: **`multi_atlas`** and its alias **`bianciardi`**.
-`segmentation.sh:extract_brainstem_final` always produces the Harvard-Oxford
-gross extent first, then — for these methods — calls
-`run_multi_atlas_brainstem`. The `freesurfer` and `atlas`/`harvard_oxford`
-cases are unchanged; an unknown value still falls back to the HO gross mask.
+`config/default_config.sh` documents the `BRAINSTEM_SEGMENTATION_METHOD`
+values that trigger this path: **`multi_atlas`** and its alias **`bianciardi`**
+(single-method), and the default **`all`** mode, in which the multi-atlas warp
+runs as one of the concurrent parallel paths whenever `SEG_RUN_MULTI_ATLAS=true`
+(the default). `segmentation.sh:extract_brainstem_final` always produces the
+Harvard-Oxford gross extent first, then — for these methods (or in `all` mode
+with the multi-atlas path enabled) — calls `run_multi_atlas_brainstem`. The
+`freesurfer` and `atlas`/`harvard_oxford` single-method cases are unchanged; an
+unknown value still falls back to the HO gross mask.
 
 `multi_atlas.sh` is sourced by both `segmentation.sh` and `pipeline.sh`.
 


### PR DESCRIPTION
Surgical review/update of the **narrative documentation** so it matches the fully-merged pipeline (this session's PRs). Edits are confined to `README.md` and `docs/*.md` — **no code, no `CLAUDE.md`**.

## What changed, per file

**`README.md`**
- Key Features: added cross-modal corroboration, contrast-matched cascade, parallel multi-method segmentation (`all` default), FreeSurfer recon harvest + ML methods, and the reporting layer; noted DICOM cluster→source mapping is gated off; WMH bullet reframed from "default OFF" to "exploratory; none validated in the brainstem".
- Pipeline-stages list: stages 4–7 updated (cascade, parallel `all`-mode seg, per-region GMM + cross-modal, report viz) + a Step-8.5 reporting note.
- Documentation links: added `output_structure.md` + `brainstem_freesurfer_segmentation_spec.md`. Acknowledgments: FreeSurfer line now lists harvest + SynthSeg+/SynthSR/sclimbic.

**`docs/README.md`**
- Section retitled to "Parallel Multi-Method Segmentation…"; documents `all` default + `SEG_RUN_*` toggles + provenance tagging; added FS recon-harvest + ML-methods bullet.
- New "Multi-Modal Corroboration (SWI/DWI/T2)" and "Output & Reporting Layer" sections.
- Stage 5/6/7 updated + new Stage 8.5; "(all default-off)" WMH claims → self-gated; "default `freesurfer`" framings → `all`; DICOM-mapping section marked gated-off; module-reference list extended (multi_atlas, freesurfer_harvest, cross_modal, wmh_*, fp_filter, aanseg, reporting).

**`docs/TECHNICAL_OVERVIEW.md`** — same set of corrections as `docs/README.md` (parallel seg default, FS harvest+ML, multi-modal + reporting sections, stage 5/6/7 + 8.5, self-gated WMH, DICOM gated-off, module-reference list).

**`docs/multi_atlas_integration_spec.md`** — Dispatch-hook section now notes the multi-atlas warp also runs in the default `all` mode (when `SEG_RUN_MULTI_ATLAS=true`), not only the `multi_atlas`/`bianciardi` single-method values.

**`docs/README_scan_selection.md`** — "four"→"five" modes (the list already had five); added a "Secondary-Modality Discovery (SWI/DWI-trace/ADC/T2)" section for `discover_secondary_modality_specs`.

**`docs/dicom_cluster_mapping_implementation.md`** — added a top status banner: feature is GATED OFF (`RUN_DICOM_MAPPING=false`) pending a rewrite; design below describes the intended (currently inactive) flow.

## Docs already accurate (left as-is)
`docs/output_structure.md`, `docs/brainstem_freesurfer_segmentation_spec.md`, `docs/complete_pipeline_analysis_and_fix_plan.md`, `docs/synthetic_test_data.md` already reflect the merged state. Design/historical/test docs (`sota-comparison`, `multiaxis_improvements`, `orientation-distortion-correction`, `planned_improvements_1a`, `adaptive_reference_space_selection_plan`, `map-nifti-to-dicom-slices`, `BUGS_FOUND`, `ds004199_validation_dataset`, `README_reference_space_selection`, `README_tests`) make no false live-capability claims and were left untouched.

## Verification
- `git ls-files '*.sh' | xargs -I{} bash -n {}` → OK (no code touched).
- `bash src/pipeline.sh --help | grep -q "Usage:"` → OK.
- Markdown: all code fences balanced; **all `.md`→`.md` links resolve** (incl. the two new ones).
- `git grep -niE 'talairach' -- '*.md'` → only removal/legacy/rationale notes; no stale "live capability" claims.

## Flagged (potential pre-existing doc/convention issue, NOT introduced here)
- `docs/README.md`'s "Complete Module Implementation" list uses editor-style `src/...:1` deep-links that do not resolve as relative paths from `docs/` (they resolve from repo root). This convention is **pre-existing at HEAD**; I matched it for the new entries to stay consistent rather than diverge mid-list. The sibling list in `docs/TECHNICAL_OVERVIEW.md` uses the correct `../src/...:1` form. Worth normalizing `docs/README.md` to `../src/...` in a follow-up, but it was out of scope for a surgical narrative pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
