### PR TITLE
Fix 4D-DWI composed resample + harden registration Dice metric

### DIFF
--- a/src/modules/qa.sh
+++ b/src/modules/qa.sh
@@ -848,50 +848,71 @@ calculate_extended_registration_metrics() {
     local jacobian_std="N/A"
     local quality="UNKNOWN"
     
-    # 1. Calculate Dice coefficient between T1 brain and FLAIR brain
+    # 1. Calculate Dice coefficient between fixed and warped tissue masks.
     log_message "Calculating Dice coefficient between brains"
     if [ -f "$fixed" ] && [ -f "$warped" ]; then
         # Create tissue-specific masks for more accurate Dice calculation
-        local temp_dir=$(mktemp -d)
-        
-        # Segment fixed image (T1)
+        local temp_dir
+        temp_dir=$(mktemp -d)
+
+        # FAST often cannot segment low-contrast / already-brain-extracted images
+        # (DWI trace, SWI, etc.): it aborts with "Not enough classes detected to
+        # init KMeans" and never writes the *_pve_* maps.  Run it defensively and
+        # only compute Dice if BOTH segmentations produced their PVE outputs;
+        # otherwise skip gracefully (dice stays N/A) instead of letting fslmaths
+        # abort on a missing file (which previously hung the safe_fslmaths watchdog
+        # and emitted bc "Parse error: bad token" on the empty result).
+        local dice_ok=true
+
         log_message "Segmenting fixed image for Dice calculation..."
-        fast -t 1 -n 3 -o "${temp_dir}/fixed_seg" "$fixed"
-        # Combine GM and WM for a brain tissue mask
-        fslmaths "${temp_dir}/fixed_seg_pve_1.nii.gz" -add "${temp_dir}/fixed_seg_pve_2.nii.gz" -thr 0.5 -bin "${temp_dir}/fixed_tissue_mask.nii.gz"
-
-        # Segment warped image (FLAIR)
-        log_message "Segmenting warped image for Dice calculation..."
-        fast -t 2 -n 3 -o "${temp_dir}/warped_seg" "$warped"
-        # Combine GM and WM for a brain tissue mask
-        fslmaths "${temp_dir}/warped_seg_pve_1.nii.gz" -add "${temp_dir}/warped_seg_pve_2.nii.gz" -thr 0.5 -bin "${temp_dir}/warped_tissue_mask.nii.gz"
-
-        # Calculate intersection and union volumes of the tissue masks
-        fslmaths "${temp_dir}/fixed_tissue_mask.nii.gz" -mul "${temp_dir}/warped_tissue_mask.nii.gz" "${temp_dir}/intersection.nii.gz"
-        
-        local vol_fixed=$(fslstats "${temp_dir}/fixed_tissue_mask.nii.gz" -V | awk '{print $1}')
-        local vol_warped=$(fslstats "${temp_dir}/warped_tissue_mask.nii.gz" -V | awk '{print $1}')
-        local vol_intersection=$(fslstats "${temp_dir}/intersection.nii.gz" -V | awk '{print $1}')
-        
-        # Calculate Dice coefficient
-        if [ "$vol_fixed" != "0" ] && [ "$vol_warped" != "0" ]; then
-            dice=$(echo "scale=4; 2 * $vol_intersection / ($vol_fixed + $vol_warped)" | bc)
-            log_message "Dice coefficient: $dice"
-            
-            # Assess quality based on Dice (adjusted thresholds for inter-modality registration)
-            if (( $(echo "$dice > 0.8" | bc -l) )); then
-                quality="EXCELLENT"
-            elif (( $(echo "$dice > 0.6" | bc -l) )); then
-                quality="GOOD"
-            elif (( $(echo "$dice > 0.4" | bc -l) )); then
-                quality="ACCEPTABLE"
-            else
-                quality="POOR"
-            fi
-        else
-            log_formatted "WARNING" "Cannot calculate Dice coefficient (zero volume detected)"
+        if ! fast -t 1 -n 3 -o "${temp_dir}/fixed_seg" "$fixed" >"${temp_dir}/fixed_fast.log" 2>&1 \
+           || [ ! -f "${temp_dir}/fixed_seg_pve_1.nii.gz" ] \
+           || [ ! -f "${temp_dir}/fixed_seg_pve_2.nii.gz" ]; then
+            log_formatted "WARNING" "FAST could not segment the fixed image (low contrast / brain-extracted) - skipping Dice"
+            dice_ok=false
         fi
-        
+
+        if [ "$dice_ok" = true ]; then
+            log_message "Segmenting warped image for Dice calculation..."
+            if ! fast -t 2 -n 3 -o "${temp_dir}/warped_seg" "$warped" >"${temp_dir}/warped_fast.log" 2>&1 \
+               || [ ! -f "${temp_dir}/warped_seg_pve_1.nii.gz" ] \
+               || [ ! -f "${temp_dir}/warped_seg_pve_2.nii.gz" ]; then
+                log_formatted "WARNING" "FAST could not segment the warped image (low contrast / brain-extracted) - skipping Dice"
+                dice_ok=false
+            fi
+        fi
+
+        if [ "$dice_ok" = true ]; then
+            # Combine GM and WM into brain tissue masks, then intersect.
+            fslmaths "${temp_dir}/fixed_seg_pve_1.nii.gz" -add "${temp_dir}/fixed_seg_pve_2.nii.gz" -thr 0.5 -bin "${temp_dir}/fixed_tissue_mask.nii.gz"
+            fslmaths "${temp_dir}/warped_seg_pve_1.nii.gz" -add "${temp_dir}/warped_seg_pve_2.nii.gz" -thr 0.5 -bin "${temp_dir}/warped_tissue_mask.nii.gz"
+            fslmaths "${temp_dir}/fixed_tissue_mask.nii.gz" -mul "${temp_dir}/warped_tissue_mask.nii.gz" "${temp_dir}/intersection.nii.gz"
+
+            local vol_fixed vol_warped vol_intersection
+            vol_fixed=$(fslstats "${temp_dir}/fixed_tissue_mask.nii.gz" -V | awk '{print $1}')
+            vol_warped=$(fslstats "${temp_dir}/warped_tissue_mask.nii.gz" -V | awk '{print $1}')
+            vol_intersection=$(fslstats "${temp_dir}/intersection.nii.gz" -V | awk '{print $1}')
+
+            # Guard against empty/zero volumes before any bc arithmetic.
+            if [ -n "$vol_fixed" ] && [ -n "$vol_warped" ] && [ "$vol_fixed" != "0" ] && [ "$vol_warped" != "0" ]; then
+                dice=$(echo "scale=4; 2 * ${vol_intersection:-0} / ($vol_fixed + $vol_warped)" | bc)
+                log_message "Dice coefficient: $dice"
+
+                # Assess quality based on Dice (inter-modality-adjusted thresholds).
+                if [ -n "$dice" ] && (( $(echo "$dice > 0.8" | bc -l) )); then
+                    quality="EXCELLENT"
+                elif [ -n "$dice" ] && (( $(echo "$dice > 0.6" | bc -l) )); then
+                    quality="GOOD"
+                elif [ -n "$dice" ] && (( $(echo "$dice > 0.4" | bc -l) )); then
+                    quality="ACCEPTABLE"
+                else
+                    quality="POOR"
+                fi
+            else
+                log_formatted "WARNING" "Cannot calculate Dice coefficient (zero/empty volume detected)"
+            fi
+        fi
+
         # Clean up
         rm -rf "$temp_dir"
     else

--- a/src/modules/registration.sh
+++ b/src/modules/registration.sh
@@ -1494,6 +1494,31 @@ register_contrast_matched_modality() {
 
     local ants_bin="${ANTS_BIN:-${ANTS_PATH}/bin}"
 
+    # --- Handle 4D modality inputs (e.g. DWI trace+ADC / multi-b) ----------------
+    # antsApplyTransforms -d 3 aborts immediately on a 4D input, and every
+    # downstream stage expects a single 3D image.  If the modality has more than
+    # one volume, extract volume 0 ONCE and use it for BOTH the FLAIR registration
+    # and the composed resample so the moving image stays consistent with the
+    # transform.  Output naming stays tied to the original modality basename.
+    local modality_input="$modality_image"
+    local mod_ndim
+    mod_ndim=$(fslval "$modality_image" dim0 2>/dev/null | tr -d ' ')
+    if [ "${mod_ndim:-3}" = "4" ]; then
+        local mod_nvol
+        mod_nvol=$(fslval "$modality_image" dim4 2>/dev/null | tr -d ' ')
+        if [ "${mod_nvol:-1}" -gt 1 ] 2>/dev/null; then
+            local modality_3d="${output_dir}/$(basename "$modality_image" .nii.gz)_vol0.nii.gz"
+            log_formatted "WARNING" "${modality_name} image is 4D (${mod_nvol} volumes); using volume 0 for the cascade: $modality_3d"
+            if [ ! -s "$modality_3d" ]; then
+                if ! fslroi "$modality_image" "$modality_3d" 0 1; then
+                    log_formatted "ERROR" "Failed to extract a 3D volume from the 4D ${modality_name} image"
+                    return "${ERR_PREPROC:-1}"
+                fi
+            fi
+            modality_input="$modality_3d"
+        fi
+    fi
+
     # --- Step 1: register the modality to the FLAIR anchor (same-contrast). -----
     # Reuse register_to_reference (multi-stage rigid->affine->SyN).  The metric is
     # chosen inside perform_multistage_registration: same modality name => CC,
@@ -1510,7 +1535,7 @@ register_contrast_matched_modality() {
         # Capture status without tripping `set -e` if a caller invokes this
         # function outside an if/|| context.
         local reg_status=0
-        register_to_reference "$flair_anchor" "$modality_image" "$modality_name" "$mod_to_flair_prefix" || reg_status=$?
+        register_to_reference "$flair_anchor" "$modality_input" "$modality_name" "$mod_to_flair_prefix" || reg_status=$?
         if [ "$reg_status" -ne 0 ] || [ ! -f "$mod_to_flair_warped" ]; then
             log_formatted "ERROR" "${modality_name}->FLAIR registration failed (status $reg_status)"
             return "${ERR_REGISTRATION:-1}"
@@ -1585,7 +1610,7 @@ register_contrast_matched_modality() {
         "Composed ${modality_name}->FLAIR->T1 resample (single application)" \
         "${ants_bin}/antsApplyTransforms" \
         -d 3 \
-        -i "$modality_image" \
+        -i "$modality_input" \
         -r "$t1_reference" \
         -o "$composed_warped" \
         "${forward_args[@]}" \


### PR DESCRIPTION
## Summary

- **registration.sh (Bug 1):** `antsApplyTransforms -d 3` aborts immediately when the modality image is 4D (e.g. a DWI series with 2 volumes, common with trace+ADC scans). Root cause: `register_contrast_matched_modality()` passed `$modality_image` directly to both `register_to_reference` and the composed resample step. Fix: detect a 4D input via `fslval dim0`, extract volume 0 with `fslroi` into a 3D sidecar, and use that (`$modality_input`) for both the FLAIR registration and the `antsApplyTransforms` call. Naming/provenance variables continue to use `$modality_image` so manifest files and output basenames are unchanged.

- **qa.sh (Bug 2):** `calculate_extended_registration_metrics()` ran `fast` unconditionally and then called `fslmaths` on the `*_pve_*` outputs it produces — but FAST aborts with "Not enough classes detected to init KMeans" on low-contrast / already-brain-extracted images (DWI trace, SWI, etc.) and never writes those files. The `fslmaths` call on a missing file triggered abort trap 6, which hung the `safe_fslmaths` watchdog for ~10 minutes, after which an empty result was fed to `bc` causing "Parse error: bad token". Fix: run `fast` with stdout/stderr redirected, check both the exit status AND the existence of both PVE maps, and skip the Dice calculation gracefully (leaving `dice=N/A`) when either segmentation fails. All `bc` arithmetic is also guarded against empty/zero operands.

Both fixes are surgical — no other functions, files, or behaviour are touched.

## Test plan

- [x] `bash -n src/modules/qa.sh && bash -n src/modules/registration.sh` — no syntax errors
- [x] `shellcheck --severity=error src/modules/qa.sh src/modules/registration.sh` — clean
- [x] `declare -f calculate_extended_registration_metrics` resolves after sourcing
- [x] `declare -f register_contrast_matched_modality` resolves after sourcing
- [x] `bash tests/test_environment_unit.sh` — 100/100 PASS
- [x] `bash tests/test_pipeline_control_unit.sh` — 98/98 PASS
- [x] `git diff --stat` shows only `src/modules/qa.sh` and `src/modules/registration.sh`

🤖 Generated with [Claude Code](https://claude.com/claude-code)