### PR TITLE
Unit B: within-subject registration presets (WITHIN_SUBJECT_REGISTRATION)

### DIFF
--- a/config/default_config.sh
+++ b/config/default_config.sh
@@ -394,6 +394,19 @@ export REG_METRIC_CROSS_MODALITY="MI"  # Mutual Information - for cross-modality
 export REG_METRIC_SAME_MODALITY="CC"   # Cross Correlation - for same modality
 export REG_PRECISION=1                 # Registration precision
 
+# Within-subject (same-subject, cross-session) registration presets (Unit B).
+# When true: same-modality pairs use rigid-only (6 DOF, no SyN); cross-modal
+# pairs use rigid + MI + a constrained low-deformation SyN stage to preserve
+# morphometry across timepoints.  Default false = unchanged behaviour.
+export WITHIN_SUBJECT_REGISTRATION="${WITHIN_SUBJECT_REGISTRATION:-false}"
+
+# ANTs convergence schedule for the constrained within-subject SyN stage
+# (cross-modal path when WITHIN_SUBJECT_REGISTRATION=true).  Format is
+# [iterationsxiterationsxiterations,convergenceThreshold,windowSize] matching
+# the number of resolution levels in TEMPLATE_SHRINK_FACTORS (default 4 levels).
+# Fewer iterations than the default SyN to limit deformation in cross-session alignment.
+export WITHIN_SUBJECT_SYN_CONVERGENCE="${WITHIN_SUBJECT_SYN_CONVERGENCE:-[20x10x5x2,1e-6,10]}"
+
 # Per-metric tuning shared by all stages of perform_multistage_registration().
 # CC radius applies when CC is used (same-modality SyN); MI bins apply when MI is
 # used (cross-modality rigid/affine/SyN). The SyN stage now selects MI for

