### PR TITLE
Pre-init dependency check: enumerate + report all tools/modules/containers/atlases (required + optional)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -46,9 +46,10 @@ src/modules/             # 35+ modules, each sourced by pipeline.sh
   brain_extraction.sh    # SynthStrip primary (→ANTs→BET fallback) + robustfov FOV-normalization + posterior-fossa QC
   registration.sh        # multi-stage ANTs registration (~600 line register_to_reference())
   segmentation.sh        # Harvard-Oxford gross extent (thr25) + FreeSurfer brainstem substructures; optional multi-atlas warp (Bianciardi/CIT168/AAL3)
-  brainstem_freesurfer.sh # FreeSurfer segmentBS substructures (Iglesias 2015): midbrain/pons/medulla/SCP in native space
+  brainstem_freesurfer.sh # FreeSurfer recon-all → segmentBS/segment_subregions substructures (Iglesias 2015): midbrain/pons/medulla/SCP in native space (+ topology-salvage of a recon-all that died in the surface stages)
+  freesurfer_harvest.sh  # harvests EVERYTHING from the SAME recon-all: aseg/wmparc/aparc + ML methods (mri_synthseg/mri_synthsr) + optional subregion/sclimbic/hypothalamus segs + aseg/eTIV stats (feeds aseg-CSF into FP exclusion)
+  brainstem_aanseg.sh    # EXPLORATORY: FreeSurfer SegmentAAN.sh arousal-network nuclei (≤1mm only; off by default)
   multi_atlas.sh         # Bianciardi + CIT168 + AAL3 → subject-space per-region masks (SyN→MNI + GenericLabel)
-  brainstem_aanseg.sh    # EXPLORATORY: FreeSurfer AANSegment arousal-network nuclei (≤1mm only; off by default)
   analysis.sh            # hyperintensity detection, cluster analysis
   gmm_threshold.py       # standalone GMM thresholder (called by analysis.sh)
   cross_modal_analysis.sh # MULTI-MODAL: per-cluster corroboration of FLAIR clusters with co-registered SWI/DWI-trace/ADC/T2 (default on, graceful)
@@ -65,7 +66,7 @@ src/modules/             # 35+ modules, each sourced by pipeline.sh
   reporting_tables.py    # stdlib-only aggregator behind reporting.sh (parses provenance/summaries, renders tables + top-level report; called via uv)
   qa.sh                  # 20+ validation checks
 config/default_config.sh # all pipeline defaults (has include guard)
-tests/                   # 23 bash test scripts + 2 pytest modules
+tests/                   # 29 bash test scripts (incl. test_dependency_report_unit.sh) + 2 pytest modules
 ```
 
 ## Code style
@@ -125,6 +126,17 @@ The single-method values (`freesurfer`/`multi_atlas`/`bianciardi`/`atlas`/`harva
 **Atlas-on-disk prerequisite** — `atlas`/`multi_atlas`/`bianciardi` need the atlases pre-downloaded under `$FSLDIR/data/atlases` (`ATLAS_DIR`): `Bianciardi/`, `CIT168/`, `AAL3/`, `HarvardOxford/`. The startup `check_atlas_availability` step (`environment.sh`, called from `pipeline.sh`) reports presence/absence per atlas and warns if the selected method needs a missing one; absence is **non-fatal** — the pipeline degrades to the HO gross mask. Override layout via `ATLAS_{BIANCIARDI,CIT168,AAL3,HARVARDOXFORD}_REL`.
 
 **Optional WMH / seg modules** — supervised/DL add-ons, each intersected with the brainstem mask, each self-gated (graceful WARNING + skip when its tool/training-data/model is absent) and called non-fatally from `pipeline.sh`: `wmh_bianca.sh` (FSL BIANCA), `wmh_lst_samseg.sh` (LST-AI + SAMSEG), `wmh_synthseg.sh` (WMH-SynthSeg), `wmh_segcsvd.sh` (segcsvdWMH), `wmh_shiva.sh` (SHIVA-WMH), `wmh_mars.sh` (MARS-WMH); plus `brainstem_aanseg.sh` (EXPLORATORY AANSegment, ≤1 mm only) and the post-detection `fp_filter.sh`. **Default-ON** (master switch `true`, no-op until their tool/data is present): `WMH_SYNTHSEG_ENABLED`, `WMH_SHIVA_ENABLED`, `WMH_MARS_ENABLED`, `BRAINSTEM_AANSEG_ENABLED`, and `WMH_BIANCA_ENABLED` (the last is a no-op until `BIANCA_TRAINING_MASTERFILE`/`BIANCA_LOAD_CLASSIFIER` is set). **Default-OFF** (opt-in via env): `WMH_LSTAI_ENABLED`, `WMH_SAMSEG_ENABLED`, `WMH_SEGCSVD_ENABLED`, `FP_FILTER_ENABLED` (lossy — removes true small lesions; keep off for brainstem). All master switches honour env overrides (`${VAR:-default}`). These add-ons only CORROBORATE — none alters the primary FLAIR detection. None is validated in the brainstem — keep conservative pons QA / human-in-the-loop.
