### PR TITLE
Skip 4D-DWI in contrast-matched cascade + harden registration Dice metric

### DIFF
--- a/src/modules/qa.sh
+++ b/src/modules/qa.sh
@@ -848,50 +848,71 @@ calculate_extended_registration_metrics() {
     local jacobian_std="N/A"
     local quality="UNKNOWN"
     
-    # 1. Calculate Dice coefficient between T1 brain and FLAIR brain
+    # 1. Calculate Dice coefficient between fixed and warped tissue masks.
     log_message "Calculating Dice coefficient between brains"
     if [ -f "$fixed" ] && [ -f "$warped" ]; then
         # Create tissue-specific masks for more accurate Dice calculation
-        local temp_dir=$(mktemp -d)
-        
-        # Segment fixed image (T1)
+        local temp_dir
+        temp_dir=$(mktemp -d)
+
+        # FAST often cannot segment low-contrast / already-brain-extracted images
+        # (DWI trace, SWI, etc.): it aborts with "Not enough classes detected to
+        # init KMeans" and never writes the *_pve_* maps.  Run it defensively and
+        # only compute Dice if BOTH segmentations produced their PVE outputs;
+        # otherwise skip gracefully (dice stays N/A) instead of letting fslmaths
+        # abort on a missing file (which previously hung the safe_fslmaths watchdog
+        # and emitted bc "Parse error: bad token" on the empty result).
+        local dice_ok=true
+
         log_message "Segmenting fixed image for Dice calculation..."
-        fast -t 1 -n 3 -o "${temp_dir}/fixed_seg" "$fixed"
-        # Combine GM and WM for a brain tissue mask
-        fslmaths "${temp_dir}/fixed_seg_pve_1.nii.gz" -add "${temp_dir}/fixed_seg_pve_2.nii.gz" -thr 0.5 -bin "${temp_dir}/fixed_tissue_mask.nii.gz"
-
-        # Segment warped image (FLAIR)
-        log_message "Segmenting warped image for Dice calculation..."
-        fast -t 2 -n 3 -o "${temp_dir}/warped_seg" "$warped"
-        # Combine GM and WM for a brain tissue mask
-        fslmaths "${temp_dir}/warped_seg_pve_1.nii.gz" -add "${temp_dir}/warped_seg_pve_2.nii.gz" -thr 0.5 -bin "${temp_dir}/warped_tissue_mask.nii.gz"
-
-        # Calculate intersection and union volumes of the tissue masks
-        fslmaths "${temp_dir}/fixed_tissue_mask.nii.gz" -mul "${temp_dir}/warped_tissue_mask.nii.gz" "${temp_dir}/intersection.nii.gz"
-        
-        local vol_fixed=$(fslstats "${temp_dir}/fixed_tissue_mask.nii.gz" -V | awk '{print $1}')
-        local vol_warped=$(fslstats "${temp_dir}/warped_tissue_mask.nii.gz" -V | awk '{print $1}')
-        local vol_intersection=$(fslstats "${temp_dir}/intersection.nii.gz" -V | awk '{print $1}')
-        
-        # Calculate Dice coefficient
-        if [ "$vol_fixed" != "0" ] && [ "$vol_warped" != "0" ]; then
-            dice=$(echo "scale=4; 2 * $vol_intersection / ($vol_fixed + $vol_warped)" | bc)
-            log_message "Dice coefficient: $dice"
-            
-            # Assess quality based on Dice (adjusted thresholds for inter-modality registration)
-            if (( $(echo "$dice > 0.8" | bc -l) )); then
-                quality="EXCELLENT"
-            elif (( $(echo "$dice > 0.6" | bc -l) )); then
-                quality="GOOD"
-            elif (( $(echo "$dice > 0.4" | bc -l) )); then
-                quality="ACCEPTABLE"
-            else
-                quality="POOR"
-            fi
-        else
-            log_formatted "WARNING" "Cannot calculate Dice coefficient (zero volume detected)"
+        if ! fast -t 1 -n 3 -o "${temp_dir}/fixed_seg" "$fixed" >"${temp_dir}/fixed_fast.log" 2>&1 \
+           || [ ! -f "${temp_dir}/fixed_seg_pve_1.nii.gz" ] \
+           || [ ! -f "${temp_dir}/fixed_seg_pve_2.nii.gz" ]; then
+            log_formatted "WARNING" "FAST could not segment the fixed image (low contrast / brain-extracted) - skipping Dice"
+            dice_ok=false
         fi
-        
+
+        if [ "$dice_ok" = true ]; then
+            log_message "Segmenting warped image for Dice calculation..."
+            if ! fast -t 2 -n 3 -o "${temp_dir}/warped_seg" "$warped" >"${temp_dir}/warped_fast.log" 2>&1 \
+               || [ ! -f "${temp_dir}/warped_seg_pve_1.nii.gz" ] \
+               || [ ! -f "${temp_dir}/warped_seg_pve_2.nii.gz" ]; then
+                log_formatted "WARNING" "FAST could not segment the warped image (low contrast / brain-extracted) - skipping Dice"
+                dice_ok=false
+            fi
+        fi
+
+        if [ "$dice_ok" = true ]; then
+            # Combine GM and WM into brain tissue masks, then intersect.
+            fslmaths "${temp_dir}/fixed_seg_pve_1.nii.gz" -add "${temp_dir}/fixed_seg_pve_2.nii.gz" -thr 0.5 -bin "${temp_dir}/fixed_tissue_mask.nii.gz"
+            fslmaths "${temp_dir}/warped_seg_pve_1.nii.gz" -add "${temp_dir}/warped_seg_pve_2.nii.gz" -thr 0.5 -bin "${temp_dir}/warped_tissue_mask.nii.gz"
+            fslmaths "${temp_dir}/fixed_tissue_mask.nii.gz" -mul "${temp_dir}/warped_tissue_mask.nii.gz" "${temp_dir}/intersection.nii.gz"
+
+            local vol_fixed vol_warped vol_intersection
+            vol_fixed=$(fslstats "${temp_dir}/fixed_tissue_mask.nii.gz" -V | awk '{print $1}')
+            vol_warped=$(fslstats "${temp_dir}/warped_tissue_mask.nii.gz" -V | awk '{print $1}')
+            vol_intersection=$(fslstats "${temp_dir}/intersection.nii.gz" -V | awk '{print $1}')
+
+            # Guard against empty/zero volumes before any bc arithmetic.
+            if [ -n "$vol_fixed" ] && [ -n "$vol_warped" ] && [ "$vol_fixed" != "0" ] && [ "$vol_warped" != "0" ]; then
+                dice=$(echo "scale=4; 2 * ${vol_intersection:-0} / ($vol_fixed + $vol_warped)" | bc)
+                log_message "Dice coefficient: $dice"
+
+                # Assess quality based on Dice (inter-modality-adjusted thresholds).
+                if [ -n "$dice" ] && (( $(echo "$dice > 0.8" | bc -l) )); then
+                    quality="EXCELLENT"
+                elif [ -n "$dice" ] && (( $(echo "$dice > 0.6" | bc -l) )); then
+                    quality="GOOD"
+                elif [ -n "$dice" ] && (( $(echo "$dice > 0.4" | bc -l) )); then
+                    quality="ACCEPTABLE"
+                else
+                    quality="POOR"
+                fi
+            else
+                log_formatted "WARNING" "Cannot calculate Dice coefficient (zero/empty volume detected)"
+            fi
+        fi
+
         # Clean up
         rm -rf "$temp_dir"
     else

--- a/src/modules/registration.sh
+++ b/src/modules/registration.sh
@@ -1490,6 +1490,18 @@ register_contrast_matched_modality() {
         return "${ERR_REGISTRATION:-1}"
     fi
 
+    # Refuse 4D / multi-volume inputs.  A raw DWI stack (b0+trace, trace+ADC,
+    # multi-b) is not a single-contrast 3D image: registering/resampling it as one
+    # modality is meaningless and antsApplyTransforms -d 3 aborts on it.  The
+    # cascade filters these out before calling; this is a defensive guard for
+    # direct callers.  The derived 3D trace/ADC come through as their own specs.
+    local mod_nvol
+    mod_nvol=$(fslval "$modality_image" dim4 2>/dev/null | tr -d ' ')
+    if [ "${mod_nvol:-1}" -gt 1 ] 2>/dev/null; then
+        log_formatted "WARNING" "Contrast-matched: ${modality_name} is 4D (${mod_nvol} volumes); skipping (use the derived 3D trace/ADC instead)"
+        return "${ERR_DATA_MISSING:-1}"
+    fi
+
     mkdir -p "$output_dir"
 
     local ants_bin="${ANTS_BIN:-${ANTS_PATH}/bin}"
@@ -1632,7 +1644,7 @@ register_contrast_matched_cascade() {
 
     local overall_status=0
     local processed=0
-    local spec name path anchor
+    local spec name path anchor nvol
     for spec in "${specs[@]}"; do
         name="${spec%%=*}"
         path="${spec#*=}"
@@ -1645,6 +1657,16 @@ register_contrast_matched_cascade() {
         anchor="$(resolve_contrast_anchor "$name")"
         if [ "$anchor" != "FLAIR" ]; then
             log_message "Skipping ${name}: anchor is '${anchor}', not FLAIR (handled by the standard T1 path)"
+            continue
+        fi
+
+        # Refuse 4D / multi-volume inputs (raw DWI stack: b0+trace, trace+ADC,
+        # multi-b).  These are not single-contrast 3D images, so registering them
+        # as one modality is meaningless and antsApplyTransforms -d 3 aborts.  The
+        # derived 3D trace/ADC, if present, come through as their own specs.
+        nvol="$(fslval "$path" dim4 2>/dev/null | tr -d ' ')"
+        if [ "${nvol:-1}" -gt 1 ] 2>/dev/null; then
+            log_formatted "WARNING" "Skipping ${name}: 4D/multi-volume image (${nvol} vols) is not a single-contrast 3D modality"
             continue
         fi
 


### PR DESCRIPTION
## Summary

Two root-cause fixes for crashes introduced when secondary modalities (raw 4D DWI stacks) were fed into the contrast-matched registration cascade:

### Fix 1 — `registration.sh`: skip 4D / multi-volume modality inputs

**Root cause:** `antsApplyTransforms -d 3` aborts immediately when given a 4D input. A raw DWI stack (e.g. b0+trace or trace+ADC combined as two volumes by dcm2niix) is **not** a single-contrast 3D image and should never enter the cascade. The derived 3D trace/ADC volumes arrive as their own separate specs and are registered correctly.

Two guards were added:
- **Cascade orchestrator** (`register_contrast_matched_cascade`): reads `fslval dim4` and skips any spec whose image has more than one volume, with a clear WARNING.
- **Modality function** (`register_contrast_matched_modality`): same guard as a defensive backstop for direct callers.

### Fix 2 — `qa.sh`: harden Dice calculation when FAST fails

**Root cause:** FSL FAST aborts with "Not enough classes detected to init KMeans" on low-contrast or already-brain-extracted images (DWI trace, SWI, ADC). It exits non-zero and never writes the `*_pve_*` maps. The old code called `fslmaths` unconditionally on those missing files, triggering the `safe_fslmaths` watchdog hang, and then passed an empty string to `bc`, producing a "Parse error: bad token" that set `dice` to an empty string, cascading into further errors.

The fix runs `fast` under `if !` so a non-zero exit is caught; additionally checks that both `_pve_1` and `_pve_2` files actually exist before proceeding; and guards all `bc` arithmetic against empty/zero volumes. When FAST can't segment, Dice is left as `N/A` and the pipeline continues gracefully.

### Supersedes PR #141

PR #141 used a `fslroi -t 0 1` approach to collapse 4D inputs to volume 0, which was rejected. This PR takes the correct approach: skip 4D inputs entirely in the cascade.

## Test plan

- [x] `bash -n src/modules/qa.sh` — no syntax errors
- [x] `bash -n src/modules/registration.sh` — no syntax errors
- [x] `shellcheck --severity=error src/modules/qa.sh src/modules/registration.sh` — no findings
- [x] `git diff --stat` shows only `src/modules/qa.sh` and `src/modules/registration.sh`
- [x] `grep -c modality_input src/modules/registration.sh` returns 0 (rejected vol0 approach absent)
- [x] `bash tests/test_environment_unit.sh` — 100/100 passed
- [x] `bash tests/test_pipeline_control_unit.sh` — 98/98 passed

🤖 Generated with [Claude Code](https://claude.com/claude-code)