--- a/src/modules/registration.sh
+++ b/src/modules/registration.sh
@@ -57,7 +57,7 @@ perform_multistage_registration() {
     log_message "Fixed: $fixed_image"
     log_message "Moving: $moving_image"
     log_message "Output: $output_prefix"
-    
+
     local ants_bin="${ANTS_BIN:-${ANTS_PATH}/bin}"
 
     # Winsorize intensity tails to suppress outliers (antsRegistrationSyN.sh standard).
@@ -79,7 +79,7 @@ perform_multistage_registration() {
         "--initialize-transforms-per-stage" "0"
         "--verbose" "1"
     )
-    
+
     # Add initial transform if provided
     if [ -n "$initial_transform" ] && [ -f "$initial_transform" ]; then
         ants_cmd+=("--initial-moving-transform" "$initial_transform")
@@ -87,19 +87,19 @@ perform_multistage_registration() {
     else
         ants_cmd+=("--initial-moving-transform" "[${fixed_image},${moving_image},1]")
     fi
-    
+
     # Add masks if provided
     if [ -n "$mask" ] && [ -f "$mask" ]; then
         ants_cmd+=("--masks" "[${mask},NULL]")
         log_message "Using registration mask: $mask"
     fi
-    
+
     # Set registration parameters based on QUALITY_PRESET
     local quality_preset="${QUALITY_PRESET:-HIGH}"
     local rigid_convergence="[1000x500x250x100,1e-6,10]"
     local affine_convergence="[1000x500x250x100,1e-6,10]"
     local syn_convergence="[100x70x50x20,1e-6,10]"
-    
+
     case "$quality_preset" in
         "ULTRA")
             rigid_convergence="[2000x1000x500x250,1e-8,15]"
@@ -122,11 +122,94 @@ perform_multistage_registration() {
             syn_convergence="[25x20x15x10,1e-4,5]"
             ;;
     esac
-    
-    # Stage 1: Rigid registration
-    local rigid_metric="${REG_METRIC_CROSS_MODALITY:-MI}"
+
+    # ---------------------------------------------------------------------------
+    # WITHIN-SUBJECT REGISTRATION PRESETS  (Unit B — longitudinal, same-subject)
+    # ---------------------------------------------------------------------------
+    # When WITHIN_SUBJECT_REGISTRATION=true the brain is the SAME anatomy across
+    # sessions.  Morphometry must be PRESERVED, not warped away by full SyN.
+    #
+    #   Same-modality (fixed == moving modality, e.g. T1<->T1):
+    #     Rigid-only (6 DOF).  The affine-scaling and large-deformation SyN stages
+    #     are SKIPPED entirely to prevent any shape change between sessions.
+    #
+    #   Cross-modal (e.g. FLAIR->T1, contrast-T1->T1):
+    #     Rigid initialization with MI + a CONSTRAINED low-deformation SyN stage
+    #     (small gradient step 0.05, tight update-field sigma 0.5 vox, total-field
+    #     sigma 0 = off, few iterations 20x10x5x2) instead of full default SyN.
+    #     This corrects EPI / susceptibility distortion and contrast mis-registration
+    #     without morphing the anatomy.
+    #
+    # The entire within-subject block is guarded by [ "$within_subject" = "true" ]
+    # so the default-off (false) path falls through to the UNCHANGED rigid->affine->
+    # SyN cascade below — byte-identical behaviour to before Unit B.
+    # ---------------------------------------------------------------------------
+    local within_subject="${WITHIN_SUBJECT_REGISTRATION:-false}"
     local shrink_factors="${TEMPLATE_SHRINK_FACTORS:-6x4x2x1}"
     local smoothing_sigmas="${TEMPLATE_SMOOTHING_SIGMAS:-3x2x1x0}"
+
+    if [ "$within_subject" = "true" ]; then
+        local mi_bins_ws="${REG_MI_BINS:-32}"
+        local ws_mi_metric="${REG_METRIC_CROSS_MODALITY:-MI}"
+        local is_same_modality=false
+        if [ -n "$fixed_modality" ] && [ -n "$moving_modality" ] && \
+           [ "$fixed_modality" = "$moving_modality" ]; then
+            is_same_modality=true
+        fi
+
+        if [ "$is_same_modality" = "true" ]; then
+            # Same-modality within-subject: rigid-only (6 DOF).
+            # MI is used rather than CC because field-strength or sequence
+            # parameters may differ between sessions of the same subject, making
+            # MI more robust than the intensity-correlation-dependent CC.
+            log_message "Within-subject same-modality: rigid-only (6 DOF, MI)"
+            ants_cmd+=(
+                "--transform" "Rigid[0.1]"
+                "--metric" "${ws_mi_metric}[${fixed_image},${moving_image},1,${mi_bins_ws},Regular,0.25]"
+                "--convergence" "$rigid_convergence"
+                "--shrink-factors" "$shrink_factors"
+                "--smoothing-sigmas" "${smoothing_sigmas}vox"
+            )
+            log_message "Within-subject registration command: ${ants_cmd[*]}"
+            execute_ants_command "multistage_registration" \
+                "Within-subject rigid-only registration (6 DOF)" "${ants_cmd[@]}"
+        else
+            # Cross-modal within-subject: rigid + MI + constrained SyN.
+            # SyN[gradientStep,updateFieldSigmaInVoxels,totalFieldSigmaInVoxels]:
+            #   gradientStep=0.05  (half the default 0.1) limits deformation magnitude
+            #   updateFieldSigma=0.5 vox  tight regularization of per-iteration updates
+            #   totalFieldSigma=0  disables additional smoothing of the velocity field
+            # Iteration schedule 20x10x5x2 is far fewer than the default 100x70x50x20
+            # — enough for cross-modal alignment without anatomical distortion.
+            log_message "Within-subject cross-modal: rigid + MI + constrained SyN"
+            local ws_syn_convergence="${WITHIN_SUBJECT_SYN_CONVERGENCE:-[20x10x5x2,1e-6,10]}"
+            # Stage 1: Rigid with MI
+            ants_cmd+=(
+                "--transform" "Rigid[0.1]"
+                "--metric" "${ws_mi_metric}[${fixed_image},${moving_image},1,${mi_bins_ws},Regular,0.25]"
+                "--convergence" "$rigid_convergence"
+                "--shrink-factors" "$shrink_factors"
+                "--smoothing-sigmas" "${smoothing_sigmas}vox"
+            )
+            # Stage 2: Constrained low-deformation SyN with MI
+            ants_cmd+=(
+                "--transform" "SyN[0.05,0.5,0]"
+                "--metric" "${ws_mi_metric}[${fixed_image},${moving_image},1,${mi_bins_ws},Regular,0.25]"
+                "--convergence" "$ws_syn_convergence"
+                "--shrink-factors" "$shrink_factors"
+                "--smoothing-sigmas" "${smoothing_sigmas}vox"
+            )
+            log_message "Within-subject registration command: ${ants_cmd[*]}"
+            execute_ants_command "multistage_registration" \
+                "Within-subject cross-modal registration (rigid + constrained SyN)" "${ants_cmd[@]}"
+        fi
+    else
+    # ---------------------------------------------------------------------------
+    # DEFAULT PATH: rigid → affine → SyN  (unchanged from before Unit B)
+    # ---------------------------------------------------------------------------
+
+    # Stage 1: Rigid registration
+    local rigid_metric="${REG_METRIC_CROSS_MODALITY:-MI}"
     ants_cmd+=(
         "--transform" "Rigid[0.1]"
         "--metric" "${rigid_metric}[${fixed_image},${moving_image},1,32,Regular,0.25]"
@@ -134,7 +217,7 @@ perform_multistage_registration() {
         "--shrink-factors" "$shrink_factors"
         "--smoothing-sigmas" "${smoothing_sigmas}vox"
     )
-    
+
     # Stage 2: Affine registration
     local affine_metric="${REG_METRIC_CROSS_MODALITY:-MI}"
     ants_cmd+=(
@@ -144,7 +227,7 @@ perform_multistage_registration() {
         "--shrink-factors" "$shrink_factors"
         "--smoothing-sigmas" "${smoothing_sigmas}vox"
     )
-    
+
     # Stage 3: SyN registration
     # Select the SyN metric the same way the rigid/affine stages do: CC assumes
     # correlated intensities, which only holds for same-modality pairs.  For a
@@ -171,11 +254,13 @@ perform_multistage_registration() {
         "--shrink-factors" "$shrink_factors"
         "--smoothing-sigmas" "${smoothing_sigmas}vox"
     )
-    
+
     log_message "Multi-stage registration command: ${ants_cmd[*]}"
-    
+
     # Execute the multi-stage registration
     execute_ants_command "multistage_registration" "Multi-stage registration (rigid→affine→SyN)" "${ants_cmd[@]}"
+    fi  # end within_subject branch
+
     local reg_status=$?
     
     # Check registration status first


### PR DESCRIPTION
## Summary

- Adds `WITHIN_SUBJECT_REGISTRATION` flag (default `false`) to `config/default_config.sh` in the registration config block
- When `true`, `perform_multistage_registration()` in `src/modules/registration.sh` selects rigid-dominant presets for same-subject (cross-session) registration:
  - **Same-modality** (e.g. T1→T1): rigid-only, 6 DOF — no affine-scaling or large-deformation SyN stages, preserving morphometry exactly
  - **Cross-modal** (e.g. FLAIR→T1): rigid initialization with MI + constrained low-deformation SyN (`SyN[0.05,0.5,0]`, 20×10×5×2 iterations) — corrects EPI/susceptibility distortion without anatomical warping
- `WITHIN_SUBJECT_SYN_CONVERGENCE` (default `[20x10x5x2,1e-6,10]`) declared in config so it is discoverable and tunable
- **Backward-compatible**: guarded by `if [ "$within_subject" = "true" ]`; with `WITHIN_SUBJECT_REGISTRATION=false` (the default) the entire new block is skipped and the existing rigid→affine→SyN cascade runs byte-identically

## Backward-compat guarantee

The default-path guard is:
```bash
local within_subject="${WITHIN_SUBJECT_REGISTRATION:-false}"
if [ "$within_subject" = "true" ]; then
    # ... new within-subject presets ...
else
    # default: rigid → affine → SyN — unchanged from before Unit B
    ...
    execute_ants_command "multistage_registration" "Multi-stage registration (rigid→affine→SyN)" "${ants_cmd[@]}"
fi
```
When `WITHIN_SUBJECT_REGISTRATION` is unset or `false`, the `else` branch runs. The command array, stage parameters, metric selection, and `execute_ants_command` call in the else branch are byte-identical to the code before this PR.

## Test plan

- [ ] `bash -n` on both changed files: pass
- [ ] `shellcheck --severity=error` on both changed files: pass
- [ ] `bash tests/test_environment_unit.sh`: 100 passed, 0 failed
- [ ] `bash tests/test_pipeline_control_unit.sh`: 98 passed, 0 failed
- [ ] `bash tests/test_import_unit.sh`: 29 passed, 0 failed
- [ ] `bash src/pipeline.sh --help | grep -q "Usage:"`: pass
- [ ] `declare -f register_to_reference` after sourcing module: OK
- [ ] PII grep on diff: clean (no paths, emails, dates, study IDs)
- [ ] `git diff --stat` shows only `config/default_config.sh` and `src/modules/registration.sh`
- [ ] Code review (high effort): one actionable finding fixed (`WITHIN_SUBJECT_SYN_CONVERGENCE` missing from config); no correctness bugs surviving verification

## Scope

Unit B only — no changes to the longitudinal orchestrator, contrast-T1 detection, or analysis. Implements spec §6 / §8.B from `docs/longitudinal_multisession_spec.md`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)