### PR TITLE
Unit C: contrast-enhanced T1 detection + non-contrast anchor preference

### DIFF
--- a/src/modules/reference_space_selection.sh
+++ b/src/modules/reference_space_selection.sh
@@ -13,6 +13,10 @@
 # 5. Modality-specific suitability (+100)
 #
 
+# Include guard
+if [ -n "${_REFERENCE_SPACE_SELECTION_LOADED:-}" ]; then return 0 2>/dev/null || true; fi
+_REFERENCE_SPACE_SELECTION_LOADED=1
+
 # Source environment and existing scan selection functions
 SCRIPT_DIR="$(dirname "${BASH_SOURCE[0]}")"
 source "${SCRIPT_DIR}/require_env.sh"
@@ -536,6 +540,140 @@ log_decision_rationale() {
     log_message "Rationale: $rationale"
 }
 
+# ---------------------------------------------------------------------------
+# is_contrast_enhanced_t1 <nifti_path>
+# ---------------------------------------------------------------------------
+# Returns 0 (true) when the supplied T1 image appears to be a post-gadolinium
+# (contrast-enhanced) acquisition; returns 1 (false) otherwise.
+#
+# Detection priority:
+#   1. dcm2niix JSON sidecar (same basename, .json):
+#        a. jq path  — ContrastBolusAgent present and non-empty/non-"NONE"
+#                    — ImageType array contains "CONTRAST" (case-insensitive)
+#        b. grep fallback when jq is absent
+#   2. Conservative filename heuristics ONLY when no sidecar is found.
+#      False-positive risk is explicit-logged; tokens are kept generic.
+#
+# IMPORTANT: this function is purely advisory.  A true-positive means the
+# pipeline should prefer a configured non-contrast external anchor; it never
+# deletes or hides the contrast-enhanced image (it remains as enhancement
+# signal).  False positives with PREFER_EXTERNAL_NONCONTRAST_T1=false are
+# harmless because the guard is never entered.
+# ---------------------------------------------------------------------------
+is_contrast_enhanced_t1() {
+    local nifti_path="$1"
+    log_message "is_contrast_enhanced_t1: checking $(basename "${nifti_path}")"
+
+    # Resolve the JSON sidecar path (support both .nii.gz and .nii).
+    local json_file=""
+    if [[ "${nifti_path}" == *.nii.gz ]]; then
+        json_file="${nifti_path%.nii.gz}.json"
+    elif [[ "${nifti_path}" == *.nii ]]; then
+        json_file="${nifti_path%.nii}.json"
+    fi
+
+    # -----------------------------------------------------------------------
+    # Primary path: DICOM/JSON metadata via dcm2niix sidecar
+    # -----------------------------------------------------------------------
+    if [ -n "${json_file}" ] && [ -f "${json_file}" ]; then
+        log_message "is_contrast_enhanced_t1: sidecar found: $(basename "${json_file}")"
+
+        if command -v jq &>/dev/null; then
+            # --- ContrastBolusAgent: present, non-empty, and not "NONE" ----
+            local contrast_agent
+            contrast_agent=$(jq -r '.ContrastBolusAgent // empty' "${json_file}" 2>/dev/null || true)
+            if [ -n "${contrast_agent}" ]; then
+                local _ca_upper
+                _ca_upper=$(printf '%s' "${contrast_agent}" | tr '[:lower:]' '[:upper:]')
+                if [ "${_ca_upper}" != "NONE" ] && [ "${_ca_upper}" != "NULL" ]; then
+                    log_message "is_contrast_enhanced_t1: CONTRAST detected via ContrastBolusAgent='${contrast_agent}' (jq, JSON sidecar)"
+                    return 0
+                fi
+            fi
+
+            # --- ImageType array: any element matches /CONTRAST/i -----------
+            local has_contrast_type
+            has_contrast_type=$(jq -r '
+                if (.ImageType | type) == "array" then
+                    .ImageType[] | ascii_downcase
+                elif (.ImageType | type) == "string" then
+                    .ImageType | ascii_downcase
+                else empty end' "${json_file}" 2>/dev/null \
+                | grep -qi "contrast" && echo "yes" || true)
+            if [ "${has_contrast_type}" = "yes" ]; then
+                log_message "is_contrast_enhanced_t1: CONTRAST detected via ImageType (jq, JSON sidecar)"
+                return 0
+            fi
+
+            log_message "is_contrast_enhanced_t1: sidecar present; no contrast markers found (jq)"
+            return 1
+        else
+            # --- grep-based fallback (no jq) --------------------------------
+            # ContrastBolusAgent: field present and value is not empty/"NONE"
+            local agent_line
+            agent_line=$(grep -i '"ContrastBolusAgent"' "${json_file}" 2>/dev/null | head -1 || true)
+            if [ -n "${agent_line}" ]; then
+                # Extract the value after the colon, strip quotes and whitespace
+                local agent_val
+                agent_val=$(echo "${agent_line}" | sed 's/.*"ContrastBolusAgent"[[:space:]]*:[[:space:]]*//' \
+                    | sed 's/[",[:space:]]//g')
+                local agent_upper
+                agent_upper=$(printf '%s' "${agent_val}" | tr '[:lower:]' '[:upper:]')
+                if [ -n "${agent_upper}" ] && \
+                   [ "${agent_upper}" != "NONE" ] && \
+                   [ "${agent_upper}" != "NULL" ]; then
+                    log_message "is_contrast_enhanced_t1: CONTRAST detected via ContrastBolusAgent (grep fallback, JSON sidecar)"
+                    return 0
+                fi
+            fi
+
+            # ImageType contains "CONTRAST" (case-insensitive)
+            if grep -i '"ImageType"' "${json_file}" 2>/dev/null | grep -qi "contrast"; then
+                log_message "is_contrast_enhanced_t1: CONTRAST detected via ImageType (grep fallback, JSON sidecar)"
+                return 0
+            fi
+
+            log_message "is_contrast_enhanced_t1: sidecar present; no contrast markers found (grep fallback)"
+            return 1
+        fi
+    fi
+
+    # -----------------------------------------------------------------------
+    # Weak fallback: conservative filename heuristics (no sidecar available)
+    # These tokens are deliberately generic to avoid false positives.
+    # Log explicitly that the decision is heuristic-based.
+    # -----------------------------------------------------------------------
+    local fname
+    fname=$(basename "${nifti_path}" | tr '[:upper:]' '[:lower:]')
+    # Remove extension for cleaner token matching
+    fname="${fname%.nii.gz}"
+    fname="${fname%.nii}"
+
+    local matched_token=""
+    # Require unambiguous post-contrast markers; avoid generic words like "c".
+    # "+c" and "_c_" are excluded: they false-positive on names containing
+    # "acq+contrast" or similar.  Metadata (ContrastBolusAgent / ImageType) is
+    # the primary signal; these tokens are only reached when no sidecar exists.
+    for token in "post_gad" "postgad" "postcontrast" "post_contrast" \
+                 "postgd" "post_gd" "_gd_" "_gd." \
+                 "_ce_" "_ce." "ce_t1" "t1ce" "t1_ce" \
+                 "gad_" "_gad" "gadolinium"; do
+        if [[ "${fname}" == *"${token}"* ]]; then
+            matched_token="${token}"
+            break
+        fi
+    done
+
+    if [ -n "${matched_token}" ]; then
+        log_formatted "WARNING" \
+            "is_contrast_enhanced_t1: CONTRAST suspected via filename heuristic '${matched_token}' in '$(basename "${nifti_path}")' (no JSON sidecar). Verify manually."
+        return 0
+    fi
+
+    log_message "is_contrast_enhanced_t1: no contrast markers found (no sidecar, heuristics negative)"
+    return 1
+}
+
 # Export functions for external use
 export -f select_optimal_reference_space
 export -f discover_original_sequences
@@ -543,5 +681,6 @@ export -f is_original_acquisition
 export -f analyze_sequence_quality
 export -f make_reference_space_decision
 export -f present_interactive_decision_matrix
+export -f is_contrast_enhanced_t1
 
 log_message "Reference space selection module loaded"

--- a/src/pipeline.sh
+++ b/src/pipeline.sh
@@ -411,6 +411,78 @@ run_contrast_matched_cascade_stage() {
   return 0
 }
 
+# ---------------------------------------------------------------------------
+# adopt_external_anatomical_t1 <source_path> <reason>
+# ---------------------------------------------------------------------------
+# Shared helper used by BOTH Unit A (no in-study T1) and Unit C (contrast-
+# enhanced T1 swap).  Copies <source_path> into EXTRACT_DIR as
+# external_anatomical_T1.nii.gz (idempotent: only re-copies on size change),
+# sanity-checks the result, sets the caller's local `t1_file` and
+# `_external_t1_adopted` vars via `eval`, and writes provenance.
+#
+# Preconditions (caller must verify before invoking):
+#   - EXTRACT_DIR is set and the directory exists
+#   - RESULTS_DIR is set
+#   - <source_path> exists and is a .nii.gz file
+#   - ERR_DATA_MISSING is defined
+#
+# Sets (in the caller's scope via eval):
+#   t1_file            → path to the adopted file in EXTRACT_DIR
+#   _external_t1_adopted → "true"
+#
+# Appends optional extra provenance key=value pairs as a 3rd argument string
+# (each line written verbatim after the base keys), e.g.:
+#   "contrast_enhanced_original=/path\nreason=some reason"
+# ---------------------------------------------------------------------------
+adopt_external_anatomical_t1() {
+  local _src_path="$1"
+  local _reason="$2"
+  local _extra_provenance="${3:-}"
+
+  local _adopted_path="${EXTRACT_DIR}/external_anatomical_T1.nii.gz"
+  local _ref_label="${ANATOMICAL_REFERENCE_LABEL:-${_src_path}}"
+
+  log_formatted "WARNING" "Adopting external anatomical T1 (${_reason}): ${_ref_label}"
+
+  # Copy — refresh when source and destination sizes differ.
+  local _s _d
+  _s=$(wc -c < "${_src_path}" 2>/dev/null || echo 0)
+  _d=$([ -f "${_adopted_path}" ] && wc -c < "${_adopted_path}" 2>/dev/null || echo 0)
+  if [ "${_s}" != "${_d}" ] || [ ! -f "${_adopted_path}" ]; then
+    log_message "adopt_external_anatomical_t1: copying into extract dir (source size: ${_s} bytes)"
+    if ! cp "${_src_path}" "${_adopted_path}"; then
+      log_error "adopt_external_anatomical_t1: failed to copy ${_src_path} into EXTRACT_DIR" "$ERR_DATA_MISSING"
+      return "$ERR_DATA_MISSING"
+    fi
+  else
+    log_message "adopt_external_anatomical_t1: already present in extract dir (size matches; skipping copy)"
+  fi
+
+  # Sanity-check: must exist and be non-empty.
+  local _adopted_size
+  _adopted_size=$(wc -c < "${_adopted_path}" 2>/dev/null || echo 0)
+  if [ ! -f "${_adopted_path}" ] || [ "${_adopted_size}" -eq 0 ]; then
+    log_error "adopt_external_anatomical_t1: adopted file is missing or empty: ${_adopted_path}" "$ERR_DATA_MISSING"
+    return "$ERR_DATA_MISSING"
+  fi
+
+  # Write provenance (overwrite = idempotent across resumes).
+  {
+    printf 'source=%s\nlabel=%s\ntype=%s\nadopted_as=%s\n' \
+      "${_src_path}" "${_ref_label}" "${_reason}" "${_adopted_path}"
+    if [ -n "${_extra_provenance}" ]; then
+      printf '%s\n' "${_extra_provenance}"
+    fi
+  } > "${RESULTS_DIR}/anatomical_reference_provenance.txt"
+
+  # Propagate to caller scope.
+  eval 't1_file="${_adopted_path}"'
+  eval '_external_t1_adopted="true"'
+
+  log_message "adopt_external_anatomical_t1: adopted as ${_adopted_path}"
+  log_message "adopt_external_anatomical_t1: provenance written to ${RESULTS_DIR}/anatomical_reference_provenance.txt"
+}
+
 # Run the pipeline
 run_pipeline() {
   local subject_id="$SUBJECT_ID"
@@ -570,38 +642,62 @@ run_pipeline() {
       log_error "ANATOMICAL_REFERENCE_T1 must be a compressed NIfTI (.nii.gz); got: ${ANATOMICAL_REFERENCE_T1}" $ERR_DATA_MISSING
       return $ERR_DATA_MISSING
     fi
-    local adopted_t1="${EXTRACT_DIR}/external_anatomical_T1.nii.gz"
-    local ref_label="${ANATOMICAL_REFERENCE_LABEL:-${ANATOMICAL_REFERENCE_T1}}"
-    log_formatted "WARNING" "No in-study T1 found; adopting EXTERNAL anatomical T1 reference: ${ref_label}"
-    # Refresh the copy when source and destination sizes differ (covers both the
-    # first run and a changed ANATOMICAL_REFERENCE_T1 on a subsequent resume).
-    local _src_size _dst_size
-    _src_size=$(wc -c < "${ANATOMICAL_REFERENCE_T1}" 2>/dev/null || echo 0)
-    _dst_size=$([ -f "${adopted_t1}" ] && wc -c < "${adopted_t1}" 2>/dev/null || echo 0)
-    if [ "${_src_size}" != "${_dst_size}" ] || [ ! -f "${adopted_t1}" ]; then
-      log_message "Copying external anatomical T1 into extract dir (source size: ${_src_size} bytes)"
-      if ! cp "${ANATOMICAL_REFERENCE_T1}" "${adopted_t1}"; then
-        log_error "Failed to copy external anatomical T1 reference into EXTRACT_DIR" $ERR_DATA_MISSING
-        return $ERR_DATA_MISSING
+    adopt_external_anatomical_t1 "${ANATOMICAL_REFERENCE_T1}" "external" || return $?
+  fi
+  # ---------------------------------------------------------------------------
+
+  # ---------------------------------------------------------------------------
+  # Unit C — contrast-enhanced T1 preference
+  # ---------------------------------------------------------------------------
+  # Fires ONLY when ALL of the following hold:
+  #   1. PREFER_EXTERNAL_NONCONTRAST_T1=true   (default false → complete no-op)
+  #   2. An in-study T1 was found (t1_file is non-empty)
+  #   3. The external adoption block did NOT already fire (_external_t1_adopted=false)
+  #   4. is_contrast_enhanced_t1 reports the in-study T1 is post-gadolinium
+  #   5. ANATOMICAL_REFERENCE_T1 is set and points to an existing .nii.gz file
+  #
+  # When it fires, the external non-contrast T1 is adopted as the anatomical
+  # anchor for recon-all/segmentation using the same copy+provenance mechanism
+  # as Unit A.  The contrast-enhanced in-study T1 is NOT deleted — it stays on
+  # disk and remains available as an enhancement signal for downstream analysis.
+  #
+  # When PREFER_EXTERNAL_NONCONTRAST_T1=false (the default), this block is
+  # completely unreachable and pipeline behaviour is byte-identical to before.
+  # ---------------------------------------------------------------------------
+  if [ "${PREFER_EXTERNAL_NONCONTRAST_T1:-false}" = "true" ] \
+     && [ -n "${t1_file:-}" ] \
+     && [ "${_external_t1_adopted}" = "false" ]; then
+
+    if is_contrast_enhanced_t1 "${t1_file}"; then
+      log_formatted "WARNING" \
+        "Unit C: in-study T1 appears contrast-enhanced: $(basename "${t1_file}")"
+
+      if [ -z "${ANATOMICAL_REFERENCE_T1:-}" ]; then
+        log_formatted "WARNING" \
+          "Unit C: PREFER_EXTERNAL_NONCONTRAST_T1=true but ANATOMICAL_REFERENCE_T1 is unset — keeping contrast-enhanced in-study T1 as anchor"
+      elif [ ! -f "${ANATOMICAL_REFERENCE_T1}" ]; then
+        log_formatted "WARNING" \
+          "Unit C: ANATOMICAL_REFERENCE_T1 set but file not found: ${ANATOMICAL_REFERENCE_T1} — keeping contrast-enhanced in-study T1 as anchor"
+      elif [[ "${ANATOMICAL_REFERENCE_T1}" != *.nii.gz ]]; then
+        log_formatted "WARNING" \
+          "Unit C: ANATOMICAL_REFERENCE_T1 must be .nii.gz; got: ${ANATOMICAL_REFERENCE_T1} — keeping contrast-enhanced in-study T1 as anchor"
+      else
+        # All preconditions met: swap the anchor to the external non-contrast T1.
+        local ce_t1_path="${t1_file}"
+        log_formatted "WARNING" \
+          "Unit C: replacing contrast-enhanced in-study T1 anchor with external non-contrast T1"
+        log_message "Unit C: contrast-enhanced T1 retained on disk for enhancement analysis: ${ce_t1_path}"
+        # Export the contrast T1 path so downstream can use it as enhancement signal.
+        export CONTRAST_ENHANCED_T1="${ce_t1_path}"
+        log_message "Unit C: CONTRAST_ENHANCED_T1 exported for enhancement analysis: ${CONTRAST_ENHANCED_T1}"
+        adopt_external_anatomical_t1 "${ANATOMICAL_REFERENCE_T1}" \
+          "external_noncontrast_preference" \
+          "contrast_enhanced_original=${ce_t1_path}
+reason=in-study T1 is contrast-enhanced; using external non-contrast anchor" || return $?
       fi
     else
-      log_message "External anatomical T1 already present in extract dir (size matches; skipping copy)"
+      log_message "Unit C: in-study T1 is not contrast-enhanced; no anchor substitution needed"
     fi
-    # Sanity-check the adopted file: must exist and be non-empty.
-    local _adopted_size
-    _adopted_size=$(wc -c < "${adopted_t1}" 2>/dev/null || echo 0)
-    if [ ! -f "${adopted_t1}" ] || [ "${_adopted_size}" -eq 0 ]; then
-      log_error "Adopted external anatomical T1 is missing or empty: ${adopted_t1}" $ERR_DATA_MISSING
-      return $ERR_DATA_MISSING
-    fi
-    t1_file="${adopted_t1}"
-    _external_t1_adopted="true"
-    # Record provenance (overwrite = idempotent across resumes).
-    printf 'source=%s\nlabel=%s\ntype=external\nadopted_as=%s\n' \
-      "${ANATOMICAL_REFERENCE_T1}" "${ref_label}" "${adopted_t1}" \
-      > "${RESULTS_DIR}/anatomical_reference_provenance.txt"
-    log_message "External anatomical T1 adopted as: ${adopted_t1}"
-    log_message "Provenance recorded in: ${RESULTS_DIR}/anatomical_reference_provenance.txt"
   fi
   # ---------------------------------------------------------------------------
 


### PR DESCRIPTION
## Summary

- **Detection** (`is_contrast_enhanced_t1` in `src/modules/reference_space_selection.sh`): inspects the dcm2niix JSON sidecar first (via `jq` or grep fallback) for `ContrastBolusAgent` and `ImageType CONTRAST`; falls back to conservative filename heuristics only when no sidecar is available. All `${var^^}` bash-4-only expansions replaced with portable `printf '%s' | tr` for bash 3.2 compatibility (macOS system shell).

- **Preference/swap** (Unit C block in `src/pipeline.sh`): when `PREFER_EXTERNAL_NONCONTRAST_T1=true` and the in-study T1 is detected as contrast-enhanced, the external non-contrast anchor (`ANATOMICAL_REFERENCE_T1`) is adopted as the structural reference. The in-study contrast-enhanced T1 is **never deleted** — it is exported as `CONTRAST_ENHANCED_T1` so downstream analysis can use it as an enhancement signal. The swap is graceful: missing/unset `ANATOMICAL_REFERENCE_T1` logs a WARNING and keeps the contrast T1 in place.

- **Shared helper refactor** (`adopt_external_anatomical_t1`): the ~30-line copy + size-check + sanity-check + provenance block that was duplicated across Unit A and Unit C is now a single shared helper. Both Unit A (no in-study T1) and Unit C (contrast swap) call it. Behavior of both paths is preserved exactly.

- **Additional self-review fixes applied**:
  - Removed ambiguous filename tokens `+c` and `_c_` from the heuristic fallback to prevent false-positives on names like `acq+contrast`.
  - Removed dead code: redundant `[ "${agent_upper}" != "" ]` condition (identical to the preceding `[ -n "${agent_upper}" ]`).
  - Collapsed redundant double-grep on `ImageType` into a single piped check.

- **Backward compatibility**: the Unit C preference/swap block is guarded by `[ "${PREFER_EXTERNAL_NONCONTRAST_T1:-false}" = "true" ]`. With the default `false`, the entire block is unreachable and pipeline behaviour is byte-identical to before. Unit A's no-T1 adoption path is also unchanged in behaviour after the helper extraction.

## Test plan

- [ ] `bash -n src/modules/reference_space_selection.sh` — syntax OK
- [ ] `bash -n src/pipeline.sh` — syntax OK
- [ ] `shellcheck --severity=error` both files — 0 findings
- [ ] `bash tests/test_environment_unit.sh` — 100/100 PASS
- [ ] `bash tests/test_pipeline_control_unit.sh` — 98/98 PASS
- [ ] `bash tests/test_import_unit.sh` — 29/29 PASS
- [ ] `bash src/pipeline.sh --help | grep -q "Usage:"` — PASS
- [ ] `declare -f is_contrast_enhanced_t1` resolves after sourcing module — OK
- [ ] Staged PII scan (`git diff --cached | grep -nEi '/Users/|...'`) — CLEAN
- [ ] `git diff --stat` shows only 2 files

🤖 Generated with [Claude Code](https://claude.com/claude-code)