+
+## Pre-init dependency check (required + optional inventory)
+
+At startup `pipeline.sh::main` runs `check_all_dependencies` (`environment.sh`) — the single authoritative pre-init dependency report. It enforces the genuine **core** requirements (fatal if missing) and then calls `check_optional_dependencies` to print a **report-only** inventory of EVERY optional tool/package/container/atlas the pipeline can use, so the user sees upfront exactly what is available and which optional features will run vs skip.
+
+- **Output format** — one line per dependency: `name | REQ/OPT | present/absent (+path/version) | gates: <feature>`, grouped into `Core (REQUIRED)`, `FreeSurfer (OPTIONAL)`, `MRtrix (OPTIONAL)`, `WMH / ML tools (OPTIONAL)`, `Container runtimes & images (OPTIONAL)`, `Atlases (OPTIONAL)`.
+- **Core (REQUIRED, fatal):** FSL (`fslmaths`/`flirt`/`fast`/`bet`/`robustfov`/`cluster`/`fslstats`/`fslinfo`), ANTs (`antsRegistration`/`antsApplyTransforms`/`N4BiasFieldCorrection`/`DenoiseImage`/`Atropos`/`ThresholdImage`/`ImageMath`/`ResampleImage`/`antsRegistrationSyN.sh`), `dcm2niix`, `c3d`, and Python via `uv` (`nibabel`/`numpy`/`sklearn`). The fatal enforcement still lives in `check_ants`/`check_fsl`/`check_c3d`/`check_dcm2niix`; the inventory mirrors them as REQ for one combined view.
+- **Optional (report-only, NEVER fatal):** FreeSurfer (`FREESURFER_HOME`+license, `recon-all`, `segmentBS.sh`/`segment_subregions`, `SegmentAAN.sh`, `mri_synthseg`, `mri_synthsr`, `mri_synthstrip`, `mri_WMHsynthseg`, `mri_sclimbic_seg`, `mri_segment_hypothalamic_subunits`, `run_samseg`); MRtrix (`dwidenoise`, `mrdegibbs`, `dwifslpreproc`, `dwibiascorrect`, `dwi2mask`, `mrconvert`); WMH/ML (`bianca`, `make_bianca_mask`, `python:antspynet` → SHIVA, `lst`/`lst_ai` → LST-AI); container runtimes (`docker`, `apptainer`/`singularity`) AND the specific images the WMH modules reference (segcsvd, LST-AI, SHiVAi, MARS-WMH, MARS-brainstem) probed via `docker image inspect` / `.sif`-on-disk with **short timeouts** so a wedged Docker daemon can never hang startup; atlases (HarvardOxford, FSL standard templates — the full Bianciardi/CIT168/AAL3 probe is done by `check_atlas_availability`).
+- **Config cross-reference** — the inventory reads the feature toggles (`BRAINSTEM_SEGMENTATION_METHOD`, `SEG_RUN_FREESURFER`/`SEG_RUN_MULTI_ATLAS`/`SEG_RUN_SYNTHSEG`, `USE_SYNTHSR`, `PROCESS_DWI`, `WMH_*_ENABLED`, `MARS_BRAINSTEM_ENABLED`, `BRAINSTEM_AANSEG_ENABLED`). When a feature is **enabled but its dependency is absent** it logs a clear `WARNING` ("X is ENABLED but <tool> not found — that feature will be SKIPPED") and adds it to the end-of-section **skip list**. The summary block prints present/absent counts and the concise list of optional features that WILL be skipped.
+- **Container image env vars / defaults** (override to point at your pull / `.sif`): `SEGCSVD_DOCKER_IMAGE` (`segcsvd_rc03`) / `SEGCSVD_CONTAINER_IMAGE` (.sif); `LSTAI_DOCKER_IMAGE` (`jqmcginnis/lst-ai:latest`); `SHIVA_WMH_CONTAINER_IMAGE` (docker name OR .sif); `MARS_WMH_DOCKER_IMAGE` (`ghcr.io/miac-research/wmh-nnunet:latest`) / `MARS_WMH_SIF`; `MARS_BRAINSTEM_DOCKER_IMAGE` (`ghcr.io/miac-research/dl-brainstem:latest`) / `MARS_BRAINSTEM_SIF`.
+- **Implementation** — helpers in `environment.sh`: `_dep_probe_cmd` (command→path), `_dep_probe_pymodule` (`uv run --no-sync python -c "import …"`, bounded), `_dep_probe_image` (docker/`.sif`, bounded), `_dep_timeout` (portable `timeout`/`gtimeout`/watchdog bound), `_dep_report` (matrix line + enabled-but-missing WARNING + counters). Unit-tested in `tests/test_dependency_report_unit.sh` (mocked present/absent, skip-list, non-fatal). The CI smoke test still greps the preserved strings `Comprehensive Pipeline Dependency Check` and `Dependency Check Summary`.
 
 ## Multi-modal (SWI / DWI / T2) end-to-end
 

--- a/src/modules/environment.sh
+++ b/src/modules/environment.sh
@@ -800,9 +800,16 @@ check_all_dependencies() {
     fi
   fi
   
+  # Optional / feature-gated dependency inventory (report-only, NON-fatal).
+  # Enumerates EVERY optional tool, container image, Python package and atlas the
+  # pipeline can use, grouped by feature, and cross-references the config toggles
+  # so the user sees upfront what will run vs skip. Never increments error_count
+  # (optional deps must never abort the run); it only emits informational lines.
+  check_optional_dependencies || true
+
   # Summary
   log_formatted "INFO" "==== Dependency Check Summary ===="
-  
+
   if [ $error_count -eq 0 ] && [ $warning_count -eq 0 ]; then
     log_formatted "SUCCESS" "All required dependencies are installed and configured correctly!"
     return 0
@@ -817,6 +824,319 @@ check_all_dependencies() {
     log_formatted "INFO" "Please install the missing dependencies before running the processing pipeline."
     return 1
   fi
+}
+
+# ------------------------------------------------------------------------------
+# Optional / feature-gated dependency inventory (report-only, NON-fatal)
+# ------------------------------------------------------------------------------
+# Enumerates EVERY optional external tool, Python package, container image and
+# atlas that any pipeline module can use, grouped by feature, and cross-checks
+# the config toggles that gate each feature. Output is a one-line-per-dependency
+# matrix:
+#
+#   <name> | REQ|OPT | present|absent (+path/version) | gates: <feature>
+#
+# This NEVER aborts the pipeline (every dependency here is optional); genuine
+# core requirements are still enforced by check_all_dependencies above. When a
+# feature is ENABLED via config but its dependency is missing, a clear WARNING
+# is logged ("X enabled but <tool> not found — will skip"). At the end it prints
+# counts and the concise list of optional features that WILL be skipped.
+
+# Probe a single command. Echoes "present|<path>" or "absent". Always returns 0.
+_dep_probe_cmd() {
+  local cmd="$1"
+  local path
+  if path="$(command -v "$cmd" 2>/dev/null)"; then
+    printf 'present|%s' "$path"
+  else
+    printf 'absent'
+  fi
+}
+
+# Probe an importable Python module via uv (Python 3.12.8; never bare python).
+# --no-sync so a mere availability probe never triggers a slow/network sync.
+# Short timeout so a broken environment can never hang startup. Echoes
+# "present" or "absent". Always returns 0.
+_dep_probe_pymodule() {
+  local module="$1"
+  if ! command -v uv >/dev/null 2>&1; then
+    printf 'absent'
+    return 0
+  fi
+  if _dep_timeout 25 uv run --no-sync python -c "import ${module}" >/dev/null 2>&1; then
+    printf 'present'
+  else
+    printf 'absent'
+  fi
+}
+
+# Portable bounded-time runner. Uses `timeout`/`gtimeout` when present; otherwise
+# falls back to a background-process watchdog so container/python probes can
+# never hang the startup check. Args: <seconds> <cmd...>. Returns the command's
+# exit status, or 124 on timeout (matching coreutils `timeout`).
+_dep_timeout() {
+  local secs="$1"; shift
+  if command -v timeout >/dev/null 2>&1; then
+    timeout "$secs" "$@"
+    return $?
+  fi
+  if command -v gtimeout >/dev/null 2>&1; then
+    gtimeout "$secs" "$@"
+    return $?
+  fi
+  # Fallback watchdog (no coreutils timeout, e.g. stock macOS /bin/bash). A
+  # sentinel file lets us tell a real timeout (→124) from a command that simply
+  # exited non-zero on its own. Every kill is `|| true` so a race where the
+  # target already exited can never abort under the caller's set -e.
+  local timedout="${TMPDIR:-/tmp}/.dep_timeout.$$.$RANDOM"
+  "$@" &
+  local cmd_pid=$!
+  ( sleep "$secs"; : > "$timedout"; kill -TERM "$cmd_pid" 2>/dev/null || true ) &
+  local wd_pid=$!
+  local status=0
+  wait "$cmd_pid" 2>/dev/null || status=$?
+  kill -TERM "$wd_pid" 2>/dev/null || true
+  wait "$wd_pid" 2>/dev/null || true
+  if [ -f "$timedout" ]; then
+    rm -f "$timedout" 2>/dev/null || true
+    return 124
+  fi
+  return "$status"
+}
+
+# Probe a container image. Detects whether the image is materialised for an
+# available runtime (Docker image, or an Apptainer/Singularity .sif on disk).
+# Args: <docker_image_or_empty> <sif_path_or_empty>
+# Echoes "present|<detail>" or "absent". Always returns 0; short timeouts so a
+# wedged Docker daemon never hangs the startup check.
+_dep_probe_image() {
+  local docker_image="${1:-}"
+  local sif_path="${2:-}"
+
+  # Apptainer/Singularity .sif on disk (fast, no daemon).
+  if [ -n "$sif_path" ] && [ -f "$sif_path" ] && \
+     { command -v apptainer >/dev/null 2>&1 || command -v singularity >/dev/null 2>&1; }; then
+    printf 'present|sif:%s' "$sif_path"
+    return 0
+  fi
+  # A bare .sif may also be passed as the "docker_image" arg (SHIVA/segcsvd).
+  if [ -n "$docker_image" ] && [ -f "$docker_image" ] && \
+     { command -v apptainer >/dev/null 2>&1 || command -v singularity >/dev/null 2>&1; }; then
+    printf 'present|sif:%s' "$docker_image"
+    return 0
+  fi
+  # Docker image inspect (bounded; a hung daemon returns absent, never hangs).
+  if [ -n "$docker_image" ] && command -v docker >/dev/null 2>&1; then
+    if _dep_timeout 8 docker image inspect "$docker_image" >/dev/null 2>&1; then
+      printf 'present|docker:%s' "$docker_image"
+      return 0
+    fi
+  fi
+  printf 'absent'
+  return 0
+}
+
+# Emit one matrix line and (for OPT deps that gate an ENABLED feature but are
+# absent) a WARNING. Increments the module-scope counters by name reference.
+# Args: <name> <REQ|OPT> <probe-result> <gates-feature> [<enabled:true|false>]
+_dep_report() {
+  local name="$1" kind="$2" probe="$3" gates="$4" enabled="${5:-}"
+  local state detail
+  if [ "${probe%%|*}" = "present" ]; then
+    state="present"
+    detail="${probe#present}"; detail="${detail#|}"
+  else
+    state="absent"
+    detail=""
+  fi
+
+  local line
+  if [ -n "$detail" ]; then
+    line="  ${name} | ${kind} | ${state} (${detail}) | gates: ${gates}"
+  else
+    line="  ${name} | ${kind} | ${state} | gates: ${gates}"
+  fi
+
+  if [ "$state" = "present" ]; then
+    log_formatted "SUCCESS" "✓ ${line}"
+    _DEP_PRESENT=$((_DEP_PRESENT + 1))
+  else
+    log_formatted "INFO" "· ${line}"
+    _DEP_ABSENT=$((_DEP_ABSENT + 1))
+    # Enabled-but-missing → actionable WARNING + add to the skip list.
+    if [ "$kind" = "OPT" ] && [ "$enabled" = "true" ]; then
+      log_formatted "WARNING" "⚠ ${gates} is ENABLED but ${name} not found — that feature will be SKIPPED"
+      _DEP_SKIPPED_FEATURES+=("${gates} (missing ${name})")
+    fi
+  fi
+}
+
+check_optional_dependencies() {
+  log_formatted "INFO" "==== Optional / Feature-Gated Dependency Inventory ===="
+  log_message  "Legend: name | REQ/OPT | present/absent (+path/version) | gates-which-feature"
+
+  # Module-scope counters / lists (consumed by _dep_report and the summary).
+  _DEP_PRESENT=0
+  _DEP_ABSENT=0
+  _DEP_SKIPPED_FEATURES=()
+
+  # Resolve the effective config toggles (mirror config/default_config.sh
+  # defaults so the report is correct even if config has not been sourced yet).
+  local seg_method="${BRAINSTEM_SEGMENTATION_METHOD:-all}"
+  local seg_run_fs="${SEG_RUN_FREESURFER:-true}"
+  local seg_run_synthseg="${SEG_RUN_SYNTHSEG:-true}"
+  local use_synthsr="${USE_SYNTHSR:-false}"
+  local process_dwi="${PROCESS_DWI:-false}"
+  local wmh_bianca="${WMH_BIANCA_ENABLED:-false}"
+  local wmh_lstai="${WMH_LSTAI_ENABLED:-false}"
+  local wmh_samseg="${WMH_SAMSEG_ENABLED:-false}"
+  local wmh_synthseg="${WMH_SYNTHSEG_ENABLED:-true}"
+  local wmh_segcsvd="${WMH_SEGCSVD_ENABLED:-false}"
+  local wmh_shiva="${WMH_SHIVA_ENABLED:-true}"
+  local wmh_mars="${WMH_MARS_ENABLED:-true}"
+  local mars_brainstem="${MARS_BRAINSTEM_ENABLED:-false}"
+  local aanseg="${BRAINSTEM_AANSEG_ENABLED:-false}"
+
+  # FreeSurfer is needed when its seg path or any FS-backed WMH/seg feature runs.
+  local fs_enabled=false
+  if { [ "$seg_method" = "all" ] && [ "$seg_run_fs" = true ]; } || \
+     [ "$seg_method" = "freesurfer" ] || \
+     [ "$wmh_samseg" = true ] || [ "$wmh_synthseg" = true ] || \
+     [ "$use_synthsr" = true ] || [ "$aanseg" = true ]; then
+    fs_enabled=true
+  fi
+
+  # ── Core required tools (mirror check_ants/check_fsl extents, report-only) ──
+  # These are ALSO enforced (fatally) by check_all_dependencies; listing them
+  # here gives the user one authoritative inventory. Marked REQ.
+  log_formatted "INFO" "---- Core (REQUIRED) ----"
+  local t
+  for t in fslmaths flirt fast bet robustfov cluster fslstats fslinfo; do
+    _dep_report "$t" "REQ" "$(_dep_probe_cmd "$t")" "FSL core"
+  done
+  for t in antsRegistration antsApplyTransforms N4BiasFieldCorrection \
+           DenoiseImage Atropos ThresholdImage ImageMath ResampleImage \
+           antsRegistrationSyN.sh; do
+    _dep_report "$t" "REQ" "$(_dep_probe_cmd "$t")" "ANTs core"
+  done
+  _dep_report "dcm2niix" "REQ" "$(_dep_probe_cmd dcm2niix)" "DICOM import"
+  _dep_report "c3d"      "REQ" "$(_dep_probe_cmd c3d)"      "Convert3D ops"
+  _dep_report "uv"       "REQ" "$(_dep_probe_cmd uv)"       "Python (uv) runtime"
+  for t in nibabel numpy sklearn; do
+    _dep_report "python:${t}" "REQ" "$(_dep_probe_pymodule "$t")" "GMM / image I/O"
+  done
+
+  # ── FreeSurfer (OPTIONAL) ──
+  log_formatted "INFO" "---- FreeSurfer (OPTIONAL) ----"
+  local fs_home_probe="absent"
+  [ -n "${FREESURFER_HOME:-}" ] && [ -d "${FREESURFER_HOME:-}" ] && fs_home_probe="present|${FREESURFER_HOME}"
+  _dep_report "FREESURFER_HOME" "OPT" "$fs_home_probe" "FreeSurfer seg/recon" "$fs_enabled"
+  local fs_lic="absent"
+  if [ -n "${FS_LICENSE:-}" ] && [ -f "${FS_LICENSE:-}" ]; then
+    fs_lic="present|${FS_LICENSE}"
+  elif [ -f "${FREESURFER_HOME:-}/license.txt" ]; then
+    fs_lic="present|${FREESURFER_HOME}/license.txt"
+  elif [ -f "${FREESURFER_HOME:-}/.license" ]; then
+    fs_lic="present|${FREESURFER_HOME}/.license"
+  fi
+  # Only treat a missing license as a skip-cause when FREESURFER_HOME itself is
+  # present — otherwise the missing-FREESURFER_HOME warning above already covers
+  # the root cause and we would double-count the same "FreeSurfer not installed".
+  local lic_gate=""
+  [ "${fs_home_probe%%|*}" = present ] && lic_gate="$fs_enabled"
+  _dep_report "FreeSurfer license" "OPT" "$fs_lic" "FreeSurfer seg/recon" "$lic_gate"
+  _dep_report "recon-all"             "OPT" "$(_dep_probe_cmd recon-all)"             "FS brainstem (recon)" "$fs_enabled"
+  # segmentBS.sh OR segment_subregions satisfies the brainstem substructure path.
+  local segbs; segbs="$(_dep_probe_cmd segmentBS.sh)"
+  [ "${segbs%%|*}" != present ] && segbs="$(_dep_probe_cmd segment_subregions)"
+  _dep_report "segmentBS.sh/segment_subregions" "OPT" "$segbs" "FS brainstem substructures" "$fs_enabled"
+  _dep_report "SegmentAAN.sh"        "OPT" "$(_dep_probe_cmd SegmentAAN.sh)"          "AANSegment nuclei"        "$aanseg"
+  _dep_report "mri_synthseg"         "OPT" "$(_dep_probe_cmd mri_synthseg)"           "SynthSeg ML seg"          "$seg_run_synthseg"
+  _dep_report "mri_synthsr"          "OPT" "$(_dep_probe_cmd mri_synthsr)"            "SynthSR super-res"        "$use_synthsr"
+  _dep_report "mri_synthstrip"       "OPT" "$(_dep_probe_cmd mri_synthstrip)"         "SynthStrip brain extract"
+  _dep_report "mri_WMHsynthseg"      "OPT" "$(_dep_probe_cmd mri_WMHsynthseg)"        "WMH-SynthSeg"             "$wmh_synthseg"
+  _dep_report "mri_sclimbic_seg"     "OPT" "$(_dep_probe_cmd mri_sclimbic_seg)"       "ScLimbic harvest"
+  _dep_report "mri_segment_hypothalamic_subunits" "OPT" "$(_dep_probe_cmd mri_segment_hypothalamic_subunits)" "Hypothalamus harvest"
+  _dep_report "run_samseg"           "OPT" "$(_dep_probe_cmd run_samseg)"             "SAMSEG WMH"               "$wmh_samseg"
+
+  # ── MRtrix (OPTIONAL — DWI preprocessing) ──
+  log_formatted "INFO" "---- MRtrix (OPTIONAL) ----"
+  for t in dwidenoise mrdegibbs dwifslpreproc dwibiascorrect dwi2mask mrconvert; do
+    _dep_report "$t" "OPT" "$(_dep_probe_cmd "$t")" "DWI preprocessing (PROCESS_DWI)" "$process_dwi"
+  done
+
+  # Probe the container images up front: SHIVA and LST-AI each accept multiple
+  # ALTERNATIVE back-ends (any-of), so the enabled-but-missing WARNING must fire
+  # only when EVERY back-end is absent — never once per alternative (that would
+  # falsely claim a feature will skip when one of its back-ends is present).
+  local img_shiva img_lstai
+  img_shiva="$(_dep_probe_image "${SHIVA_WMH_CONTAINER_IMAGE:-}" "${SHIVA_WMH_CONTAINER_IMAGE:-}")"
+  img_lstai="$(_dep_probe_image "${LSTAI_DOCKER_IMAGE:-jqmcginnis/lst-ai:latest}" "")"
+
+  # ── WMH / ML tools (OPTIONAL) ──
+  log_formatted "INFO" "---- WMH / ML tools (OPTIONAL) ----"
+  _dep_report "bianca"          "OPT" "$(_dep_probe_cmd bianca)"          "FSL BIANCA WMH"  "$wmh_bianca"
+  _dep_report "make_bianca_mask" "OPT" "$(_dep_probe_cmd make_bianca_mask)" "FSL BIANCA mask" "$wmh_bianca"
+
+  # SHIVA-WMH: antspynet OR a SHiVAi container (any-of). Report each back-end as
+  # informational; warn ONCE only when both are absent and the feature is on.
+  local shiva_antspynet; shiva_antspynet="$(_dep_probe_pymodule antspynet)"
+  _dep_report "python:antspynet" "OPT" "$shiva_antspynet" "SHIVA-WMH (antspynet back-end)"
+  _dep_report "image:SHiVAi"     "OPT" "$img_shiva"        "SHIVA-WMH (container back-end)"
+  local shiva_any="absent"
+  { [ "${shiva_antspynet%%|*}" = present ] || [ "${img_shiva%%|*}" = present ]; } && shiva_any="present"
+  _dep_report "SHIVA-WMH back-end" "OPT" "$shiva_any" "SHIVA-WMH" "$wmh_shiva"
+
+  # LST-AI: 'lst' CLI OR importable lst_ai module OR Docker image (any-of).
+  local lstai_cli; lstai_cli="$(_dep_probe_cmd lst)"
+  [ "${lstai_cli%%|*}" != present ] && lstai_cli="$(_dep_probe_pymodule lst_ai)"
+  _dep_report "LST-AI (lst / lst_ai)" "OPT" "$lstai_cli" "LST-AI (CLI/module back-end)"
+  _dep_report "image:LST-AI"          "OPT" "$img_lstai"  "LST-AI (container back-end)"
+  local lstai_any="absent"
+  { [ "${lstai_cli%%|*}" = present ] || [ "${img_lstai%%|*}" = present ]; } && lstai_any="present"
+  _dep_report "LST-AI back-end" "OPT" "$lstai_any" "LST-AI WMH" "$wmh_lstai"
+
+  # ── Container runtimes + images (OPTIONAL) ──
+  log_formatted "INFO" "---- Container runtimes & images (OPTIONAL) ----"
+  _dep_report "docker"               "OPT" "$(_dep_probe_cmd docker)"      "containerised WMH tools"
+  local appt; appt="$(_dep_probe_cmd apptainer)"
+  [ "${appt%%|*}" != present ] && appt="$(_dep_probe_cmd singularity)"
+  _dep_report "apptainer/singularity" "OPT" "$appt" "containerised WMH tools (.sif)"
+  # Single-back-end containers: each is gated directly on its feature toggle.
+  _dep_report "image:segcsvd"        "OPT" "$(_dep_probe_image "${SEGCSVD_DOCKER_IMAGE:-segcsvd_rc03}" "${SEGCSVD_CONTAINER_IMAGE:-}")" "segcsvdWMH" "$wmh_segcsvd"
+  _dep_report "image:MARS-WMH"       "OPT" "$(_dep_probe_image "${MARS_WMH_DOCKER_IMAGE:-ghcr.io/miac-research/wmh-nnunet:latest}" "${MARS_WMH_SIF:-}")" "MARS-WMH" "$wmh_mars"
+  _dep_report "image:MARS-brainstem" "OPT" "$(_dep_probe_image "${MARS_BRAINSTEM_DOCKER_IMAGE:-ghcr.io/miac-research/dl-brainstem:latest}" "${MARS_BRAINSTEM_SIF:-}")" "MARS brainstem ROI" "$mars_brainstem"
+
+  # ── Atlases (OPTIONAL) — delegate the heavy on-disk probing to the dedicated
+  # check_atlas_availability (called separately from main() after config load).
+  log_formatted "INFO" "---- Atlases (OPTIONAL) ----"
+  log_message "Atlas presence/absence is reported in detail by the Atlas Availability Check (see below): Bianciardi / CIT168 / AAL3 / HarvardOxford under \${FSLDIR}/data/atlases"
+  local atlas_root="${FSLDIR:-}/data/atlases"
+  local ho_probe="absent"
+  if [ -d "${atlas_root}/${ATLAS_HARVARDOXFORD_REL:-HarvardOxford}" ]; then
+    ho_probe="present|${atlas_root}/${ATLAS_HARVARDOXFORD_REL:-HarvardOxford}"
+  fi
+  _dep_report "atlas:HarvardOxford" "OPT" "$ho_probe" "Harvard-Oxford gross extent"
+  local std_probe="absent"
+  if [ -d "${FSLDIR:-}/data/standard" ]; then
+    std_probe="present|${FSLDIR}/data/standard"
+  fi
+  _dep_report "FSL standard templates" "OPT" "$std_probe" "MNI registration targets"
+
+  # ── Inventory summary ──
+  log_formatted "INFO" "==== Optional Dependency Inventory Summary ===="
+  log_formatted "INFO" "Dependencies present: ${_DEP_PRESENT} | absent: ${_DEP_ABSENT}"
+  if [ "${#_DEP_SKIPPED_FEATURES[@]}" -eq 0 ]; then
+    log_formatted "SUCCESS" "✓ No ENABLED optional feature is missing its dependency."
+  else
+    log_formatted "WARNING" "⚠ Optional features that WILL be SKIPPED (enabled but missing deps):"
+    local f
+    for f in "${_DEP_SKIPPED_FEATURES[@]}"; do
+      log_formatted "WARNING" "    - ${f}"
+    done
+  fi
+
+  return 0
 }
 
 # ------------------------------------------------------------------------------
@@ -1351,6 +1671,8 @@ initialize_environment() {
   export -f check_command
   export -f check_dependencies
   export -f check_all_dependencies
+  export -f check_optional_dependencies
+  export -f _dep_probe_cmd _dep_probe_pymodule _dep_probe_image _dep_report _dep_timeout
   export -f check_atlas_availability
   export -f standardize_datatype
   export -f get_output_path

--- a/tests/test_dependency_report_unit.sh
+++ b/tests/test_dependency_report_unit.sh
@@ -1,0 +1,294 @@
+#!/usr/bin/env bash
+#
+# test_dependency_report_unit.sh - Unit tests for the comprehensive
+# optional/feature-gated dependency inventory in src/modules/environment.sh.
+#
+# Tests:
+#   - _dep_probe_cmd          (present / absent)
+#   - _dep_timeout            (returns command status; bounds runtime)
+#   - _dep_probe_image        (docker image / .sif on disk / absent)
+#   - _dep_report             (matrix line + enabled-but-missing WARNING)
+#   - check_optional_dependencies
+#       * groups REQUIRED vs OPTIONAL
+#       * reports present/absent per dependency (mocked)
+#       * cross-references config toggles → "enabled but missing → SKIPPED"
+#       * is NON-fatal (always returns 0)
+#       * prints the inventory summary (counts + skip list)
+#
+
+set -u
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+source "$SCRIPT_DIR/test_helpers.sh"
+
+# ── Bootstrap ─────────────────────────────────────────────────────────────────
+init_test_suite "Dependency Report Unit Tests"
+setup_test_environment
+
+# Source the module under test (stderr suppressed; it emits log lines on load).
+load_environment_module
+
+# ══════════════════════════════════════════════════════════════════════════════
+# 1. _dep_probe_cmd
+# ══════════════════════════════════════════════════════════════════════════════
+begin_test_group "1. _dep_probe_cmd"
+
+# bash is always present
+probe="$(_dep_probe_cmd bash)"
+assert_contains "$probe" "present|" \
+    "_dep_probe_cmd reports 'present|<path>' for an existing command"
+
+probe="$(_dep_probe_cmd this_command_does_not_exist_xyz)"
+assert_equals "absent" "$probe" \
+    "_dep_probe_cmd reports 'absent' for a missing command"
+
+# ══════════════════════════════════════════════════════════════════════════════
+# 2. _dep_timeout
+# ══════════════════════════════════════════════════════════════════════════════
+begin_test_group "2. _dep_timeout"
+
+set +e
+_dep_timeout 5 true
+ec=$?
+set -e
+assert_exit_code 0 "$ec" \
+    "_dep_timeout passes through a successful command's exit status"
+
+set +e
+_dep_timeout 5 false
+ec=$?
+set -e
+assert_exit_code 1 "$ec" \
+    "_dep_timeout passes through a failing command's exit status"
+
+# A command that would run forever must be bounded (must not hang the suite).
+start=$(date +%s)
+set +e
+_dep_timeout 1 sleep 30 >/dev/null 2>&1
+set -e
+end=$(date +%s)
+elapsed=$((end - start))
+if [[ "$elapsed" -le 10 ]]; then
+    echo -e "${GREEN}  PASS${NC}: _dep_timeout bounds a long-running command (${elapsed}s)"
+    PASS_COUNT=$((PASS_COUNT + 1)); TEST_COUNT=$((TEST_COUNT + 1))
+else
+    echo -e "${RED}  FAIL${NC}: _dep_timeout did NOT bound a long-running command (${elapsed}s)"
+    FAIL_COUNT=$((FAIL_COUNT + 1)); TEST_COUNT=$((TEST_COUNT + 1))
+    FAILED_TESTS+=("_dep_timeout bounds a long-running command")
+fi
+
+# ══════════════════════════════════════════════════════════════════════════════
+# 3. _dep_probe_image
+# ══════════════════════════════════════════════════════════════════════════════
+begin_test_group "3. _dep_probe_image"
+
+# A non-existent docker image with no runtime that can satisfy it → absent.
+# (We can't assume docker is installed; with no .sif and a bogus image it must
+#  fall through to 'absent' without hanging — short internal timeout.)
+probe="$(_dep_probe_image "nonexistent/image:does-not-exist-xyz" "")"
+assert_equals "absent" "$probe" \
+    "_dep_probe_image reports 'absent' for an unknown image / no .sif"
+
+# A .sif file on disk + a (mocked) apptainer runtime → present|sif:<path>.
+fake_sif="$TEMP_TEST_DIR/fake_model.sif"
+touch "$fake_sif"
+create_mock_command "apptainer" 0 "apptainer version 1.0"
+probe="$(_dep_probe_image "" "$fake_sif")"
+assert_contains "$probe" "present|sif:$fake_sif" \
+    "_dep_probe_image reports a present .sif when an apptainer runtime exists"
+
+# ══════════════════════════════════════════════════════════════════════════════
+# 4. _dep_report (matrix line + enabled-but-missing WARNING)
+# ══════════════════════════════════════════════════════════════════════════════
+begin_test_group "4. _dep_report"
+
+# NOTE: _dep_report mutates module-scope counters/arrays, so it must run in the
+# CURRENT shell (NOT a $(...) subshell). Capture its output to a temp file.
+_dep_out="$TEMP_TEST_DIR/dep_report.out"
+
+# Present REQ → SUCCESS line, increments _DEP_PRESENT.
+_DEP_PRESENT=0; _DEP_ABSENT=0; _DEP_SKIPPED_FEATURES=()
+_dep_report "toolA" "REQ" "present|/usr/bin/toolA" "core thing" >"$_dep_out" 2>&1
+out="$(cat "$_dep_out")"
+assert_contains "$out" "toolA | REQ | present (/usr/bin/toolA) | gates: core thing" \
+    "_dep_report formats a present REQ matrix line"
+assert_equals "1" "$_DEP_PRESENT" "_dep_report increments _DEP_PRESENT on present"
+assert_equals "0" "${#_DEP_SKIPPED_FEATURES[@]}" "_dep_report adds no skip entry on present"
+
+# Absent OPT that is ENABLED → WARNING + skip-list entry.
+_DEP_PRESENT=0; _DEP_ABSENT=0; _DEP_SKIPPED_FEATURES=()
+_dep_report "toolB" "OPT" "absent" "Fancy Feature" "true" >"$_dep_out" 2>&1
+out="$(cat "$_dep_out")"
+assert_contains "$out" "toolB | OPT | absent | gates: Fancy Feature" \
+    "_dep_report formats an absent OPT matrix line"
+assert_contains "$out" "Fancy Feature is ENABLED but toolB not found" \
+    "_dep_report warns when an ENABLED optional feature's dep is absent"
+assert_equals "1" "$_DEP_ABSENT" "_dep_report increments _DEP_ABSENT on absent"
+assert_equals "1" "${#_DEP_SKIPPED_FEATURES[@]}" "_dep_report records the skipped feature"
+
+# Absent OPT that is NOT enabled → no warning, no skip entry.
+_DEP_PRESENT=0; _DEP_ABSENT=0; _DEP_SKIPPED_FEATURES=()
+_dep_report "toolC" "OPT" "absent" "Disabled Feature" "false" >"$_dep_out" 2>&1
+out="$(cat "$_dep_out")"
+assert_not_contains "$out" "is ENABLED but toolC not found" \
+    "_dep_report does NOT warn when the optional feature is disabled"
+assert_equals "0" "${#_DEP_SKIPPED_FEATURES[@]}" \
+    "_dep_report records no skip entry for a disabled feature"
+
+# ══════════════════════════════════════════════════════════════════════════════
+# 5. check_optional_dependencies (end-to-end, fully mocked PATH)
+# ══════════════════════════════════════════════════════════════════════════════
+begin_test_group "5. check_optional_dependencies"
+
+# Build a deterministic PATH containing ONLY our mocks + the bare essentials so
+# present/absent is controlled by the test, not the host.
+mock_dir="$TEMP_TEST_DIR/dep_mock_bin"
+mkdir -p "$mock_dir"
+for tool in \
+    fslmaths flirt fast bet robustfov cluster fslstats fslinfo \
+    antsRegistration antsApplyTransforms N4BiasFieldCorrection DenoiseImage \
+    Atropos ThresholdImage ImageMath ResampleImage antsRegistrationSyN.sh \
+    dcm2niix c3d uv \
+    recon-all segmentBS.sh mri_synthseg ; do
+    printf '#!/usr/bin/env bash\nexit 0\n' > "$mock_dir/$tool"
+    chmod +x "$mock_dir/$tool"
+done
+# Keep coreutils/bash available so the function body runs.
+essentials_dir="$(dirname "$(command -v bash)")"
+saved_path="$PATH"
+export PATH="$mock_dir:$essentials_dir:/usr/bin:/bin"
+
+# Make the FreeSurfer / atlas / FSL / container probes hermetic by clearing any
+# host environment the developer's machine may have set, so present/absent is
+# controlled by the test (mocked PATH) and not by the host.
+unset FREESURFER_HOME FS_LICENSE FSLDIR \
+      SEGCSVD_DOCKER_IMAGE SEGCSVD_CONTAINER_IMAGE LSTAI_DOCKER_IMAGE \
+      SHIVA_WMH_CONTAINER_IMAGE MARS_WMH_DOCKER_IMAGE MARS_WMH_SIF \
+      MARS_BRAINSTEM_DOCKER_IMAGE MARS_BRAINSTEM_SIF 2>/dev/null || true
+
+# Config: enable a feature whose dep is deliberately ABSENT (mri_WMHsynthseg is
+# not mocked) and disable everything container/python-based so the test is
+# hermetic and fast.
+export BRAINSTEM_SEGMENTATION_METHOD="all"
+export SEG_RUN_FREESURFER="true"
+export SEG_RUN_MULTI_ATLAS="false"
+export SEG_RUN_SYNTHSEG="true"
+export USE_SYNTHSR="false"
+export PROCESS_DWI="false"
+export WMH_BIANCA_ENABLED="false"
+export WMH_LSTAI_ENABLED="false"
+export WMH_SAMSEG_ENABLED="false"
+export WMH_SYNTHSEG_ENABLED="true"     # enabled, but mri_WMHsynthseg is ABSENT
+export WMH_SEGCSVD_ENABLED="false"
+export WMH_SHIVA_ENABLED="false"
+export WMH_MARS_ENABLED="false"
+export MARS_BRAINSTEM_ENABLED="false"
+export BRAINSTEM_AANSEG_ENABLED="false"
+
+set +e
+out="$(check_optional_dependencies 2>&1)"
+ec=$?
+set -e
+export PATH="$saved_path"
+
+# Strip ANSI colour codes for matching.
+out_plain="$(printf '%s' "$out" | sed 's/\x1b\[[0-9;]*m//g')"
+
+assert_exit_code 0 "$ec" \
+    "check_optional_dependencies is NON-fatal (returns 0)"
+
+assert_contains "$out_plain" "Optional / Feature-Gated Dependency Inventory" \
+    "prints the inventory header"
+assert_contains "$out_plain" "Core (REQUIRED)" \
+    "prints the REQUIRED group header"
+assert_contains "$out_plain" "FreeSurfer (OPTIONAL)" \
+    "prints the OPTIONAL FreeSurfer group header"
+assert_contains "$out_plain" "Container runtimes & images (OPTIONAL)" \
+    "prints the container group header"
+
+# Mocked-present core tool shows present.
+assert_contains "$out_plain" "fslmaths | REQ | present" \
+    "reports a mocked core tool (fslmaths) as present"
+# Mocked-present optional FS tool shows present.
+assert_contains "$out_plain" "recon-all | OPT | present" \
+    "reports a mocked optional tool (recon-all) as present"
+# Non-mocked optional tool shows absent.
+assert_contains "$out_plain" "mri_WMHsynthseg | OPT | absent" \
+    "reports a non-mocked optional tool (mri_WMHsynthseg) as absent"
+
+# Enabled-but-missing feature must produce a WARNING + appear in the skip list.
+assert_contains "$out_plain" "WMH-SynthSeg is ENABLED but mri_WMHsynthseg not found" \
+    "warns that an ENABLED feature with a missing dep will be skipped"
+assert_contains "$out_plain" "Optional features that WILL be SKIPPED" \
+    "prints the skip-list summary header"
+assert_contains "$out_plain" "WMH-SynthSeg (missing mri_WMHsynthseg)" \
+    "lists the skipped feature in the summary"
+
+# Summary line with counts is present.
+assert_contains "$out_plain" "Dependencies present:" \
+    "prints the present/absent counts summary"
+
+# ══════════════════════════════════════════════════════════════════════════════
+# 5b. Any-of back-end gating (SHIVA: antspynet OR container)
+#     Enabling SHIVA with ONE back-end present must NOT warn it will be skipped.
+# ══════════════════════════════════════════════════════════════════════════════
+begin_test_group "5b. Any-of back-end gating"
+
+# Same hermetic core PATH; clear host env again for determinism.
+unset FREESURFER_HOME FS_LICENSE FSLDIR \
+      SEGCSVD_DOCKER_IMAGE SEGCSVD_CONTAINER_IMAGE LSTAI_DOCKER_IMAGE \
+      MARS_WMH_DOCKER_IMAGE MARS_WMH_SIF \
+      MARS_BRAINSTEM_DOCKER_IMAGE MARS_BRAINSTEM_SIF 2>/dev/null || true
+
+# Provide a SHiVAi .sif on disk + a mocked apptainer runtime so the CONTAINER
+# back-end is present, while antspynet (no uv project here) stays ABSENT.
+shiva_sif="$TEMP_TEST_DIR/shiva_model.sif"
+touch "$shiva_sif"
+export SHIVA_WMH_CONTAINER_IMAGE="$shiva_sif"
+# mock_dir already has 'uv' (returns 0), so antspynet import "succeeds" trivially;
+# point uv at a stub that FAILS the import so antspynet is genuinely absent.
+printf '#!/usr/bin/env bash\nexit 1\n' > "$mock_dir/uv"
+chmod +x "$mock_dir/uv"
+printf '#!/usr/bin/env bash\nexit 0\n' > "$mock_dir/apptainer"
+chmod +x "$mock_dir/apptainer"
+
+export PATH="$mock_dir:$essentials_dir:/usr/bin:/bin"
+export WMH_SHIVA_ENABLED="true"      # SHIVA on; container present, antspynet absent
+export WMH_SYNTHSEG_ENABLED="false"  # silence the unrelated SynthSeg skip
+export WMH_MARS_ENABLED="false"
+export WMH_LSTAI_ENABLED="false"
+
+set +e
+out2="$(check_optional_dependencies 2>&1)"
+set -e
+export PATH="$saved_path"
+out2_plain="$(printf '%s' "$out2" | sed 's/\x1b\[[0-9;]*m//g')"
+
+assert_contains "$out2_plain" "SHIVA-WMH back-end | OPT | present" \
+    "any-of: SHIVA back-end reports present when only the container exists"
+assert_not_contains "$out2_plain" "SHIVA-WMH is ENABLED but" \
+    "any-of: enabled SHIVA does NOT warn-skip when one back-end is present"
+assert_not_contains "$out2_plain" "SHIVA-WMH (missing" \
+    "any-of: SHIVA is not listed in the skip summary when a back-end exists"
+
+# Restore the plain 'uv' mock for any later groups.
+printf '#!/usr/bin/env bash\nexit 0\n' > "$mock_dir/uv"
+chmod +x "$mock_dir/uv"
+
+# ══════════════════════════════════════════════════════════════════════════════
+# 6. Function availability
+# ══════════════════════════════════════════════════════════════════════════════
+begin_test_group "6. Function Availability"
+
+assert_function_exists "check_optional_dependencies" "check_optional_dependencies defined"
+assert_function_exists "_dep_probe_cmd"              "_dep_probe_cmd defined"
+assert_function_exists "_dep_probe_pymodule"         "_dep_probe_pymodule defined"
+assert_function_exists "_dep_probe_image"            "_dep_probe_image defined"
+assert_function_exists "_dep_report"                 "_dep_report defined"
+assert_function_exists "_dep_timeout"                "_dep_timeout defined"
+
+# ══════════════════════════════════════════════════════════════════════════════
+# Cleanup & Summary
+# ══════════════════════════════════════════════════════════════════════════════
+cleanup_test_environment
+print_test_summary


### PR DESCRIPTION
## Summary

Overhauls the startup dependency check into a single authoritative, grouped, **report-only-for-optional** inventory so a user sees upfront exactly what is available and which optional features will run vs skip. Across this session's modules many tools/containers/atlases were added but not all were checked or reported; this makes the pre-init check enumerate **every** dependency the pipeline can now use.

New `check_optional_dependencies` (`src/modules/environment.sh`), wired into the existing `check_all_dependencies` so it prints at startup. The CI smoke-test strings (`Comprehensive Pipeline Dependency Check`, `Dependency Check Summary`) are preserved. Each dependency is one matrix line:

```
name | REQ/OPT | present/absent (+path/version) | gates: <feature>
```

## What it detects + reports (grouped)

- **Core (REQUIRED, still fatally enforced):** FSL (`fslmaths`/`flirt`/`fast`/`bet`/`robustfov`/`cluster`/`fslstats`/`fslinfo`), ANTs (`antsRegistration`/`antsApplyTransforms`/`N4BiasFieldCorrection`/`DenoiseImage`/`Atropos`/`ThresholdImage`/`ImageMath`/`ResampleImage`/`antsRegistrationSyN.sh`), `dcm2niix`, `c3d`, Python via `uv` (`nibabel`/`numpy`/`sklearn`).
- **FreeSurfer (OPTIONAL):** `FREESURFER_HOME` + license, `recon-all`, `segmentBS.sh`/`segment_subregions`, `SegmentAAN.sh`, `mri_synthseg`/`synthsr`/`synthstrip`/`WMHsynthseg`/`sclimbic_seg`/`segment_hypothalamic_subunits`, `run_samseg`.
- **MRtrix (OPTIONAL):** `dwidenoise`, `mrdegibbs`, `dwifslpreproc`, `dwibiascorrect`, `dwi2mask`, `mrconvert`.
- **WMH/ML (OPTIONAL):** `bianca`/`make_bianca_mask`, antspynet (→ SHIVA), `lst`/`lst_ai` (→ LST-AI).
- **Container runtimes + images (OPTIONAL):** `docker` and/or `apptainer`/`singularity`, AND the specific images the modules reference (segcsvd, LST-AI, SHiVAi, MARS-WMH, MARS-brainstem) via `docker image inspect` / `.sif`-on-disk, with **short timeouts** so a wedged Docker daemon never hangs startup.
- **Atlases (OPTIONAL):** HarvardOxford + FSL standard templates here; full Bianciardi/CIT168/AAL3 probe stays in `check_atlas_availability`.

## Config cross-reference

Reads the feature toggles (`SEG_RUN_*`, `WMH_*_ENABLED`, `USE_*`, `PROCESS_DWI`, `MARS_BRAINSTEM_ENABLED`, `BRAINSTEM_AANSEG_ENABLED`, `BRAINSTEM_SEGMENTATION_METHOD`). An **enabled feature with a missing dep** logs a clear `WARNING` ("X is ENABLED but <tool> not found — will be SKIPPED") and joins an end-of-section **skip list**; the summary prints present/absent counts + the concise skip list. Non-fatal for all optional; core stays fatal (no regression).

Any-of back-ends (SHIVA = antspynet OR container; LST-AI = lst CLI OR lst_ai module OR docker image) warn **exactly once**, only when every back-end is absent — never once per alternative. FreeSurfer license absence is not double-counted when `FREESURFER_HOME` itself is missing. `_dep_timeout` is a portable `timeout`/`gtimeout`/watchdog bound that returns 124 on timeout and can never abort under `set -e`.

## Tests / verification

- New `tests/test_dependency_report_unit.sh` — 37 assertions (probes, timeout bounding, matrix formatting, enabled-but-missing skip-list, any-of gating, non-fatal). Mocks present/absent via PATH.
- `git ls-files '*.sh' | xargs -I{} bash -n {}` — clean.
- `... | xargs shellcheck --severity=error` — clean.
- 3 unit suites: environment (100), pipeline_control (98), import (29) — all pass.
- `pipeline.sh --help | grep -q Usage` — pass.
- Ran the new check on a host with FSL/ANTs/FreeSurfer/mrtrix/docker: correctly reports present/absent across all groups; the Docker probe does not hang.

## Files changed (code + CLAUDE.md only)

- `src/modules/environment.sh` — new check + helpers, wiring, exports.
- `tests/test_dependency_report_unit.sh` — new unit test.
- `CLAUDE.md` — completes the module table (`freesurfer_harvest.sh` et al.) and documents the comprehensive check + optional-deps matrix.

Did **not** touch `README.md` or `docs/*` (owned by another agent).

🤖 Generated with [Claude Code](https://claude.com/claude-code)